### PR TITLE
fix(image): copy config/ into the deployment image

### DIFF
--- a/tools/image/Dockerfile
+++ b/tools/image/Dockerfile
@@ -20,6 +20,10 @@ RUN useradd -ms /bin/bash -u 1000 non-root-user \
 
 WORKDIR /app
 COPY src ./src
+# Ship the RAG index configs (config/index/*.yaml) — without them every
+# index provider fails `load_config()` and silently disables itself.
+# Deploy-specific values (Qdrant URL, tokens, scope) stay env-overridable.
+COPY config ./config
 COPY pyproject.toml .
 COPY tools/config/gunicorn_conf.py ./gunicorn_conf.py
 


### PR DESCRIPTION
## Summary
- `tools/image/Dockerfile` never copied `config/` into the image, so `/app/config` did not exist at runtime. Every RAG index provider failed `load_config()` on the missing `config/index/*.yaml` and silently disabled itself — `rule_based` discipline tagging and all index enrichment (Infoscience, OpenAlex, ROR, …) went dark.
- Adds `COPY config ./config`. The 14 index YAMLs are git-tracked code-config; deploy-specific values (Qdrant URL, tokens, scope) stay env-overridable (`INDEX_QDRANT_URL`, `RCP_TOKEN`, `INDEX_*_SCOPE`), so this does not reduce redeploy flexibility.

## Test plan
- [ ] Rebuild the image; confirm `/app/config/index/` is populated
- [ ] `rule_based` extraction emits `pulse:discipline` (EPFL Graph RAG reachable)
- [ ] Set `INDEX_QDRANT_URL` in the deployed env (the YAMLs default to `localhost:6333`)
