### PR TITLE
fix(v2 cache): report real deleted count from ProviderCache.clear()

### DIFF
--- a/src/v2/ingest/cache.py
+++ b/src/v2/ingest/cache.py
@@ -112,8 +112,14 @@ class ProviderCache:
         """Remove every cached entry. Returns the number of rows deleted."""
 
         with self._connect() as conn, conn:
-            cursor = conn.execute("DELETE FROM responses;")
-            return int(cursor.rowcount or 0)
+            # `DELETE FROM <table>` with no WHERE triggers SQLite's
+            # truncate optimization, which makes `cursor.rowcount` return
+            # 0 regardless of how many rows were actually removed. Count
+            # first so the caller (and the /v2/cache/clear endpoint) gets
+            # a truthful number.
+            count = conn.execute("SELECT COUNT(*) FROM responses;").fetchone()[0]
+            conn.execute("DELETE FROM responses;")
+            return int(count or 0)
 
 
 __all__ = [

--- a/tests/v2/test_provider_cache.py
+++ b/tests/v2/test_provider_cache.py
@@ -70,3 +70,16 @@ def test_make_key_is_deterministic_and_arg_sensitive() -> None:
     c = ProviderCache.make_key("github", "get_user", username="b")
     assert a == b
     assert a != c
+
+
+def test_clear_returns_real_deleted_count(tmp_path: Path) -> None:
+    # `DELETE FROM <table>` with no WHERE triggers SQLite's truncate
+    # optimization, under which `cursor.rowcount` is 0 even when rows are
+    # removed. `clear()` must still report the true count.
+    cache = ProviderCache(tmp_path / "p.db")
+    for i in range(7):
+        cache.set(f"k{i}", {"v": i})
+
+    assert cache.clear() == 7
+    assert cache.clear() == 0
+    assert cache.get("k0") is None


### PR DESCRIPTION
## Summary
- `ProviderCache.clear()` ran `DELETE FROM responses` with no WHERE clause. That triggers SQLite's truncate optimization, under which `cursor.rowcount` returns 0 no matter how many rows were removed — so `POST /v2/cache/clear` always reported "Cleared 0 entries" even when it had wiped the entire cache.
- Fix: `SELECT COUNT(*)` before the delete and return that. The clear behaviour was always correct; only the reported number was wrong.
- Adds a regression test (`test_clear_returns_real_deleted_count`).

## Test plan
- [x] `tests/v2/test_provider_cache.py` — 7 passed
- [ ] `POST /v2/cache/clear` reports a non-zero count when the cache is populated
