### PR TITLE
feat(v2): emit internal fields under the gme-internal RDF namespace

### DIFF
--- a/docs/gme-internal.ttl
+++ b/docs/gme-internal.ttl
@@ -1,0 +1,280 @@
+@prefix gme-internal: <https://openpulse.science/git-metadata-extractor#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+
+#
+# GME internal vocabulary
+# -----------------------
+# Auxiliary terms for provider metadata collected by the
+# git-metadata-extractor that the Open Pulse ontology does not (yet)
+# model. These terms appear in a /v2/extract response only when it is
+# requested with `?include_internal_fields=true`.
+#
+# This vocabulary is SEPARATE from the Open Pulse ontology and does not
+# modify it. A document carrying gme-internal:* predicates is valid RDF
+# and loads into a triplestore, but is intentionally NOT conformant to
+# the closed (sh:closed) Open Pulse SHACL shapes.
+#
+
+<https://openpulse.science/git-metadata-extractor#> a owl:Ontology ;
+    rdfs:label "GME internal vocabulary" ;
+    rdfs:comment "Auxiliary provider-metadata terms emitted by the git-metadata-extractor under include_internal_fields=true. Not part of Open Pulse." .
+
+
+# --- GitHub account/profile metadata (Person and Organization) ---
+
+gme-internal:avatar_url a rdf:Property ;
+    rdfs:label "avatar_url" ;
+    rdfs:comment "Profile avatar image URL from GitHub." .
+
+gme-internal:bio a rdf:Property ;
+    rdfs:label "bio" ;
+    rdfs:comment "Free-text bio from the GitHub profile." .
+
+gme-internal:blog a rdf:Property ;
+    rdfs:label "blog" ;
+    rdfs:comment "Personal/organisation website declared on GitHub." .
+
+gme-internal:company a rdf:Property ;
+    rdfs:label "company" ;
+    rdfs:comment "Company/affiliation string from the GitHub profile." .
+
+gme-internal:email a rdf:Property ;
+    rdfs:label "email" ;
+    rdfs:comment "Public email address from the GitHub profile." .
+
+gme-internal:location a rdf:Property ;
+    rdfs:label "location" ;
+    rdfs:comment "Free-text location from the GitHub profile." .
+
+gme-internal:twitter_username a rdf:Property ;
+    rdfs:label "twitter_username" ;
+    rdfs:comment "Twitter/X handle declared on GitHub." .
+
+gme-internal:hireable a rdf:Property ;
+    rdfs:label "hireable" ;
+    rdfs:comment "GitHub 'hireable' flag (Person only)." .
+
+gme-internal:html_url a rdf:Property ;
+    rdfs:label "html_url" ;
+    rdfs:comment "Canonical GitHub HTML profile URL." .
+
+gme-internal:followers_count a rdf:Property ;
+    rdfs:label "followers_count" ;
+    rdfs:comment "Number of GitHub followers." .
+
+gme-internal:following_count a rdf:Property ;
+    rdfs:label "following_count" ;
+    rdfs:comment "Number of accounts the user follows (Person only)." .
+
+gme-internal:public_repos a rdf:Property ;
+    rdfs:label "public_repos" ;
+    rdfs:comment "Count of public repositories on GitHub." .
+
+gme-internal:github_account_type a rdf:Property ;
+    rdfs:label "github_account_type" ;
+    rdfs:comment "GitHub account type — 'User' or 'Organization'." .
+
+gme-internal:github_created_at a rdf:Property ;
+    rdfs:label "github_created_at" ;
+    rdfs:comment "GitHub account creation timestamp (ISO 8601)." .
+
+gme-internal:github_updated_at a rdf:Property ;
+    rdfs:label "github_updated_at" ;
+    rdfs:comment "GitHub account last-update timestamp (ISO 8601)." .
+
+
+# --- GitHub repository metadata (SoftwareSourceCode) ---
+
+gme-internal:description a rdf:Property ;
+    rdfs:label "description" ;
+    rdfs:comment "Repository short description from GitHub." .
+
+gme-internal:keywords a rdf:Property ;
+    rdfs:label "keywords" ;
+    rdfs:comment "Repository topics/keywords from GitHub." .
+
+gme-internal:homepage a rdf:Property ;
+    rdfs:label "homepage" ;
+    rdfs:comment "Repository homepage URL declared on GitHub." .
+
+gme-internal:primary_language a rdf:Property ;
+    rdfs:label "primary_language" ;
+    rdfs:comment "Dominant programming language reported by GitHub." .
+
+gme-internal:default_branch a rdf:Property ;
+    rdfs:label "default_branch" ;
+    rdfs:comment "Default branch name." .
+
+gme-internal:license_name a rdf:Property ;
+    rdfs:label "license_name" ;
+    rdfs:comment "SPDX/GitHub license name." .
+
+gme-internal:license_url a rdf:Property ;
+    rdfs:label "license_url" ;
+    rdfs:comment "GitHub API URL for the repository license." .
+
+gme-internal:visibility a rdf:Property ;
+    rdfs:label "visibility" ;
+    rdfs:comment "Repository visibility — 'public' or 'private'." .
+
+gme-internal:archived a rdf:Property ;
+    rdfs:label "archived" ;
+    rdfs:comment "Whether the repository is archived." .
+
+gme-internal:disabled a rdf:Property ;
+    rdfs:label "disabled" ;
+    rdfs:comment "Whether the repository is disabled." .
+
+gme-internal:size_kb a rdf:Property ;
+    rdfs:label "size_kb" ;
+    rdfs:comment "Repository size in kilobytes." .
+
+gme-internal:watchers_count a rdf:Property ;
+    rdfs:label "watchers_count" ;
+    rdfs:comment "Number of watchers." .
+
+gme-internal:subscribers_count a rdf:Property ;
+    rdfs:label "subscribers_count" ;
+    rdfs:comment "Number of subscribers." .
+
+gme-internal:network_count a rdf:Property ;
+    rdfs:label "network_count" ;
+    rdfs:comment "Size of the repository fork network." .
+
+gme-internal:open_issues_count a rdf:Property ;
+    rdfs:label "open_issues_count" ;
+    rdfs:comment "Count of open issues." .
+
+gme-internal:has_wiki a rdf:Property ;
+    rdfs:label "has_wiki" ;
+    rdfs:comment "Whether the repository has a wiki." .
+
+gme-internal:has_pages a rdf:Property ;
+    rdfs:label "has_pages" ;
+    rdfs:comment "Whether GitHub Pages is enabled." .
+
+gme-internal:has_issues a rdf:Property ;
+    rdfs:label "has_issues" ;
+    rdfs:comment "Whether the issue tracker is enabled." .
+
+gme-internal:has_projects a rdf:Property ;
+    rdfs:label "has_projects" ;
+    rdfs:comment "Whether GitHub Projects is enabled." .
+
+gme-internal:has_discussions a rdf:Property ;
+    rdfs:label "has_discussions" ;
+    rdfs:comment "Whether GitHub Discussions is enabled." .
+
+gme-internal:pushed_at a rdf:Property ;
+    rdfs:label "pushed_at" ;
+    rdfs:comment "Timestamp of the last push (ISO 8601)." .
+
+gme-internal:updated_at a rdf:Property ;
+    rdfs:label "updated_at" ;
+    rdfs:comment "Repository last-update timestamp (ISO 8601)." .
+
+
+# --- ROR (Research Organization Registry) metadata (Organization) ---
+
+gme-internal:ror_country a rdf:Property ;
+    rdfs:label "ror_country" ;
+    rdfs:comment "Country of the ROR-registered organisation." .
+
+gme-internal:ror_types a rdf:Property ;
+    rdfs:label "ror_types" ;
+    rdfs:comment "ROR organisation type labels." .
+
+gme-internal:ror_status a rdf:Property ;
+    rdfs:label "ror_status" ;
+    rdfs:comment "ROR record status (e.g. 'active')." .
+
+gme-internal:ror_established a rdf:Property ;
+    rdfs:label "ror_established" ;
+    rdfs:comment "Year the organisation was established, per ROR." .
+
+gme-internal:ror_links a rdf:Property ;
+    rdfs:label "ror_links" ;
+    rdfs:comment "Official links listed in the ROR record." .
+
+
+# --- ORCID metadata (Person) ---
+
+gme-internal:orcid_biography a rdf:Property ;
+    rdfs:label "orcid_biography" ;
+    rdfs:comment "Biography text from the ORCID record." .
+
+gme-internal:orcid_country a rdf:Property ;
+    rdfs:label "orcid_country" ;
+    rdfs:comment "Country from the ORCID record." .
+
+gme-internal:orcid_keywords a rdf:Property ;
+    rdfs:label "orcid_keywords" ;
+    rdfs:comment "Self-declared keywords from the ORCID record." .
+
+gme-internal:orcid_other_names a rdf:Property ;
+    rdfs:label "orcid_other_names" ;
+    rdfs:comment "Alternative names listed on the ORCID record." .
+
+gme-internal:orcid_researcher_urls a rdf:Property ;
+    rdfs:label "orcid_researcher_urls" ;
+    rdfs:comment "Researcher URLs listed on the ORCID record." .
+
+gme-internal:orcid_external_identifiers a rdf:Property ;
+    rdfs:label "orcid_external_identifiers" ;
+    rdfs:comment "External identifiers on the ORCID record." .
+
+
+# --- Infoscience / DSpace metadata (Person and Organization) ---
+
+gme-internal:infoscience_url a rdf:Property ;
+    rdfs:label "infoscience_url" ;
+    rdfs:comment "Infoscience profile/record URL." .
+
+gme-internal:infoscience_code a rdf:Property ;
+    rdfs:label "infoscience_code" ;
+    rdfs:comment "Infoscience organisational unit code." .
+
+gme-internal:infoscience_position a rdf:Property ;
+    rdfs:label "infoscience_position" ;
+    rdfs:comment "Position/role from Infoscience (Person)." .
+
+gme-internal:infoscience_employment_status a rdf:Property ;
+    rdfs:label "infoscience_employment_status" ;
+    rdfs:comment "Employment status from Infoscience (Person)." .
+
+gme-internal:unit_code a rdf:Property ;
+    rdfs:label "unit_code" ;
+    rdfs:comment "Organisational unit code (DSpace)." .
+
+gme-internal:parent_acronym a rdf:Property ;
+    rdfs:label "parent_acronym" ;
+    rdfs:comment "Acronym of the parent organisational unit." .
+
+gme-internal:director_name a rdf:Property ;
+    rdfs:label "director_name" ;
+    rdfs:comment "Name of the unit director (DSpace)." .
+
+gme-internal:org_type_dspace a rdf:Property ;
+    rdfs:label "org_type_dspace" ;
+    rdfs:comment "Organisation type as recorded in DSpace." .
+
+gme-internal:acronyms a rdf:Property ;
+    rdfs:label "acronyms" ;
+    rdfs:comment "Acronyms associated with the organisation." .
+
+gme-internal:aliases a rdf:Property ;
+    rdfs:label "aliases" ;
+    rdfs:comment "Alternative names for the organisation." .
+
+gme-internal:labels a rdf:Property ;
+    rdfs:label "labels" ;
+    rdfs:comment "Multilingual labels for the organisation." .
+
+
+# --- Pipeline-derived metadata ---
+
+gme-internal:dropped_affiliations a rdf:Property ;
+    rdfs:label "dropped_affiliations" ;
+    rdfs:comment "Affiliations collected but dropped during reconciliation for lack of a confirmable identifier anchor." .

