### PR TITLE
fix(gimie): collapse PAT pool to a single GITHUB_TOKEN before calling gimie

### DIFF
--- a/src/v1/gimie_utils/gimie_methods.py
+++ b/src/v1/gimie_utils/gimie_methods.py
@@ -23,8 +23,10 @@ see the fixes.
 from __future__ import annotations
 
 import calendar
+import contextlib
 import json
 import logging
+import os
 import re
 from http import HTTPStatus
 from typing import Any
@@ -176,6 +178,41 @@ GithubExtractor.list_files = _patched_list_files
 from gimie.project import Project  # noqa: E402  # import after monkeypatches
 
 
+def _first_non_empty_token(raw: str) -> str | None:
+    return next((t.strip() for t in raw.split(",") if t.strip()), None)
+
+
+@contextlib.contextmanager
+def _gimie_legacy_github_token_env():
+    """Force `GITHUB_TOKEN` to a single PAT for the duration of a gimie call.
+
+    `gimie.extractors.github.GithubExtractor` reads `os.environ["GITHUB_TOKEN"]`
+    verbatim and 401s when the value contains commas. The post-rename
+    deployments expose the PAT pool under `GME_GITHUB_TOKEN_POOL` /
+    `GME_GITHUB_TOKEN`, and many local shells still export the legacy
+    `GITHUB_TOKEN` with the same comma-separated string — either way
+    gimie needs to see one entry. Promote whichever source has a value
+    (in order: POOL > GME single > legacy) to a single first token for
+    the call, then restore.
+    """
+    prior = os.environ.get("GITHUB_TOKEN")
+    raw = (
+        os.environ.get("GME_GITHUB_TOKEN_POOL", "")
+        or os.environ.get("GME_GITHUB_TOKEN", "")
+        or os.environ.get("GITHUB_TOKEN", "")
+    )
+    first = _first_non_empty_token(raw)
+    if first:
+        os.environ["GITHUB_TOKEN"] = first
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop("GITHUB_TOKEN", None)
+        else:
+            os.environ["GITHUB_TOKEN"] = prior
+
+
 def extract_gimie(full_path: str, serialization_format: str = "json-ld"):
     """
     Extracts the GIMIE project from the given URL.
@@ -189,13 +226,11 @@ def extract_gimie(full_path: str, serialization_format: str = "json-ld"):
     """
     logger.info(f"Extracting GIMIE metadata for: {full_path}")
 
-    proj = Project(full_path)
-
-    # To retrieve the rdflib.Graph object
-    g = proj.extract()
+    with _gimie_legacy_github_token_env():
+        proj = Project(full_path)
+        g = proj.extract()
 
     if serialization_format == "json-ld":
-        # To retrieve the graph in JSON-LD format
         output = json.loads(g.serialize(format="json-ld"))
     else:
         output = g.serialize(format=serialization_format)

--- a/src/v2/agents/terminal/runner.py
+++ b/src/v2/agents/terminal/runner.py
@@ -355,25 +355,16 @@ class TerminalRunner:
         # gimie: reuse the v1 helper because it carries monkey-patches
         # against a known empty-repo crash and a REST-query bug; importing
         # plain `gimie.project.Project` here would re-introduce those.
+        # The helper also normalises the legacy `GITHUB_TOKEN` env that
+        # gimie reads (gimie 401s on a comma-separated pool), so the
+        # call site doesn't need to wrap it any further.
         from src.v1.gimie_utils.gimie_methods import extract_gimie  # noqa: PLC0415
 
-        # The repo's GME_GITHUB_TOKEN is comma-separated for v1's rotation
-        # logic. gimie expects a single token and 401s on the literal
-        # comma string; pick the first non-empty token for the gimie
-        # call only, then restore the original env.
-        gh_token_orig = os.environ.get("GME_GITHUB_TOKEN", "")
-        if "," in gh_token_orig:
-            primary = next((t.strip() for t in gh_token_orig.split(",") if t.strip()), gh_token_orig)
-            os.environ["GME_GITHUB_TOKEN"] = primary
         try:
