### PR TITLE
fix(v2): owned-repo gimie iteration + include_internal_fields on POST

### DIFF
--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -370,6 +370,7 @@ async def _run_extract_job(
             output_format=payload.output_format,
             agent_runtime=payload.agent_runtime,
             include_context_summary=payload.include_context_summary,
+            include_internal_fields=payload.include_internal_fields,
             providers=providers,
             _token="",
         )

--- a/src/v2/api_models/contracts.py
+++ b/src/v2/api_models/contracts.py
@@ -36,10 +36,36 @@ class V2JSONOutputEnvelope(BaseModel):
 
 
 class V2ExtractRequest(BaseModel):
-    source_url: str
-    output_format: Literal["jsonld", "json"] = "jsonld"
-    agent_runtime: Literal["rule_based", "llm", "hybrid"] | None = None
-    include_context_summary: bool = False
+    source_url: str = Field(
+        description="GitHub repository, user, or organization URL or handle.",
+        examples=["https://github.com/sdsc-ordes/gimie"],
+    )
+    output_format: Literal["jsonld", "json"] = Field(
+        default="jsonld",
+        description="Response shape: `jsonld` (JSON-LD graph) or `json` (flat envelope).",
+    )
+    agent_runtime: Literal["rule_based", "llm", "hybrid"] | None = Field(
+        default=None,
+        description=(
+            "Pipeline runtime. `rule_based` is deterministic; `llm` adds the "
+            "agent refiners; `hybrid` runs rule-based then LLM refinement. "
+            "Falls back to the server's V2_AGENT_RUNTIME_DEFAULT when omitted."
+        ),
+    )
+    include_context_summary: bool = Field(
+        default=False,
+        description="When true, attaches the scout context summary to the response.",
+    )
+    include_internal_fields: bool = Field(
+        default=False,
+        description=(
+            "When true, the response keeps `_`-prefixed internal fields "
+            "(e.g. `_bio`, `_avatar_url`, `_orcid_keywords`, `_company`) that "
+            "aren't part of the Open Pulse ontology yet. Strict SHACL "
+            "validation still runs identically — this flag only affects what "
+            "the consumer sees. Default false for ontology compliance."
+        ),
+    )
 
 
 class V2ExtractResponse(BaseModel):

--- a/src/v2/pipeline/orchestrator.py
+++ b/src/v2/pipeline/orchestrator.py
@@ -47,6 +47,7 @@ from src.v2.ingest.cache import ProviderCache
 from src.v2.ingest.detection.models import GitHubURLClassification
 from src.v2.pipeline.models import AgentGroup, ExecutionPlan, PipelineResult, Stage
 from src.v2.pipeline.stages import ContextBundle, gather_context
+from src.v2.pipeline.stages.context_gather import should_expand_owned_repos
 
 if TYPE_CHECKING:
     from src.v2.agents.contracts import RuntimeAgent
@@ -92,7 +93,7 @@ COMPILED_CONTEXT_PROMPT_BLOCK_HEADER = "## Compiled Source Summary"
 # Note that the fan-out cap is now a *secondary* guard — by default the
 # user/org flows emit owned repos as `@id` references in `pulse:owns`
 # WITHOUT materialising each as a full `schema:SoftwareSourceCode`
-# entity (see `_should_expand_owned_repos`). The cap only kicks in when
+# entity (see `should_expand_owned_repos`). The cap only kicks in when
 # expansion is explicitly turned on via `V2_EXPAND_OWNED_REPOS=true`.
 _DEFAULT_MAX_REPO_FANOUT_ORG = 25
 _DEFAULT_MAX_REPO_FANOUT_USER = 50
@@ -114,26 +115,6 @@ def _resolve_repo_fanout_cap(detected_type: str) -> int:
     except ValueError:
         return default
     return max(0, value)
