### PR TITLE
fix(zenodo): stop orphaning communities referenced by record_communities

### DIFF
--- a/src/index/zenodo/ingest/records.py
+++ b/src/index/zenodo/ingest/records.py
@@ -193,6 +193,12 @@ def persist_record(
         store.upsert_record_creators(record_id, creator_positions)
 
     if communities:
+        # Keep the `communities` master table free of orphan references:
+        # ensure a row exists for every community the record links to.
+        # `ensure_community` is insert-if-absent, so it never overwrites
+        # richer metadata written by the scope bootstrap pass.
+        for cid in communities:
+            store.ensure_community(cid)
         store.upsert_record_communities(record_id, communities)
 
     for file_row in _project_files(record_id, item):

--- a/src/index/zenodo/storage/duckdb_store.py
+++ b/src/index/zenodo/storage/duckdb_store.py
@@ -199,6 +199,24 @@ class ZenodoStore:
             ],
         )
 
+    def ensure_community(self, community_id: str) -> None:
+        """Insert a stub `communities` row if the id is not already
+        present — never overwrites an existing row.
+
+        Records reference communities the crawl never bootstrapped
+        metadata for. Without this, those ids appear in
+        `record_communities` but are absent from the `communities`
+        master table (orphan references). `ON CONFLICT DO NOTHING`
+        guarantees a stub never clobbers real metadata written by
+        `upsert_community`, regardless of ingest order.
+        """
+        self.connect().execute(
+            "INSERT INTO communities (community_id, title, raw, ingested_at) "
+            "VALUES (?, NULL, NULL, ?) "
+            "ON CONFLICT (community_id) DO NOTHING",
+            [community_id, self._now()],
+        )
+
     def upsert_record_communities(
         self,
         record_id: str,


### PR DESCRIPTION
## Summary
- `persist_record()` wrote every community a Zenodo record lists into the `record_communities` link table, but only the scope **bootstrap** pass ever populated the `communities` master table. Records routinely reference communities outside the crawl scope, so those ids landed in `record_communities` with no matching master row.
- Observed: **152 orphan community ids** (155 referenced by `record_communities`, only 3 in the `communities` master).
- Fix: new `ZenodoStore.ensure_community()` (insert-if-absent) called for every referenced community in `persist_record`. `ON CONFLICT DO NOTHING` guarantees a stub never overwrites richer metadata written by the bootstrap's `upsert_community`, regardless of ingest order.

## Test plan
- [x] Functional check: stub-then-real fills the title; real-then-stub keeps it; pure orphan gets a stub row
- [x] Re-ingest a Zenodo scope; confirm `communities` row count >= distinct `record_communities.community_id`
