### PR TITLE
Self Name Bug due to TOKEN expired

### DIFF
--- a/src/analysis/repositories.py
+++ b/src/analysis/repositories.py
@@ -19,13 +19,7 @@ from ..utils.utils import is_github_repo_public
 
 class Repository:
     def __init__(self, full_path: str, force_refresh: bool = False):
-        # Check if the repository is public before proceeding
-        if not is_github_repo_public(full_path):
-            logger.error(
-                f"Cannot process repository: {full_path} is not public or not accessible",
-            )
-            return
-
+        # Initialize all attributes first
         self.full_path: str = full_path
         self.data: SoftwareSourceCode = None
         self.gimie = None
@@ -45,6 +39,13 @@ class Repository:
         self.start_time: datetime = None
         self.end_time: datetime = None
         self.analysis_successful: bool = False
+        
+        # Check if the repository is public before proceeding
+        self.is_public: bool = is_github_repo_public(full_path)
+        if not self.is_public:
+            logger.error(
+                f"Cannot process repository: {full_path} is not public or not accessible",
+            )
 
     def run_gimie_analysis(self):
         def fetch_gimie_data():
@@ -560,6 +561,12 @@ class Repository:
         Run the full analysis pipeline with optional steps.
         Checks cache before running each step unless force_refresh is True.
         """
+        # Check if repository is public
+        if not self.is_public:
+            logger.error(f"Cannot run analysis: repository {self.full_path} is not public")
+            self.analysis_successful = False
+            return
+        
         # Track start time
         self.start_time = datetime.now()
         

--- a/src/api.py
+++ b/src/api.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from typing import Optional
 
-from fastapi import FastAPI, HTTPException, Path, Query, Request
+from fastapi import Depends, FastAPI, HTTPException, Path, Query, Request, Response
 from fastapi.responses import JSONResponse
 
 from .analysis import Organization, Repository, User
@@ -17,6 +17,7 @@ from .data_models import (
     ResourceType,
 )
 from .utils.enhanced_logging import AsyncRequestContext, setup_logging
+from .utils.github_dependency import validate_github_token
 
 # Setup enhanced logging with colors
 # Allow LOG_LEVEL environment variable to override (DEBUG, INFO, WARNING, ERROR)
@@ -535,6 +536,7 @@ def index():
 
 @app.get("/v1/org/llm/json/{full_path:path}", tags=["Organization"])
 async def get_org_json(
+    response: Response,
     full_path: str = Path(
         ...,
         description="GitHub organization URL or path",
@@ -550,6 +552,7 @@ async def get_org_json(
         False,
         description="Enable organization enrichment using PydanticAI agent to analyze and standardize organization information using ROR API",
     ),
+    github_info: dict = Depends(validate_github_token),
 ) -> APIOutput:
     """
     Retrieve and enrich GitHub organization metadata.
@@ -612,11 +615,19 @@ async def get_org_json(
         start_time=usage_stats["start_time"],
         end_time=usage_stats["end_time"],
         status_code=usage_stats["status_code"],
+        github_rate_limit=github_info["rate_limit_limit"],
+        github_rate_remaining=github_info["rate_limit_remaining"],
+        github_rate_reset=github_info["rate_limit_reset"],
     )
     # Calculate total tokens (both official and estimated)
     stats.calculate_total_tokens()
+    
+    # Set rate limit response headers
+    response.headers["X-RateLimit-Limit"] = str(github_info["rate_limit_limit"])
+    response.headers["X-RateLimit-Remaining"] = str(github_info["rate_limit_remaining"])
+    response.headers["X-RateLimit-Reset"] = github_info["rate_limit_reset"].isoformat()
 