-
-
-def _should_expand_owned_repos() -> bool:
-    """When False (default), the user/organization flows emit each
-    owned repo as a bare `@id` reference in the root entity's
-    `pulse:owns` array, but DO NOT materialise it as a full
-    `schema:SoftwareSourceCode` entity in the graph.
-
-    Rationale: an org or prolific user can easily own 50-200 repos.
-    Running gimie + the contributor pipeline on each one costs minutes
-    of wall time and most of the resulting nodes are weakly connected
-    to the root entity that motivated the extraction. The W3C-style
-    "just an IRI" reference preserves the structural link without the
-    materialisation cost. Consumers that want the rich per-repo
-    metadata can extract each repo directly via the repository flow,
-    or set `V2_EXPAND_OWNED_REPOS=true` to restore the previous
-    behaviour for the user/org flow itself.
-    """
-    raw = (os.getenv("V2_EXPAND_OWNED_REPOS") or "").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
 
 
 PLAN_BY_TYPE: dict[str, list[str]] = {
@@ -1327,7 +1308,7 @@ class PipelineOrchestrator:
         # to restore eager expansion.
         if (
             detected_type in {"user", "organization"}
-            and not _should_expand_owned_repos()
+            and not should_expand_owned_repos()
             and deduped_full_names
         ):
             warning_sink = runtime_context.setdefault("_fanout_warnings", [])

--- a/src/v2/pipeline/stages/context_gather.py
+++ b/src/v2/pipeline/stages/context_gather.py
@@ -8,6 +8,23 @@ from typing import TYPE_CHECKING, Any
 from src.v2.pipeline.stages.models import ContextBundle
 
 
+def should_expand_owned_repos() -> bool:
+    """Whether user/organization flows run the full per-repo pipeline
+    (gimie context gather + materialisation) on each owned repo.
+
+    When False (default), owned repos are kept only as `pulse:owns`
+    `@id` references: context gather skips the per-repo gimie pass and
+    the orchestrator skips materialisation. An org or prolific user can
+    own 50-200 repos and gimie on each costs minutes of wall time. Set
+    `V2_EXPAND_OWNED_REPOS=true` to restore eager expansion.
+
+    Single source of truth for the flag — the orchestrator imports this
+    so context gather and materialisation never disagree.
+    """
+    raw = (os.getenv("V2_EXPAND_OWNED_REPOS") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
 # `_clean_readme_for_llm`: a *light* cleaner that removes only the
 # high-noise / low-signal portions of a GitHub README so downstream LLM
 # prompts + RAG queries don't waste tokens on badge/image/HTML soup.
@@ -453,16 +470,21 @@ async def gather_context(  # noqa: C901, PLR0915
             or user_profile.get("repos")
             or user_profile.get("owned_repos"),
         )
+        # Per-repo gimie context is gated by V2_EXPAND_OWNED_REPOS. When
+        # off (default) the owned repos survive only as `pulse:owns`
+        # references — skipping the gimie pass here is what actually
+        # avoids the 30+ sequential sub-extractions on a prolific user.
         repository_contexts: dict[str, dict[str, Any]] = {}
-        for repo in owned_repos:
-            full_name = _normalize_owned_repo_full_name(username, repo)
-            repository_context = _optional_repository_context(
-                full_name=full_name,
-                providers=providers,
-                warnings=warnings,
-            )
-            if isinstance(repository_context, dict):
-                repository_contexts[full_name] = repository_context
+        if should_expand_owned_repos():
+            for repo in owned_repos:
+                full_name = _normalize_owned_repo_full_name(username, repo)
+                repository_context = _optional_repository_context(
+                    full_name=full_name,
+                    providers=providers,
+                    warnings=warnings,
+                )
+                if isinstance(repository_context, dict):
+                    repository_contexts[full_name] = repository_context
         orcid_id = _first_non_empty_string(
             user_profile.get("orcid"),
             user_profile.get("orcid_id"),
@@ -509,16 +531,18 @@ async def gather_context(  # noqa: C901, PLR0915
             organization_profile.get("repositories")
             or organization_profile.get("repos"),
         )
+        # Gated by V2_EXPAND_OWNED_REPOS — see the user branch above.
         repository_contexts: dict[str, dict[str, Any]] = {}
-        for repo in owned_repos:
-            full_name = _normalize_owned_repo_full_name(organization_name, repo)
-            repository_context = _optional_repository_context(
-                full_name=full_name,
-                providers=providers,
-                warnings=warnings,
-            )
-            if isinstance(repository_context, dict):
-                repository_contexts[full_name] = repository_context
+        if should_expand_owned_repos():
+            for repo in owned_repos:
+                full_name = _normalize_owned_repo_full_name(organization_name, repo)
+                repository_context = _optional_repository_context(
+                    full_name=full_name,
+                    providers=providers,
+                    warnings=warnings,
+                )
+                if isinstance(repository_context, dict):
+                    repository_contexts[full_name] = repository_context
 
         context["organization"] = {
             "org_name": organization_name,

--- a/src/v2/pipeline/stages/jsonld_build.py
+++ b/src/v2/pipeline/stages/jsonld_build.py
@@ -86,6 +86,15 @@ def _normalize_jsonld_value(
     return deepcopy(value)
 
 
+def _drop_internal_keys(entity: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``entity`` without top-level `_`-prefixed keys."""
+    return {
+        key: value
+        for key, value in entity.items()
+        if not (isinstance(key, str) and key.startswith("_"))
+    }
+
+
 def build_jsonld_output(
     *,
     assembled: AssembledOutput,
@@ -95,16 +104,19 @@ def build_jsonld_output(
     """Build the JSON-LD `@graph` from a validated `AssembledOutput`.
 
     ``include_internal_fields=False`` (default) preserves the
-    ontology-compliant behaviour: `_`-prefixed keys are stripped, so
-    the response only contains fields the open-pulse ontology declares.
+    ontology-compliant behaviour: `_`-prefixed keys are stripped from
+    **both** `@graph` nodes and `excluded_entities`, so the response
+    contains zero `_` fields anywhere — only terms the open-pulse
+    ontology declares.
 
     Set ``include_internal_fields=True`` to keep `_`-prefixed keys in
-    the output — useful when the caller asked for the broader profile
-    metadata (`_avatar_url`, `_bio`, `_company`, `_orcid_keywords`,
-    `_dropped_affiliations`, etc.) that we collect but don't yet have
-    ontology terms for. Strict SHACL validation has already run by
-    this point (it always strips `_` fields), so flipping this flag
-    is purely about what the consumer sees, not about validation.
+    the output (`@graph` and `excluded_entities` alike) — useful when
+    the caller asked for the broader profile metadata (`_avatar_url`,
+    `_bio`, `_company`, `_orcid_keywords`, `_dropped_affiliations`,
+    etc.) that we collect but don't yet have ontology terms for.
+    Strict SHACL validation has already run by this point (it always
+    strips `_` fields), so flipping this flag is purely about what the
+    consumer sees, not about validation.
     """
 
     entities: list[dict[str, Any]] = []
@@ -164,5 +176,15 @@ def build_jsonld_output(
         "@graph": graph,
     }
     if assembled.excluded_entities:
-        payload["excluded_entities"] = deepcopy(assembled.excluded_entities)
+        excluded = deepcopy(assembled.excluded_entities)
+        # `excluded_entities` carry the same `_`-prefixed internal fields
+        # as `@graph` nodes (nested under each record's `entity`). Honour
+        # the flag here too, so `include_internal_fields=False` yields a
+        # response with zero `_` fields anywhere — not just in `@graph`.
+        if not include_internal_fields:
+            for record in excluded:
+                inner = record.get("entity") if isinstance(record, dict) else None
+                if isinstance(inner, dict):
+                    record["entity"] = _drop_internal_keys(inner)
+        payload["excluded_entities"] = excluded
     return payload

--- a/tests/v2/test_context_gather.py
+++ b/tests/v2/test_context_gather.py
@@ -93,7 +93,11 @@ def test_repository_context_contains_expected_sections() -> None:
     assert "Python" in repository_context["languages"]
 
 
-def test_user_context_contains_profile_repos_and_orcid() -> None:
+def test_user_context_contains_profile_repos_and_orcid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Per-repo gimie context is opt-in; enable it to exercise the path.
+    monkeypatch.setenv("V2_EXPAND_OWNED_REPOS", "true")
     providers = ProviderSet(
         github=_DummyGitHubProvider(),
         orcid=_DummyORCIDProvider(),
@@ -114,7 +118,41 @@ def test_user_context_contains_profile_repos_and_orcid() -> None:
     assert user_context["orcid_data"]["name"] == "Alice Example"
 
 
-def test_org_context_contains_profile_members_and_repositories() -> None:
+def test_user_context_skips_per_repo_gimie_when_expansion_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Default (V2_EXPAND_OWNED_REPOS unset/false): owned repos are kept
+    # as names for `pulse:owns` references, but NO per-repo gimie runs.
+    monkeypatch.delenv("V2_EXPAND_OWNED_REPOS", raising=False)
+
+    class _ExplodingOnRepoGitHubProvider(_DummyGitHubProvider):
+        def get_repository(self, full_name: str) -> dict[str, Any]:
+            raise AssertionError(
+                f"get_repository must not run with expansion disabled: {full_name}",
+            )
+
+    providers = ProviderSet(
+        github=_ExplodingOnRepoGitHubProvider(),
+        orcid=_DummyORCIDProvider(),
+    )
+    url_info = GitHubURLClassification(
+        normalized_url="https://github.com/alice",
+        detected_type=GitHubURLType.USER,
+        owner="alice",
+        repo=None,
+    )
+
+    bundle = asyncio.run(gather_context("user", url_info, providers))
+
+    user_context = bundle.context["user"]
+    assert user_context["owned_repos"] == ["alice/repo-a", "repo-b"]
+    assert user_context["repository_contexts"] == {}
+
+
+def test_org_context_contains_profile_members_and_repositories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("V2_EXPAND_OWNED_REPOS", "true")
     providers = ProviderSet(github=_DummyGitHubProvider())
     url_info = GitHubURLClassification(
         normalized_url="https://github.com/orgs/example",
@@ -135,7 +173,11 @@ def test_org_context_contains_profile_members_and_repositories() -> None:
     }
 
 
-def test_optional_repository_context_failures_are_warnings_for_user_mode() -> None:
+def test_optional_repository_context_failures_are_warnings_for_user_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("V2_EXPAND_OWNED_REPOS", "true")
+
     class _PartiallyFailingGitHubProvider(_DummyGitHubProvider):
         def get_repository(self, full_name: str) -> dict[str, Any]:
             if full_name.endswith("repo-b"):


### PR DESCRIPTION
## Summary
- **`include_internal_fields` on POST** — the flag was missing from `V2ExtractRequest`/`POST /v2/extract` (only GET supported it). Added + wired into the async job runner. All five request fields now carry Swagger/OpenAPI descriptions.
- **All-or-nothing `_`-field toggle** — `build_jsonld_output` now also strips `_`-prefixed internal fields from `excluded_entities` (previously only `@graph` honoured the flag). `include_internal_fields=false` → zero `_` fields anywhere; `true` → kept everywhere.
- **`V2_EXPAND_OWNED_REPOS` bug fix** — the flag was only checked in the orchestrator's materialisation step, but `context_gather` still ran V1 gimie on *every* owned repo of a user/org. Submitting a user/org URL therefore triggered 30-90 sequential gimie sub-extractions regardless of the flag, blocking the POST handler for minutes. `should_expand_owned_repos()` is now the single source of truth and gates the per-repo gimie loops in context gather.

## Verification
- `github.com/sdsc-ordes` (88 repos): POST → `job_id` in **1.5s**, job completes in **30ms**, **0** per-repo gimie calls, 88 repos kept as `pulse:owns` references.
- `github.com/DeepLabCut` (21 repos): POST → `job_id` in **3.4s**, completes in **2.1s**, 0 gimie, 21 `pulse:owns` references.
- Full v2 suite: **737 passed, 1 skipped** (1 deselected — pre-existing env-flaky golden test).

## Known follow-up (not in scope here)
`pulse:owns` references emit a SHACL warning (`Value does not have class …`) because the references-only design yields bare IRIs rather than materialised Repository nodes. Pre-existing tension of the references-only approach; entity still survives. Left as-is per decision — relaxing the `pulse:owns` shape needs ontologist review.

## Test plan
- [ ] `POST /v2/extract` on a user/org URL returns `job_id` within ~1-3s
- [ ] `include_internal_fields=true` vs `false` on a repo extraction — `_` fields present/absent in both `@graph` and `excluded_entities`
- [ ] SHACL validation still passes (warning only on `pulse:owns`)
