### PR TITLE
fix(v2 auto-ingest): construct GitHubClient with keyword args (closes #51, #55)

### DIFF
--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -1495,13 +1495,18 @@ def _maybe_schedule_github_auto_ingest(
 
         def _do_ingest() -> tuple[str, int]:
             cfg = load_github_config()
+            cfg.require_github()
             with _GITHUB_AUTO_INGEST_LOCK:
                 store = GitHubStore.open(cfg.paths.duckdb_path)
                 try:
                     existing = store.fetch_repo(full_name)
                     if existing is not None:
                         return ("skipped_already_indexed", 0)
-                    client = GitHubClient(cfg)
+                    client = GitHubClient(
+                        api_base=cfg.github.api_base,
+                        token=cfg.github.token,
+                        cache_path=cfg.paths.cache_db_path,
+                    )
                     outcome = ingest_single_repo(
                         config=cfg, store=store, client=client, full_name=full_name,
                     )

--- a/tests/v2/test_github_auto_ingest_client_signature.py
+++ b/tests/v2/test_github_auto_ingest_client_signature.py
@@ -1,0 +1,175 @@
+"""Regression for #51 / #55: the auto-ingest closure built `GitHubClient(cfg)`
+positionally, but `GitHubClient.__init__` is keyword-only — so every
+`V2_GITHUB_RAG_AUTO_INGEST=true` deployment was silently 100%-failing the
+background ingest with a `TypeError` (catalogs stuck since 2026-05-13 / -24).
+
+The minimal guard: schedule the closure end-to-end with every heavy dep
+patched out, and assert it does **not** log the `failed` line and that
+`GitHubClient` was called with the right kwargs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.v2 import api as v2_api
+
+
+@pytest.fixture
+def fake_classification() -> Any:
+    """Stand-in for the GitHubURLClassification the closure inspects."""
+    cls = types.SimpleNamespace(
+        detected_type=types.SimpleNamespace(value="repository"),
+        normalized_url="https://github.com/octocat/Hello-World",
+    )
+    return cls
+
+
+@pytest.fixture
+def fake_config() -> Any:
+    """A config double exposing only what the auto-ingest closure reads."""
+    return types.SimpleNamespace(
+        require_github=lambda: None,
+        github=types.SimpleNamespace(
+            api_base="https://api.github.com",
+            token="ghp_test_token",
+        ),
+        paths=types.SimpleNamespace(
+            duckdb_path=Path("/tmp/not-real.duckdb"),
+            cache_db_path=Path("/tmp/not-real-providers.db"),
+        ),
+    )
+
+
+class _GitHubClientSpy:
+    """Records kwargs from each construction."""
+
+    last_kwargs: dict[str, Any] | None = None
+
+    def __init__(self, **kwargs: Any) -> None:
+        type(self).last_kwargs = kwargs
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.last_kwargs = None
+
+
+class _GitHubStoreStub:
+    @classmethod
+    def open(cls, _path: Path) -> "_GitHubStoreStub":
+        return cls()
+
+    def fetch_repo(self, _full_name: str) -> None:
+        return None  # forces the closure into the GitHubClient(...) branch
+
+    def close(self) -> None:
+        return None
+
+
+@contextmanager
+def _patched_ingest_modules(monkeypatch, *, config: Any, client_cls: type) -> Any:
+    """Stub every module the closure imports lazily.
+
+    The closure does `from src.index.github.* import ...` inside `_run`, so
+    inserting fake modules into `sys.modules` before the closure runs is
+    enough to intercept those imports without monkeypatching attributes
+    on objects the closure never touches.
+    """
+
+    def _ingest_single_repo(**_kwargs: Any) -> str:
+        return "ingested"
+
+    def _embed_repos(**_kwargs: Any) -> dict[str, int]:
+        return {"repos": 1}
+
+    fakes = {
+        "src.index.github.config": types.SimpleNamespace(
+            load_config=lambda: config,
+        ),
+        "src.index.github.embed.pipeline": types.SimpleNamespace(
+            embed_repos=_embed_repos,
+        ),
+        "src.index.github.ingest.github_client": types.SimpleNamespace(
+            GitHubClient=client_cls,
+        ),
+        "src.index.github.ingest.repos": types.SimpleNamespace(
+            ingest_single_repo=_ingest_single_repo,
+        ),
+        "src.index.github.storage.duckdb_store": types.SimpleNamespace(
+            GitHubStore=_GitHubStoreStub,
+        ),
+    }
+    originals = {name: sys.modules.get(name) for name in fakes}
+    for name, mod in fakes.items():
+        sys.modules[name] = mod
+    try:
+        yield
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def test_auto_ingest_constructs_github_client_with_keyword_args(
+    monkeypatch,
+    caplog,
+    fake_classification,
+    fake_config,
+):
+    monkeypatch.setenv("V2_GITHUB_RAG_AUTO_INGEST", "true")
+    _GitHubClientSpy.reset()
+
+    with _patched_ingest_modules(
+        monkeypatch, config=fake_config, client_cls=_GitHubClientSpy,
+    ):
+        async def _drive() -> None:
+            with caplog.at_level(logging.INFO, logger="src.v2.api"):
+                v2_api._maybe_schedule_github_auto_ingest(
+                    classification=fake_classification, run_id="test-run",
+                )
+                # Yield once so the asyncio.create_task() inside has a
+                # chance to schedule the inner `_do_ingest` thread. We then
+                # await the thread executor to drain.
+                await asyncio.sleep(0)
+                # Give the to_thread executor time to finish.
+                for _ in range(20):
+                    if _GitHubClientSpy.last_kwargs is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        asyncio.run(_drive())
+
+    assert _GitHubClientSpy.last_kwargs == {
+        "api_base": "https://api.github.com",
+        "token": "ghp_test_token",
+        "cache_path": Path("/tmp/not-real-providers.db"),
+    }
+    # And nothing logged the regression signature.
+    assert not any(
+        "auto-ingest" in record.message and "failed" in record.message
+        for record in caplog.records
+    )
+
+
+def test_auto_ingest_is_no_op_when_env_disabled(
+    monkeypatch, fake_classification, fake_config,
+):
+    monkeypatch.delenv("V2_GITHUB_RAG_AUTO_INGEST", raising=False)
+    _GitHubClientSpy.reset()
+    with _patched_ingest_modules(
+        monkeypatch, config=fake_config, client_cls=_GitHubClientSpy,
+    ):
+        v2_api._maybe_schedule_github_auto_ingest(
+            classification=fake_classification, run_id="test-run",
+        )
+    assert _GitHubClientSpy.last_kwargs is None


### PR DESCRIPTION
Closes #51, closes #55.

## Summary

`_maybe_schedule_github_auto_ingest` built `GitHubClient(cfg)` positionally, but `GitHubClient.__init__` has been keyword-only (`api_base` / `token` / `cache_path`) since the index module was carved out — so every `V2_GITHUB_RAG_AUTO_INGEST=true` deployment was silently 100%-failing the background ingest with a `TypeError`. `github.duckdb` froze on 2026-05-13 in the affected deployments, even though the `/v2/extract` response kept returning 200 OK because the auto-ingest is fire-and-forget.

Two existing call sites already do the right thing — `src/index/github/ingest/repos.py:151` and `src/v2/indices/github.py:49`. The auto-ingest closure is now aligned with them: same kwargs, same `cfg.require_github()` guard (so a missing token surfaces as a clean `ValueError`, caught by the outer except and logged as `auto-ingest ... failed: Missing required environment variable: GME_GITHUB_TOKEN` instead of a downstream surprise).

## Test plan

- [x] New `tests/v2/test_github_auto_ingest_client_signature.py` schedules `_maybe_schedule_github_auto_ingest` end-to-end with every heavy dep (`load_config` / `GitHubStore` / `GitHubClient` / `ingest_single_repo` / `embed_repos`) patched out, then asserts the `GitHubClient(...)` invocation carries the correct kwargs from the config. Pre-fix this test reproduces the exact `TypeError` from the issue traceback.
- [x] Second test guards the opt-out path (env unset → no construction).
- [x] `pytest tests/v2/ -n 4 --dist=loadfile -m 'not live_provider and not llm_integration'` — 766 passed (764 + 2 new).

## Acceptance criteria (from #55)

- [x] `GitHubClient` is constructed with the right kwargs.
- [x] Unit test for the auto-ingest closure asserting that.
- [ ] **Operator side** — after merging, set `V2_GITHUB_RAG_AUTO_INGEST=true` on a deployment that has had it stuck, run any `POST /v2/extract` for a GitHub repo, and confirm:
  - a new row appears in `github.duckdb.repos`;
  - the `github auto-ingest ... %s` log line records `outcome=ingested` (or `skipped_already_indexed` on second attempt) rather than `failed`.

## Adjacent issues called out in #51 and #55 (NOT addressed here, recommend separate PRs)

- The bind-mounted catalog dir permissions issue (`/app/index/github/{cache,cards,logs,duckdb}/` landing as `root:root` inside the container). Belongs in the Dockerfile.
- The 1 req/s `GET /v2/jobs/` 404 noise from an upstream poller hitting the list endpoint without a `job_id`. Trivial but unrelated.