-    response = APIOutput(
+    api_response = APIOutput(
         link=full_path,
         type=ResourceType.ORGANIZATION,
         parsedTimestamp=datetime.now(),
@@ -624,11 +635,12 @@ async def get_org_json(
         stats=stats,
     )
 
-    return response
+    return api_response
 
 
 @app.get("/v1/user/llm/json/{full_path:path}", tags=["User"])
 async def get_user_json(
+    response: Response,
     full_path: str = Path(
         ...,
         description="GitHub user URL or path",
@@ -648,6 +660,7 @@ async def get_user_json(
         False,
         description="Enable user/author enrichment using PydanticAI agent to analyze affiliations, ORCID data, and provide detailed author information",
     ),
+    github_info: dict = Depends(validate_github_token),
 ) -> APIOutput:
     """
     Retrieve and enrich GitHub user profile metadata.
@@ -712,11 +725,19 @@ async def get_user_json(
         start_time=usage_stats["start_time"],
         end_time=usage_stats["end_time"],
         status_code=usage_stats["status_code"],
+        github_rate_limit=github_info["rate_limit_limit"],
+        github_rate_remaining=github_info["rate_limit_remaining"],
+        github_rate_reset=github_info["rate_limit_reset"],
     )
     # Calculate total tokens (both official and estimated)
     stats.calculate_total_tokens()
+    
+    # Set rate limit response headers
+    response.headers["X-RateLimit-Limit"] = str(github_info["rate_limit_limit"])
+    response.headers["X-RateLimit-Remaining"] = str(github_info["rate_limit_remaining"])
+    response.headers["X-RateLimit-Reset"] = github_info["rate_limit_reset"].isoformat()
 
-    response = APIOutput(
+    api_response = APIOutput(
         link=full_path,
         type=ResourceType.USER,
         parsedTimestamp=datetime.now(),
@@ -724,7 +745,7 @@ async def get_user_json(
         stats=stats,
     )
 
-    return response
+    return api_response
 
 
 @app.get(
@@ -774,6 +795,7 @@ async def get_user_json(
     },
 )
 async def gimie(
+    response: Response,
     full_path: str = Path(
         ...,
         description="Full repository URL",
@@ -788,6 +810,7 @@ async def gimie(
         False,
         description="Force refresh from external APIs, bypassing cache",
     ),
+    github_info: dict = Depends(validate_github_token),
 ) -> APIOutput:
     """
     Extract repository metadata using GIMIE only.
@@ -835,11 +858,19 @@ async def gimie(
         start_time=usage_stats["start_time"],
         end_time=usage_stats["end_time"],
         status_code=usage_stats["status_code"],
+        github_rate_limit=github_info["rate_limit_limit"],
+        github_rate_remaining=github_info["rate_limit_remaining"],
+        github_rate_reset=github_info["rate_limit_reset"],
     )
     # Calculate total tokens (will be 0 for gimie-only)
     stats.calculate_total_tokens()
+    
+    # Set rate limit response headers
+    response.headers["X-RateLimit-Limit"] = str(github_info["rate_limit_limit"])
+    response.headers["X-RateLimit-Remaining"] = str(github_info["rate_limit_remaining"])
+    response.headers["X-RateLimit-Reset"] = github_info["rate_limit_reset"].isoformat()
 
-    response = APIOutput(
+    api_response = APIOutput(
         link=full_path,
         type=ResourceType.REPOSITORY,
         parsedTimestamp=datetime.now(),
@@ -847,7 +878,7 @@ async def gimie(
         stats=stats,
     )
 
-    return response
+    return api_response
 
 
 @app.get(
@@ -906,6 +937,7 @@ async def gimie(
     },
 )
 async def llm_jsonld(
+    response: Response,
     full_path: str = Path(
         ...,
         description="Full repository URL",
@@ -928,6 +960,7 @@ async def llm_jsonld(
         False,
         description="Enable user/author enrichment using PydanticAI agent to analyze affiliations, ORCID data, and provide detailed author information",
     ),
+    github_info: dict = Depends(validate_github_token),
 ) -> APIOutput:
     """
     Extract repository metadata using LLM with GIMIE context in JSON-LD format.
@@ -1035,11 +1068,19 @@ async def llm_jsonld(
         start_time=usage_stats["start_time"],
         end_time=usage_stats["end_time"],
         status_code=usage_stats["status_code"],
+        github_rate_limit=github_info["rate_limit_limit"],
+        github_rate_remaining=github_info["rate_limit_remaining"],
+        github_rate_reset=github_info["rate_limit_reset"],
     )
     # Calculate total tokens (both official and estimated)
     stats.calculate_total_tokens()
+    
+    # Set rate limit response headers
+    response.headers["X-RateLimit-Limit"] = str(github_info["rate_limit_limit"])
+    response.headers["X-RateLimit-Remaining"] = str(github_info["rate_limit_remaining"])
+    response.headers["X-RateLimit-Reset"] = github_info["rate_limit_reset"].isoformat()
 
-    response = APIOutput(
+    api_response = APIOutput(
         link=full_path,
         type=ResourceType.REPOSITORY,
         parsedTimestamp=datetime.now(),
@@ -1048,15 +1089,16 @@ async def llm_jsonld(
     )
     
     # Debug: Log what we're about to return
-    logger.info(f"Response output type before return: {type(response.output)}")
-    if isinstance(response.output, dict):
-        logger.info(f"Response output has keys: {list(response.output.keys())[:5]}")
+    logger.info(f"Response output type before return: {type(api_response.output)}")
+    if isinstance(api_response.output, dict):
+        logger.info(f"Response output has keys: {list(api_response.output.keys())[:5]}")
 
-    return response
+    return api_response
 
 
 @app.get("/v1/repository/llm/json/{full_path:path}", tags=["Repository"])
 async def llm_json(
+    response: Response,
     full_path: str = Path(
         ...,
         description="Full repository URL",
@@ -1079,6 +1121,7 @@ async def llm_json(
         False,
         description="Enable user/author enrichment using PydanticAI agent to analyze affiliations, ORCID data, and provide detailed author information",
     ),
+    github_info: dict = Depends(validate_github_token),
 ) -> APIOutput:
     """
     Extract repository metadata using LLM with GIMIE context.
@@ -1140,11 +1183,19 @@ async def llm_json(
         start_time=usage_stats["start_time"],
         end_time=usage_stats["end_time"],
         status_code=usage_stats["status_code"],
+        github_rate_limit=github_info["rate_limit_limit"],
+        github_rate_remaining=github_info["rate_limit_remaining"],
+        github_rate_reset=github_info["rate_limit_reset"],
     )
     # Calculate total tokens (both official and estimated)
     stats.calculate_total_tokens()
+    
+    # Set rate limit response headers
+    response.headers["X-RateLimit-Limit"] = str(github_info["rate_limit_limit"])
+    response.headers["X-RateLimit-Remaining"] = str(github_info["rate_limit_remaining"])
+    response.headers["X-RateLimit-Reset"] = github_info["rate_limit_reset"].isoformat()
 
-    response = APIOutput(
+    api_response = APIOutput(
         link=full_path,
         type=ResourceType.REPOSITORY,
         parsedTimestamp=datetime.now(),
@@ -1152,7 +1203,7 @@ async def llm_json(
         stats=stats,
     )
 
-    return response
+    return api_response
 
 
 ###########################################################

--- a/src/data_models/api.py
+++ b/src/data_models/api.py
@@ -32,6 +32,11 @@ class APIStats(BaseModel):
     end_time: datetime = None
     status_code: int = None
     
+    # GitHub API rate limit information
+    github_rate_limit: int = None
+    github_rate_remaining: int = None
+    github_rate_reset: datetime = None
+    
     def calculate_total_tokens(self):
         """Calculate total tokens from input and output tokens."""
         if self.agent_input_tokens is not None and self.agent_output_tokens is not None:

--- a/src/utils/github_dependency.py
+++ b/src/utils/github_dependency.py
@@ -1,0 +1,113 @@
+"""
+GitHub Token Validation Dependency
+
+FastAPI dependency for validating GitHub tokens and retrieving rate limit information.
+"""
+
+import logging
+import os
+from datetime import datetime
+from typing import Dict
+
+import requests
+from fastapi import HTTPException, status
+
+logger = logging.getLogger(__name__)
+
+
+async def validate_github_token() -> dict:
+    """
+    Validate GitHub token and retrieve rate limit information.
+    
+    This dependency:
+    - Checks if GITHUB_TOKEN is configured
+    - Validates the token by calling GitHub API
+    - Retrieves current rate limit information
+    - Returns rate limit data for logging and response inclusion
+    
+    Returns:
+        dict with:
+        - valid: bool - Token is valid
+        - rate_limit_limit: int - Total rate limit
+        - rate_limit_remaining: int - Remaining requests
+        - rate_limit_reset: datetime - When rate limit resets
+        
+    Raises:
+        HTTPException 401 if token is missing, invalid, or expired
+    """
+    token = os.environ.get("GITHUB_TOKEN")
+    
+    # Check if token is configured
+    if not token:
+        logger.error("GitHub token not configured")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="GitHub token not configured. Set GITHUB_TOKEN environment variable.",
+        )
+    
+    # Validate token by calling GitHub API rate limit endpoint
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "GitMetadataExtractor/2.0",
+    }
+    
+    try:
+        response = requests.get(
+            "https://api.github.com/rate_limit",
+            headers=headers,
+            timeout=10,
+        )
+        
+        # If 401, token is invalid or expired
+        if response.status_code == 401:
+            logger.error("GitHub token is invalid or expired")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="GitHub token is invalid or expired. Please update GITHUB_TOKEN environment variable.",
+            )
+        
+        # If other error status
+        if response.status_code != 200:
+            logger.error(f"GitHub API returned status {response.status_code}")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=f"GitHub API returned unexpected status: {response.status_code}",
+            )
+        
+        # Extract rate limit information
+        rate_data = response.json()
+        core_rate = rate_data.get("rate", {})
+        
+        rate_limit = core_rate.get("limit", 0)
+        rate_remaining = core_rate.get("remaining", 0)
+        rate_reset_timestamp = core_rate.get("reset", 0)
+        rate_reset = datetime.fromtimestamp(rate_reset_timestamp)
+        
+        # Log rate limit information
+        logger.info(
+            f"GitHub API rate limit: {rate_remaining}/{rate_limit} remaining, "
+            f"resets at {rate_reset.isoformat()}"
+        )
+        
+        # Warning when rate limit is low
+        if rate_remaining < 100:
+            logger.warning(
+                f"⚠️  GitHub API rate limit low: only {rate_remaining} requests remaining! "
+                f"Resets at {rate_reset.isoformat()}"
+            )
+        
+        return {
+            "valid": True,
+            "rate_limit_limit": rate_limit,
+            "rate_limit_remaining": rate_remaining,
+            "rate_limit_reset": rate_reset,
+        }
+        
+    except requests.RequestException as e:
+        logger.error(f"Failed to validate GitHub token: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Failed to connect to GitHub API: {str(e)}",
+        )
+


### PR DESCRIPTION
Refactor repository public access check and enhance API responses with GitHub rate limit information. The Repository class now checks if a GitHub repo is public during initialization and before running analysis. Updated API endpoints to include GitHub rate limit headers and added corresponding fields in APIStats model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds GitHub token validation and rate-limit data to API responses/stats, and moves repository public-access checks to runtime in Repository.
> 
> - **API**:
>   - Add `validate_github_token` FastAPI dependency to `org`, `user`, and `repository` endpoints.
>   - Include GitHub rate-limit info in responses: set `X-RateLimit-*` headers and populate `APIStats` (`github_rate_limit`, `github_rate_remaining`, `github_rate_reset`).
>   - Minor: import `Depends`, `Response`; avoid shadowing by returning `api_response`.
> - **Models**:
>   - Extend `APIStats` with GitHub rate-limit fields and keep estimated token totals.
> - **Repository Analysis**:
>   - Initialize attributes before access check; store `self.is_public`.
>   - Enforce public-repo check at start of `run_analysis` (early return, set `analysis_successful=False`).
>   - When loading full analysis from cache, mark success and set `end_time`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c252ee9565446bd626e4d066822de4e04d1a78c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->