### PR TITLE
feat(v2 indices): GET /v2/indices/{provider}/stats — read-only catalog counts (closes #52)

### DIFF
--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -69,6 +69,12 @@ from src.v2.indices.oamonitor import (
 from src.v2.indices.openalex import run_openalex_ingest_job, run_openalex_search
 from src.v2.indices.orcid import run_orcid_ingest_job, run_orcid_search
 from src.v2.indices.renkulab import run_renkulab_ingest_job, run_renkulab_search
+from src.v2.indices.stats import (
+    IndexStatsResponse,
+    UnknownIndexProviderError,
+    collect_index_stats,
+    fetch_store_for_stats,
+)
 from src.v2.indices.swissubase import (
     run_swissubase_ingest_job,
     run_swissubase_search,
@@ -2358,6 +2364,55 @@ async def oamonitor_search_post(
         await run_oamonitor_search(payload, request.app.state),
         index_name="oamonitor",
     )
+
+
+@v2_router.get(
+    "/indices/{provider}/stats",
+    response_model=IndexStatsResponse,
+    response_model_exclude_none=True,
+    tags=["Indices"],
+)
+async def index_stats_get(
+    provider: Annotated[str, Path(description="One of the supported index providers.")],
+    request: Request,
+    _token: Annotated[str, Depends(verify_token)],
+) -> IndexStatsResponse | JSONResponse:
+    """Read-only catalog stats: total rows + per-table breakdown + last_updated.
+
+    External consumers (Open Pulse Hub Overview, dashboards) used to poll
+    each `.duckdb` file with `duckdb.connect(path, read_only=True)`. That
+    fails as soon as the GME holds a write connection (auto-ingest et al)
+    because DuckDB's advisory lock is per-process. This endpoint runs the
+    same `SELECT COUNT(*)` queries on the GME's already-open connection,
+    so the file lock is never contested.
+    """
+
+    try:
+        store = fetch_store_for_stats(provider, request.app.state)
+    except UnknownIndexProviderError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": str(exc)},
+        )
+    if store is None:
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={
+                "detail": f"{provider} index resources unavailable on this deployment",
+            },
+        )
+
+    try:
+        stats = await asyncio.to_thread(
+            collect_index_stats, provider, store.connect(),
+        )
+    except Exception as exc:  # noqa: BLE001 — surface as 503 + log
+        logger.exception("index stats query failed: provider=%s", provider)
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={"detail": f"stats query failed: {exc}"},
+        )
+    return stats
 
 
 @v2_router.get(

--- a/src/v2/indices/stats.py
+++ b/src/v2/indices/stats.py
@@ -1,0 +1,223 @@
+"""Read-only catalog stats for `GET /v2/indices/{provider}/stats`.
+
+External consumers (Open Pulse Hub's Overview charts, dashboards) used to
+poll each `.duckdb` file directly with `duckdb.connect(path, read_only=True)`.
+That stopped working the moment the GME started auto-ingesting concurrently
+— DuckDB takes an advisory file lock even in read-only mode, and a reader
+colliding with the GME's writer gets `Could not set lock on file ...
+Conflicting lock is held in PID 0`. So we expose the same numbers
+through the API process that already owns the open connection.
+
+Implementation is intentionally schema-agnostic: we list user tables via
+`information_schema.tables`, run `SELECT COUNT(*)` on each, and pick a
+`last_updated` from whichever timestamp column happens to be present.
+This means adding a new provider (or a new table inside a provider's
+DuckDB) doesn't need a code change here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    import duckdb
+
+INDEX_STATS_SUPPORTED_PROVIDERS: tuple[str, ...] = (
+    "zenodo",
+    "github",
+    "huggingface",
+    "openalex",
+    "orcid",
+    "renkulab",
+    "swissubase",
+    "ethz_research_collection",
+    "oamonitor",
+)
+
+# Common "this row was last touched" column names, in priority order.
+# First one present per table wins. Extend as new schemas show up.
+_TIMESTAMP_COLUMN_CANDIDATES: tuple[str, ...] = (
+    "updated_at",
+    "ingested_at",
+    "fetched_at",
+    "updated",
+    "pushed_at",
+    "created_at",
+)
+
+
+class IndexStatsResponse(BaseModel):
+    """Read-only catalog stats response shape."""
+
+    provider: str = Field(..., description="One of INDEX_STATS_SUPPORTED_PROVIDERS.")
+    count: int = Field(..., ge=0, description="Total rows across every user table.")
+    last_updated: datetime | None = Field(
+        default=None,
+        description=(
+            "Most recent timestamp found in any timestamp-like column across "
+            "all tables. `null` when the catalog is empty or no such column exists."
+        ),
+    )
+    by_table: dict[str, int] = Field(
+        default_factory=dict,
+        description="Row count per user table, useful for multi-table catalogs.",
+    )
+
+
+class UnknownIndexProviderError(ValueError):
+    """Raised when the URL provider isn't in INDEX_STATS_SUPPORTED_PROVIDERS."""
+
+
+def _coerce_timestamp(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return None
+
+
+def collect_index_stats(
+    provider: str,
+    conn: duckdb.DuckDBPyConnection,
+) -> IndexStatsResponse:
+    """Schema-introspect the DuckDB at `conn` and return its stats."""
+
+    table_rows = conn.execute(
+        """
+        SELECT table_name
+          FROM information_schema.tables
+         WHERE table_schema = 'main' AND table_type = 'BASE TABLE'
+         ORDER BY table_name
+        """,
+    ).fetchall()
+
+    by_table: dict[str, int] = {}
+    for (table_name,) in table_rows:
+        count_row = conn.execute(
+            f'SELECT COUNT(*) FROM "{table_name}"',
+        ).fetchone()
+        by_table[table_name] = int(count_row[0]) if count_row else 0
+
+    last_updated: datetime | None = None
+    for table_name in by_table:
+        col_rows = conn.execute(
+            """
+            SELECT column_name FROM information_schema.columns
+             WHERE table_schema = 'main' AND table_name = ?
+            """,
+            [table_name],
+        ).fetchall()
+        present = {row[0] for row in col_rows}
+        for candidate in _TIMESTAMP_COLUMN_CANDIDATES:
+            if candidate not in present:
+                continue
+            value_row = conn.execute(
+                f'SELECT MAX("{candidate}") FROM "{table_name}"',
+            ).fetchone()
+            value = value_row[0] if value_row else None
+            coerced = _coerce_timestamp(value)
+            if coerced is not None and (
+                last_updated is None or coerced > last_updated
+            ):
+                last_updated = coerced
+            break
+
+    return IndexStatsResponse(
+        provider=provider,
+        count=sum(by_table.values()),
+        last_updated=last_updated,
+        by_table=by_table,
+    )
+
+
+def fetch_store_for_stats(provider: str, app_state: Any) -> Any | None:
+    """Return the long-lived DuckDB-backed Store for `provider`, or None.
+
+    Reuses the existing `get_or_create_<provider>_resources` helpers so we
+    share the writer's open connection and avoid the cross-process lock
+    fight. ETHZ has no long-lived store on `app_state`, so we open one
+    on demand for the read.
+    """
+
+    if provider not in INDEX_STATS_SUPPORTED_PROVIDERS:
+        raise UnknownIndexProviderError(
+            f"unknown index provider: {provider!r}; "
+            f"supported: {', '.join(INDEX_STATS_SUPPORTED_PROVIDERS)}",
+        )
+
+    if provider == "github":
+        from src.v2.indices.github import (  # noqa: PLC0415
+            get_or_create_github_resources,
+        )
+        res = get_or_create_github_resources(app_state)
+        return res[1] if res else None
+    if provider == "zenodo":
+        from src.v2.indices.zenodo import (  # noqa: PLC0415
+            get_or_create_zenodo_store,
+        )
+        res = get_or_create_zenodo_store(app_state)
+        return res[1] if res else None
+    if provider == "huggingface":
+        from src.v2.indices.huggingface import (  # noqa: PLC0415
+            get_or_create_huggingface_resources,
+        )
+        res = get_or_create_huggingface_resources(app_state)
+        return res[2] if res else None
+    if provider == "openalex":
+        from src.v2.indices.openalex import (  # noqa: PLC0415
+            get_or_create_openalex_resources,
+        )
+        res = get_or_create_openalex_resources(app_state)
+        return res[1] if res else None
+    if provider == "orcid":
+        from src.v2.indices.orcid import (  # noqa: PLC0415
+            get_or_create_orcid_resources,
+        )
+        res = get_or_create_orcid_resources(app_state)
+        return res[1] if res else None
+    if provider == "renkulab":
+        from src.v2.indices.renkulab import (  # noqa: PLC0415
+            get_or_create_renkulab_resources,
+        )
+        res = get_or_create_renkulab_resources(app_state)
+        return res[2] if res else None
+    if provider == "swissubase":
+        from src.v2.indices.swissubase import (  # noqa: PLC0415
+            get_or_create_swissubase_resources,
+        )
+        res = get_or_create_swissubase_resources(app_state)
+        return res[2] if res else None
+    if provider == "oamonitor":
+        from src.v2.indices.oamonitor import (  # noqa: PLC0415
+            get_or_create_oamonitor_resources,
+        )
+        res = get_or_create_oamonitor_resources(app_state)
+        return res[2] if res else None
+    if provider == "ethz_research_collection":
+        try:
+            from src.index.ethz_research_collection.storage import (  # noqa: PLC0415
+                DuckDBStore,
+            )
+        except Exception:  # noqa: BLE001 — optional dependency
+            return None
+        try:
+            return DuckDBStore.open()
+        except Exception:  # noqa: BLE001 — config / disk issues
+            return None
+    return None
+
+
+__all__ = [
+    "INDEX_STATS_SUPPORTED_PROVIDERS",
+    "IndexStatsResponse",
+    "UnknownIndexProviderError",
+    "collect_index_stats",
+    "fetch_store_for_stats",
+]

--- a/tests/v2/test_indices_stats_endpoint.py
+++ b/tests/v2/test_indices_stats_endpoint.py
@@ -1,0 +1,237 @@
+"""`GET /v2/indices/{provider}/stats` — unblock external readers (#52).
+
+External consumers (Open Pulse Hub) used to poll each `.duckdb` file with
+`duckdb.connect(path, read_only=True)`. That fails the moment the GME holds
+a write connection, because DuckDB's lock is per-process. The new endpoint
+runs `SELECT COUNT(*)` and a `MAX(timestamp_col)` lookup on the GME's
+already-open connection, so the file lock is never contested.
+
+These tests stand up a tiny FastAPI app with a hand-crafted DuckDB file
+pre-seeded on `app.state.v2_<provider>_resources`, then call the endpoint
+through the ASGI transport (no network, no Qdrant, no GitHub).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.v2.api import v2_router
+from src.v2.indices import stats as stats_module
+from src.v2.indices.stats import (
+    IndexStatsResponse,
+    UnknownIndexProviderError,
+    collect_index_stats,
+    fetch_store_for_stats,
+)
+
+HTTP_OK = 200
+HTTP_NOT_FOUND = 404
+HTTP_SERVICE_UNAVAILABLE = 503
+
+# Matches the value seeded by the `_isolate_v2_runtime_env` autouse
+# fixture in `tests/v2/conftest.py`.
+TEST_API_TOKEN = "test-api-token"  # noqa: S105 — test fixture
+_AUTH_HEADERS = {"Authorization": f"Bearer {TEST_API_TOKEN}"}
+
+
+class _FakeStore:
+    """Just enough surface for `fetch_store_for_stats` callers.
+
+    `app.state.v2_<provider>_resources` is a tuple — we shove this fake
+    in the right tuple slot per provider so the stats handler reads the
+    pre-seeded DuckDB file we set up below.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._conn: duckdb.DuckDBPyConnection | None = None
+
+    def connect(self) -> duckdb.DuckDBPyConnection:
+        if self._conn is None:
+            self._conn = duckdb.connect(str(self._db_path))
+        return self._conn
+
+
+def _build_test_db(
+    tmp_path: Path,
+    *,
+    tables: dict[str, list[dict[str, Any]]],
+    timestamp_column: str | None = None,
+) -> Path:
+    """Materialise a tiny DuckDB with one or more tables for stats to count."""
+    path = tmp_path / "stats.duckdb"
+    conn = duckdb.connect(str(path))
+    for name, rows in tables.items():
+        cols: list[tuple[str, str]] = [("id", "INTEGER")]
+        if timestamp_column is not None:
+            cols.append((timestamp_column, "TIMESTAMP"))
+        col_defs = ", ".join(f'"{c}" {t}' for c, t in cols)
+        conn.execute(f'CREATE TABLE "{name}" ({col_defs})')
+        for row in rows:
+            placeholders = ", ".join("?" for _ in cols)
+            values = [row.get(c) for c, _ in cols]
+            conn.execute(
+                f'INSERT INTO "{name}" VALUES ({placeholders})',
+                values,
+            )
+    conn.close()
+    return path
+
+
+def _build_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(v2_router)
+    return app
+
+
+def _get(app: FastAPI, path: str) -> tuple[int, Any]:
+    """Call `path` through the ASGI transport and return (status, json)."""
+
+    async def _run() -> tuple[int, Any]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(path, headers=_AUTH_HEADERS)
+        try:
+            body: Any = resp.json()
+        except Exception:  # noqa: BLE001 — response with no JSON body
+            body = resp.text
+        return resp.status_code, body
+
+    return asyncio.run(_run())
+
+
+# ----------------------------------------------------------------------------
+# collect_index_stats — pure schema introspection
+# ----------------------------------------------------------------------------
+
+
+def test_collect_index_stats_sums_counts_across_tables(tmp_path: Path) -> None:
+    db = _build_test_db(
+        tmp_path,
+        tables={
+            "datasets": [{"id": i} for i in range(3)],
+            "models": [{"id": i} for i in range(2)],
+            "spaces": [{"id": 1}],
+        },
+    )
+    conn = duckdb.connect(str(db))
+    try:
+        stats = collect_index_stats("huggingface", conn)
+    finally:
+        conn.close()
+    assert stats.provider == "huggingface"
+    assert stats.count == 6
+    assert stats.by_table == {"datasets": 3, "models": 2, "spaces": 1}
+    assert stats.last_updated is None  # no timestamp column on this fixture
+
+
+def test_collect_index_stats_picks_max_timestamp_across_tables(tmp_path: Path) -> None:
+    older = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+    newer = datetime(2026, 5, 24, 10, 36, 50, tzinfo=timezone.utc)
+    db = _build_test_db(
+        tmp_path,
+        tables={
+            "repos": [
+                {"id": 1, "ingested_at": older},
+                {"id": 2, "ingested_at": newer},
+            ],
+        },
+        timestamp_column="ingested_at",
+    )
+    conn = duckdb.connect(str(db))
+    try:
+        stats = collect_index_stats("github", conn)
+    finally:
+        conn.close()
+    assert stats.count == 2
+    assert stats.last_updated == newer
+
+
+def test_collect_index_stats_empty_catalog(tmp_path: Path) -> None:
+    db = _build_test_db(tmp_path, tables={"repos": []}, timestamp_column="ingested_at")
+    conn = duckdb.connect(str(db))
+    try:
+        stats = collect_index_stats("github", conn)
+    finally:
+        conn.close()
+    assert stats.count == 0
+    assert stats.by_table == {"repos": 0}
+    assert stats.last_updated is None
+
+
+# ----------------------------------------------------------------------------
+# fetch_store_for_stats — provider dispatch
+# ----------------------------------------------------------------------------
+
+
+def test_fetch_store_unknown_provider_raises():
+    with pytest.raises(UnknownIndexProviderError):
+        fetch_store_for_stats("doesnotexist", app_state=object())
+
+
+# ----------------------------------------------------------------------------
+# GET /v2/indices/{provider}/stats — end-to-end through the router
+# ----------------------------------------------------------------------------
+
+
+def test_stats_endpoint_returns_counts_for_github(tmp_path: Path) -> None:
+    db = _build_test_db(
+        tmp_path,
+        tables={
+            "repos": [
+                {"id": 1, "ingested_at": datetime(2026, 5, 13, tzinfo=timezone.utc)},
+                {"id": 2, "ingested_at": datetime(2026, 5, 24, tzinfo=timezone.utc)},
+            ],
+        },
+        timestamp_column="ingested_at",
+    )
+    app = _build_test_app()
+    # github resources tuple is (config, store, client) — only the store
+    # is read by the stats path, so the other slots can be plain Nones.
+    app.state.v2_github_resources = (None, _FakeStore(db), None)
+
+    status_code, body = _get(app, "/v2/indices/github/stats")
+
+    assert status_code == HTTP_OK
+    parsed = IndexStatsResponse.model_validate(body)
+    assert parsed.provider == "github"
+    assert parsed.count == 2
+    assert parsed.by_table == {"repos": 2}
+    assert parsed.last_updated == datetime(2026, 5, 24, tzinfo=timezone.utc)
+
+
+def test_stats_endpoint_503_when_resources_unavailable(monkeypatch) -> None:
+    app = _build_test_app()
+    # Force the resources getter to return None so we deterministically hit
+    # the "unavailable" branch, regardless of whether a YAML/Qdrant happens
+    # to be reachable in the test environment. The handler imports the name
+    # into src.v2.api's namespace, so we patch it there.
+    from src.v2 import api as v2_api
+
+    monkeypatch.setattr(
+        v2_api,
+        "fetch_store_for_stats",
+        lambda provider, app_state: None,
+    )
+
+    status_code, body = _get(app, "/v2/indices/huggingface/stats")
+
+    assert status_code == HTTP_SERVICE_UNAVAILABLE
+    assert "unavailable" in body["detail"]
+
+
+def test_stats_endpoint_404_for_unknown_provider() -> None:
+    app = _build_test_app()
+
+    status_code, body = _get(app, "/v2/indices/totally-fake/stats")
+
+    assert status_code == HTTP_NOT_FOUND
+    assert "unknown index provider" in body["detail"]


### PR DESCRIPTION
Closes #52.

## Summary

External consumers (Open Pulse Hub's Overview charts, dashboards) used to poll each `.duckdb` file with `duckdb.connect(path, read_only=True)`. That fails the moment the GME holds a write connection (auto-ingest et al), because DuckDB's advisory lock is per-process — readers get `Could not set lock on file ... Conflicting lock is held in PID 0`. So in any deployment with `V2_GITHUB_RAG_AUTO_INGEST=true` the Overview's DuckDB chart has been permanently flat.

This endpoint runs the same numbers (row count + per-table breakdown + last_updated) on the GME's already-open connection, so the file lock is never contested. Response shape matches the issue spec exactly:

```json
{
  "provider": "github",
  "count": 7100,
  "last_updated": "2026-05-24T10:36:50Z",
  "by_table": {"repos": 7100}
}
```

## Approach

- `src/v2/indices/stats.py::collect_index_stats` is schema-agnostic: it walks `information_schema.tables`, runs `SELECT COUNT(*)` on each, and picks the max value across common timestamp columns (`updated_at`, `ingested_at`, `fetched_at`, `updated`, `pushed_at`, `created_at`) for `last_updated`. Adding a new table inside a provider's DuckDB needs zero code here.
- `fetch_store_for_stats` dispatches to each provider's existing `get_or_create_<provider>_resources` helper, so we share the writer's open connection. ETHZ has no long-lived store on `app_state`, so we open one on demand.
- One FastAPI handler at `GET /v2/indices/{provider}/stats`, tagged `Indices`, guarded by the same `verify_token` dep as the rest of the index routes.

## Errors

- `404 unknown index provider` when `{provider}` isn't in `INDEX_STATS_SUPPORTED_PROVIDERS` (the same 9 the existing `/ingest` + `/search` routes accept).
- `503 ... index resources unavailable` when the per-provider resources getter returns None (config missing, optional module not installed, etc.).
- `503 stats query failed: ...` on any unexpected DuckDB error (logged at exception level so the operator sees the traceback).

## Test plan

- [x] 7 new tests in `tests/v2/test_indices_stats_endpoint.py`:
  - `collect_index_stats` sums across tables, picks max timestamp, handles empty catalogs.
  - `fetch_store_for_stats` raises `UnknownIndexProviderError` for unknown names.
  - End-to-end through the ASGI transport: 200 for a pre-seeded GitHub store, 503 when resources unavailable, 404 for unknown provider names.
- [x] `pytest tests/v2/ -n 4 --dist=loadfile -m 'not live_provider and not llm_integration'` → 773 passed (766 + 7 new).

## Acceptance criteria (from #52)

- [x] `GET /v2/indices/{provider}/stats` returns provider/count/last_updated/by_table.
- [x] All providers in `/v2/indices/{provider}/{ingest,search}` are accepted.
- [x] No cross-process lock contention — the GME serves the read from its own connection.