-            try:
-                gimie_payload = extract_gimie(source_url, serialization_format="json-ld")
-            except Exception as err:  # noqa: BLE001 — gimie is best-effort
-                logger.warning("gimie extraction failed for %s: %s", source_url, err)
-                gimie_payload = {"@graph": [], "_gimie_error": str(err)}
-        finally:
-            if gh_token_orig:
-                os.environ["GME_GITHUB_TOKEN"] = gh_token_orig
+            gimie_payload = extract_gimie(source_url, serialization_format="json-ld")
+        except Exception as err:  # noqa: BLE001 — gimie is best-effort
+            logger.warning("gimie extraction failed for %s: %s", source_url, err)
+            gimie_payload = {"@graph": [], "_gimie_error": str(err)}
         (workdir / "gimie.jsonld").write_text(
             json.dumps(gimie_payload, indent=2, ensure_ascii=False, default=str),
             encoding="utf-8",

--- a/tests/v1/test_gimie_legacy_token_normalization.py
+++ b/tests/v1/test_gimie_legacy_token_normalization.py
@@ -1,0 +1,121 @@
+"""`extract_gimie` must hand gimie a single PAT, not a comma-separated pool.
+
+Regression test for the rename-PR follow-up: `gimie.GithubExtractor`
+reads `os.environ["GITHUB_TOKEN"]` verbatim and 401s on a pool string.
+The wrapper in `src/v1/gimie_utils/gimie_methods.py` normalises that
+env before calling `Project(...)` and restores it on exit, so callers
+(production runner + standalone tests) don't need a per-site shim.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from src.v1.gimie_utils import gimie_methods
+
+
+class _StubGraph:
+    def serialize(self, format: str = "json-ld") -> str:
+        return "[]"
+
+
+class _StubProject:
+    """Captures the value of `os.environ['GITHUB_TOKEN']` at the moment
+    gimie would have read it inside the context manager.
+    """
+
+    captured_github_token: str | None = None
+
+    def __init__(self, full_path: str) -> None:
+        type(self).captured_github_token = os.environ.get("GITHUB_TOKEN")
+
+    def extract(self) -> _StubGraph:
+        return _StubGraph()
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GME_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GME_GITHUB_TOKEN_POOL", raising=False)
+    _StubProject.captured_github_token = None
+
+
+def test_pool_first_token_promoted_to_legacy_env(monkeypatch):
+    monkeypatch.setenv("GME_GITHUB_TOKEN_POOL", "ghp_pool_a,ghp_pool_b,ghp_pool_c")
+    monkeypatch.setenv("GME_GITHUB_TOKEN", "ghp_pool_a")
+
+    with patch.object(gimie_methods, "Project", _StubProject):
+        gimie_methods.extract_gimie("https://github.com/owner/repo")
+
+    assert _StubProject.captured_github_token == "ghp_pool_a"
+
+
+def test_gme_single_used_when_pool_unset(monkeypatch):
+    monkeypatch.setenv("GME_GITHUB_TOKEN", "ghp_solo")
+
+    with patch.object(gimie_methods, "Project", _StubProject):
+        gimie_methods.extract_gimie("https://github.com/owner/repo")
+
+    assert _StubProject.captured_github_token == "ghp_solo"
+
+
+def test_legacy_multi_comma_value_collapsed_to_first(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_legacy_a,ghp_legacy_b")
+
+    with patch.object(gimie_methods, "Project", _StubProject):
+        gimie_methods.extract_gimie("https://github.com/owner/repo")
+
+    assert _StubProject.captured_github_token == "ghp_legacy_a"
+    # And restored to the literal pool string after the call returns.
+    assert os.environ["GITHUB_TOKEN"] == "ghp_legacy_a,ghp_legacy_b"
+
+
+def test_prior_legacy_value_restored_on_success(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_prior_legacy")
+    monkeypatch.setenv("GME_GITHUB_TOKEN_POOL", "ghp_pool_a,ghp_pool_b")
+
+    with patch.object(gimie_methods, "Project", _StubProject):
+        gimie_methods.extract_gimie("https://github.com/owner/repo")
+
+    assert _StubProject.captured_github_token == "ghp_pool_a"
+    assert os.environ["GITHUB_TOKEN"] == "ghp_prior_legacy"
+
+
+def test_prior_unset_left_unset_on_success(monkeypatch):
+    monkeypatch.setenv("GME_GITHUB_TOKEN_POOL", "ghp_pool_a")
+
+    with patch.object(gimie_methods, "Project", _StubProject):
+        gimie_methods.extract_gimie("https://github.com/owner/repo")
+
+    assert _StubProject.captured_github_token == "ghp_pool_a"
+    assert "GITHUB_TOKEN" not in os.environ
+
+
+def test_no_tokens_anywhere_leaves_env_untouched(monkeypatch):
+    with patch.object(gimie_methods, "Project", _StubProject):
+        gimie_methods.extract_gimie("https://github.com/owner/repo")
+
+    assert _StubProject.captured_github_token is None
+    assert "GITHUB_TOKEN" not in os.environ
+
+
+def test_env_restored_when_gimie_raises(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_prior_legacy")
+    monkeypatch.setenv("GME_GITHUB_TOKEN_POOL", "ghp_pool_a,ghp_pool_b")
+
+    class _BoomProject:
+        def __init__(self, full_path: str) -> None:
+            pass
+
+        def extract(self):
+            raise RuntimeError("gimie blew up")
+
+    with patch.object(gimie_methods, "Project", _BoomProject):
+        with pytest.raises(RuntimeError, match="gimie blew up"):
+            gimie_methods.extract_gimie("https://github.com/owner/repo")
+
+    assert os.environ["GITHUB_TOKEN"] == "ghp_prior_legacy"


### PR DESCRIPTION
Follow-up to #57 (the env-var rename). Flagged as "out of scope" in #58.

## Summary

After the rename, `gimie.extractors.github.GithubExtractor` (a third-party library we vend) still reads `os.environ["GITHUB_TOKEN"]` verbatim. Two consequences slipped through:

- **Local**: `tests/v1/test_gimie_empty_github_repo.py` fails because the dev shell still exports the legacy `GITHUB_TOKEN=ghp_a,ghp_b,…` — gimie hands the literal comma string to GitHub → 401.
- **Production**: `src/v2/agents/terminal/runner.py` wrapped each gimie call by mutating `GME_GITHUB_TOKEN`, which gimie doesn't read. So in deployments with a PAT pool, the terminal-agent runtime was silently hitting 401 on every gimie extraction (pre-rename the variable name was correct but did nothing useful; post-rename it's also misnamed).

## Approach

- `src/v1/gimie_utils/gimie_methods.py` wraps `Project(...)` in a `_gimie_legacy_github_token_env()` context manager that promotes the first non-empty token from `GME_GITHUB_TOKEN_POOL > GME_GITHUB_TOKEN > GITHUB_TOKEN` into `os.environ["GITHUB_TOKEN"]` for the call's lifetime, then restores the prior value (or unsets it). One canonical place, all callers benefit.
- `src/v2/agents/terminal/runner.py` drops the (always-misnamed, now-redundant) `GME_GITHUB_TOKEN` shuffling around the gimie call. The block collapses to one call inside a try/except.

## Test plan

- [x] `pytest tests/v1/test_gimie_legacy_token_normalization.py` — 7 new tests covering source precedence (POOL > GME > legacy), env restoration on success + on raise, "no token anywhere", and the legacy multi-comma collapse.
- [x] `pytest tests/v1/test_gimie_empty_github_repo.py` — now passes against a real PAT pool. Was failing on develop post-#57 because the wrapper couldn't translate the pool to a single token.
- [x] `pytest tests/v1/ tests/utils/` — 30 passed.
- [x] `pytest tests/v2/ -n 4 --dist=loadfile -m 'not live_provider and not llm_integration'` — 764 passed.

## Notes

- Stacks cleanly on top of #58 (the v1 parser rotation fix). No textual conflict — they touch different files.
- The fix is intentionally narrow to gimie's call boundary. Other libraries that read `GITHUB_TOKEN` at import time (none today) would need their own normalisation, or `src/api.py` startup could mirror `GME_GITHUB_TOKEN[0]` into `GITHUB_TOKEN` globally. Skipped that for now to keep the blast radius small.