--- a/src/v2/pipeline/stages/jsonld_build.py
+++ b/src/v2/pipeline/stages/jsonld_build.py
@@ -9,6 +9,17 @@ if TYPE_CHECKING:
 ENTITY_URI_PREFIX = "urn:pulse:"
 HELPER_ONLY_FIELDS = {"shacl", "identifiers", "idSource", "_person_ref"}
 
+# Auxiliary namespace for the rich provider metadata the extractor
+# collects but the Open Pulse ontology does not (yet) model. Surfaced
+# only when `include_internal_fields=True`: a `_avatar_url` field is
+# emitted as the JSON-LD term `gme-internal:avatar_url`, which expands
+# to a real IRI so the payload loads into an RDF triplestore. This is a
+# separate vocabulary — it does NOT touch the Open Pulse ontology, and
+# such output is intentionally not conformant to its closed SHACL
+# shapes (a triplestore load needs no SHACL conformance).
+GME_INTERNAL_PREFIX = "gme-internal"
+GME_INTERNAL_NAMESPACE = "https://openpulse.science/git-metadata-extractor#"
+
 
 def _normalize_node_id(value: Any, *, index: int) -> str:
     if isinstance(value, str) and value:
@@ -95,6 +106,25 @@ def _drop_internal_keys(entity: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _internal_term(key: str) -> str:
+    """Map a `_`-prefixed internal field to its `gme-internal:` JSON-LD
+    term (`_avatar_url` -> `gme-internal:avatar_url`)."""
+    return f"{GME_INTERNAL_PREFIX}:{key.lstrip('_')}"
+
+
+def _rewrite_internal_keys(entity: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``entity`` with top-level `_`-prefixed keys
+    renamed to their `gme-internal:` terms, so they expand to real IRI
+    predicates instead of being dropped as undefined JSON-LD terms."""
+    out: dict[str, Any] = {}
+    for key, value in entity.items():
+        if isinstance(key, str) and key.startswith("_"):
+            out[_internal_term(key)] = value
+        else:
+            out[key] = value
+    return out
+
+
 def build_jsonld_output(
     *,
     assembled: AssembledOutput,
@@ -109,14 +139,19 @@ def build_jsonld_output(
     contains zero `_` fields anywhere — only terms the open-pulse
     ontology declares.
 
-    Set ``include_internal_fields=True`` to keep `_`-prefixed keys in
-    the output (`@graph` and `excluded_entities` alike) — useful when
-    the caller asked for the broader profile metadata (`_avatar_url`,
-    `_bio`, `_company`, `_orcid_keywords`, `_dropped_affiliations`,
-    etc.) that we collect but don't yet have ontology terms for.
-    Strict SHACL validation has already run by this point (it always
-    strips `_` fields), so flipping this flag is purely about what the
-    consumer sees, not about validation.
+    Set ``include_internal_fields=True`` to surface the broader profile
+    metadata (`_avatar_url`, `_bio`, `_company`, `_orcid_keywords`,
+    `_dropped_affiliations`, etc.) that we collect but don't yet have
+    ontology terms for. Each `_`-prefixed key is renamed to a
+    `gme-internal:` JSON-LD term (`_avatar_url` -> `gme-internal:avatar_url`)
+    and the `gme-internal` prefix is registered in `@context`, so the
+    payload expands to real IRI triples and loads into an RDF
+    triplestore. This applies to `@graph` nodes and `excluded_entities`
+    alike. Strict SHACL validation has already run by this point (it
+    always strips `_` fields), so flipping this flag is purely about
+    what the consumer sees, not about validation — and the resulting
+    document is intentionally not conformant to the closed Open Pulse
+    SHACL shapes.
     """
 
     entities: list[dict[str, Any]] = []
@@ -143,17 +178,18 @@ def build_jsonld_output(
         for key, value in entity.items():
             if key in HELPER_ONLY_FIELDS or key in {"id", "type"}:
                 continue
-            if (
-                not include_internal_fields
-                and isinstance(key, str)
-                and key.startswith("_")
-            ):
-                continue
-            node[key] = _normalize_jsonld_value(
+            out_key = key
+            if isinstance(key, str) and key.startswith("_"):
+                if not include_internal_fields:
+                    continue
+                # Emit as a `gme-internal:` term so it expands to a real
+                # IRI predicate rather than a dropped undefined term.
+                out_key = _internal_term(key)
+            node[out_key] = _normalize_jsonld_value(
                 value,
                 id_map=id_map,
                 iri_typed_terms=iri_typed_terms,
-                current_property=key,
+                current_property=out_key,
             )
 
         # Strip `pulse:ror` when redundant with the node's own `@id`. The
@@ -171,20 +207,28 @@ def build_jsonld_output(
         graph.append(node)
 
     graph.sort(key=lambda item: str(item.get("@id", "")))
+    context = deepcopy(jsonld_context)
+    if include_internal_fields:
+        # Register the prefix so `gme-internal:*` terms expand to IRIs.
+        context[GME_INTERNAL_PREFIX] = GME_INTERNAL_NAMESPACE
     payload: dict[str, Any] = {
-        "@context": deepcopy(jsonld_context),
+        "@context": context,
         "@graph": graph,
     }
     if assembled.excluded_entities:
         excluded = deepcopy(assembled.excluded_entities)
         # `excluded_entities` carry the same `_`-prefixed internal fields
         # as `@graph` nodes (nested under each record's `entity`). Honour
-        # the flag here too, so `include_internal_fields=False` yields a
-        # response with zero `_` fields anywhere — not just in `@graph`.
-        if not include_internal_fields:
-            for record in excluded:
-                inner = record.get("entity") if isinstance(record, dict) else None
-                if isinstance(inner, dict):
-                    record["entity"] = _drop_internal_keys(inner)
+        # the flag here too: drop them when off, rename them to
+        # `gme-internal:` terms when on — so the whole response is
+        # consistent (zero `_` fields, or all of them as real IRIs).
+        for record in excluded:
+            inner = record.get("entity") if isinstance(record, dict) else None
+            if isinstance(inner, dict):
+                record["entity"] = (
+                    _rewrite_internal_keys(inner)
+                    if include_internal_fields
+                    else _drop_internal_keys(inner)
+                )
         payload["excluded_entities"] = excluded
     return payload

--- a/tests/v2/test_jsonld_build.py
+++ b/tests/v2/test_jsonld_build.py
@@ -141,3 +141,71 @@ def test_build_jsonld_output_emits_license_citation_and_org_hierarchy_as_iris() 
     assert list(graph.objects(org_child, URIRef("http://www.w3.org/ns/org#unitOf"))) == [
         org_parent,
     ]
+
+
+def _assembled_with_internal_fields() -> AssembledOutput:
+    return AssembledOutput(
+        root_entity={
+            "id": "owner/repo",
+            "type": "schema:SoftwareSourceCode",
+            "schema:name": "owner/repo",
+            "_homepage": "https://example.org",
+            "_watchers_count": 42,
+        },
+        related_entities=[],
+        excluded_entities=[
+            {
+                "entity_type": "person",
+                "entity": {
+                    "id": "alice",
+                    "type": "schema:Person",
+                    "schema:name": "Alice",
+                    "_bio": "researcher",
+                },
+                "reason": [{"message": "strict_validation"}],
+            },
+        ],
+    )
+
+
+def test_internal_fields_dropped_when_flag_off() -> None:
+    payload = build_jsonld_output(
+        assembled=_assembled_with_internal_fields(),
+        jsonld_context=_context(),
+        include_internal_fields=False,
+    )
+    node = payload["@graph"][0]
+    excluded = payload["excluded_entities"][0]["entity"]
+    assert "gme-internal" not in payload["@context"]
+    assert not [k for k in node if str(k).startswith(("_", "gme-internal:"))]
+    assert not [k for k in excluded if str(k).startswith(("_", "gme-internal:"))]
+
+
+def test_internal_fields_renamed_to_gme_internal_terms_when_flag_on() -> None:
+    payload = build_jsonld_output(
+        assembled=_assembled_with_internal_fields(),
+        jsonld_context=_context(),
+        include_internal_fields=True,
+    )
+    # Prefix registered so the terms expand to real IRIs.
+    assert (
+        payload["@context"]["gme-internal"]
+        == "https://openpulse.science/git-metadata-extractor#"
+    )
+    node = payload["@graph"][0]
+    assert node["gme-internal:homepage"] == "https://example.org"
+    assert node["gme-internal:watchers_count"] == 42
+    assert "_homepage" not in node
+    # Applies to excluded_entities too.
+    excluded = payload["excluded_entities"][0]["entity"]
+    assert excluded["gme-internal:bio"] == "researcher"
+    assert "_bio" not in excluded
+
+    # The renamed terms expand to IRIs under the gme-internal namespace.
+    graph = Graph()
+    graph.parse(data=json.dumps(payload), format="json-ld")
+    assert (
+        None,
+        URIRef("https://openpulse.science/git-metadata-extractor#homepage"),
+        Literal("https://example.org"),
+    ) in graph


### PR DESCRIPTION
## Summary
- `include_internal_fields=true` previously kept raw `_`-prefixed keys (`_avatar_url`, `_bio`, …) verbatim. Those are undefined JSON-LD terms, so any RDF conversion silently drops them — the payload was JSON-visible but **not loadable into a triplestore**.
- Now each `_x` key is renamed to `gme-internal:x` and the `gme-internal` prefix (`https://openpulse.science/git-metadata-extractor#`) is registered in `@context`, so the document expands to real IRI triples. Applies to both `@graph` nodes and `excluded_entities`.
- Adds `docs/gme-internal.ttl` — a companion vocabulary documenting the 60 terms (GitHub profile/repo, ROR, ORCID, Infoscience).

## Design notes
- `gme-internal` is a **separate auxiliary vocabulary** — it does **not** touch the Open Pulse ontology.
- Output carrying `gme-internal:*` predicates is valid RDF and triplestore-loadable, but **intentionally not conformant** to the closed (`sh:closed`) Open Pulse SHACL shapes. SHACL validation still runs on the `_`-stripped copy, unchanged.
- `include_internal_fields=false` (default) is unchanged: zero `_` / `gme-internal:` fields anywhere.
- The namespace URI must be hosted at `https://openpulse.science/git-metadata-extractor#` for the terms to be dereferenceable; `docs/gme-internal.ttl` is the source to publish there.

## Test plan
- [x] `tests/v2/test_jsonld_build.py` — flag off drops all internal fields; flag on renames to `gme-internal:` terms, registers the prefix, and JSON-LD round-trip yields real IRI triples
- [x] Full v2 suite — 740 passed, 1 skipped
