### PR TITLE
fix(v1 endpoints): reject non-github URLs at the boundary (closes #11, #12)

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -42,6 +42,9 @@ def _resolve_package_version(name: str) -> str:
     except PackageNotFoundError:
         return "unknown"
 
+
+from urllib.parse import urlparse
+
 from fastapi import (
     Depends,
     FastAPI,
@@ -73,6 +76,41 @@ setup_logging(level=log_level, use_colors=True)
 
 
 logger = logging.getLogger(__name__)
+
+
+_GITHUB_HOSTS = frozenset({"github.com", "www.github.com"})
+
+
+def _assert_github_host(full_path: str) -> None:
+    """Raise 422 if `full_path` is not a github.com URL/path.
+
+    The v1 user/org/repository routes wrap atomic-agent pipelines that are
+    hard-wired to GitHub's REST + GraphQL schemas: the agent prompts emit
+    `pulse:githubRepositoryHandle` literals, image URLs are absolutised
+    against the GitHub raw-content host, and `Repository.run_atomic_llm_pipeline`
+    eventually calls `parsers/github_*`. Feeding a `gitlab.epfl.ch` URL into
+    that path produces hallucinated `github.com/unknown/<repo>` outputs
+    instead of clean data (issues #11, #12).
+
+    GitLab support proper is tracked in #54. Until that lands, fail closed
+    here so the caller gets a clear 422 instead of garbage downstream.
+    """
+    candidate = (full_path or "").strip()
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    host = (urlparse(candidate).hostname or "").lower()
+    if host in _GITHUB_HOSTS:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail=(
+            f"v1 endpoints only accept github.com URLs (got host '{host or full_path}'). "
+            "GitLab / self-hosted-Git providers are tracked in issue #54; until then "
+            "the LLM pipeline would emit hallucinated github.com identifiers (#11/#12). "
+            "Use the v2 `/v2/extract` endpoint, which returns the same 422 from its "
+            "URL classifier so the caller can branch cleanly."
+        ),
+    )
 
 
 async def startup_event(app: FastAPI | None = None):
@@ -806,6 +844,7 @@ async def get_org_json(
     - Organization Object with enriched metadata
     - Usage statistics (token counts, timing, status)
     """
+    _assert_github_host(full_path)
     org_name = full_path.split("/")[-1]
 
     # Ensure full_path is a valid URL
@@ -935,6 +974,7 @@ async def get_user_json(
     - User Object with enriched metadata (id field set to full GitHub profile URL)
     - Statistics (token usage, timing, and status)
     """
+    _assert_github_host(full_path)
     username = full_path.split("/")[-1]
 
     # Ensure full_path is a valid URL
@@ -1072,6 +1112,7 @@ async def gimie(
     - Statistics (timing and status)
     """
 
+    _assert_github_host(full_path)
     try:
         repository = Repository(full_path, force_refresh=force_refresh)
 
@@ -1274,6 +1315,7 @@ async def llm_jsonld(
     - Statistics (token usage, timing, and status)
     """
 
+    _assert_github_host(full_path)
     repository = Repository(full_path, force_refresh=force_refresh)
 
     await repository.run_analysis(
@@ -1442,6 +1484,7 @@ async def llm_json(
     - Repository Object with enriched metadata
     """
 
+    _assert_github_host(full_path)
     repository = Repository(full_path, force_refresh=force_refresh)
 
     await repository.run_analysis(

--- a/tests/v1/test_v1_endpoint_github_host_guard.py
+++ b/tests/v1/test_v1_endpoint_github_host_guard.py
@@ -1,0 +1,71 @@
+"""v1 endpoints must reject non-github URLs before invoking the LLM pipeline.
+
+Issue #11 / #12: the atomic-agent pipeline behind every v1 user/org/repo
+route hard-wires GitHub's REST + GraphQL schemas, so feeding a
+`gitlab.epfl.ch` URL through them produces hallucinated
+`github.com/unknown/<repo>` outputs (images, README links, executable
+instructions). GitLab support proper is tracked in #54; until that lands
+the guard in `src.api._assert_github_host` short-circuits the request
+with a clear 422.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from src.api import _assert_github_host
+
+
+GITHUB_INPUTS = [
+    "https://github.com/sdsc-ordes/gimie",
+    "http://github.com/sdsc-ordes/gimie",
+    "github.com/sdsc-ordes/gimie",
+    "https://www.github.com/sdsc-ordes/gimie",
+    "https://github.com/octocat",
+    "https://github.com/orgs/Imaging-Plaza",
+]
+
+NON_GITHUB_INPUTS = [
+    "https://gitlab.epfl.ch/lasa/FlowMRI-Net",
+    "https://gitlab.ethz.ch/foo/bar",
+    "https://gitlab.renkulab.io/some/project",
+    "https://gitlab.com/group/project",
+    "https://bitbucket.org/team/repo",
+    "https://example.com/owner/repo",
+    "gitlab.epfl.ch/lasa/FlowMRI-Net",  # no scheme — still rejected
+]
+
+
+@pytest.mark.parametrize("url", GITHUB_INPUTS)
+def test_assert_github_host_accepts_github_inputs(url: str) -> None:
+    """All accepted shapes — with/without scheme, with/without `www`."""
+    # Must not raise.
+    _assert_github_host(url)
+
+
+@pytest.mark.parametrize("url", NON_GITHUB_INPUTS)
+def test_assert_github_host_rejects_non_github_inputs(url: str) -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        _assert_github_host(url)
+    err = excinfo.value
+    assert err.status_code == 422
+    # The detail must surface the host (or the raw input as a fallback) so
+    # the caller can see *what* was rejected, plus point at the right
+    # follow-up issue.
+    assert "v1 endpoints only accept github.com" in err.detail
+    assert "#54" in err.detail
+
+
+def test_assert_github_host_rejects_empty_input() -> None:
+    """Empty / whitespace-only paths produce a 422 instead of TypeError."""
+    with pytest.raises(HTTPException) as excinfo:
+        _assert_github_host("")
+    assert excinfo.value.status_code == 422
+
+
+def test_assert_github_host_detail_mentions_v2_alternative() -> None:
+    """Operators should know v2 already gives a clean 422 — point them there."""
+    with pytest.raises(HTTPException) as excinfo:
+        _assert_github_host("https://gitlab.epfl.ch/lasa/FlowMRI-Net")
+    assert "/v2/extract" in excinfo.value.detail


### PR DESCRIPTION
Closes #11, closes #12.

## Why

The atomic-agent pipelines wired into every v1 user / org / repository route are hard-coded to GitHub's REST + GraphQL schemas — agent prompts emit `pulse:githubRepositoryHandle` literals, README image URLs get absolutised against the GitHub raw-content host, and `Repository.run_atomic_llm_pipeline` calls into `parsers/github_*` for contributors and metadata. Pass a `gitlab.epfl.ch` URL through that path and the LLM hallucinates `github.com/unknown/<repo>` for images and README links instead of producing clean data:

```
❌ 2 invalid URLs in image: [{'contentUrl':
   'https://github.com/unknown/FlowMRI-Net/blob/main/gifs/aorta.gif', …}]
⚠️ Unreachable URL: https://github.com/unknown/FlowMRI-Net
```

The v2 `/v2/extract` route already does the right thing — its URL classifier returns 422 UNSUPPORTED_URL for non-github inputs. This PR teaches the v1 routes the same trick.

## Approach

- `src.api._assert_github_host(full_path)` — small helper that raises `HTTPException(422, …)` for any host outside `{github.com, www.github.com}`. Detail message names the rejected host, points at #54 for GitLab support, and suggests `/v2/extract` as the route that already returns the same 422.
- Applied at the top of the five v1 endpoints that accept a `full_path:path` argument: `/v1/org/llm/json`, `/v1/user/llm/json`, `/v1/repository/gimie/json-ld`, `/v1/repository/llm/json-ld`, `/v1/repository/llm/json`.

## Test plan

- [x] `pytest tests/v1/test_v1_endpoint_github_host_guard.py` — 15 unit tests on the helper: every accepted shape (with/without scheme, with/without `www`) and every rejected family (`gitlab.com`, `gitlab.epfl.ch`, `gitlab.ethz.ch`, `gitlab.renkulab.io`, `bitbucket.org`, generic). Also asserts the detail surfaces `#54` and `/v2/extract` so the caller knows where to go next.
- [x] Full `tests/v1/ tests/v2/` suite: 804 passed. (The single pre-existing failure in `tests/v1/test_gimie_empty_github_repo.py` is unrelated and is being fixed by #59.)

## Out of scope

- Full GitLab provider support — `RealGitLabProvider`, URL-based dispatch, per-instance `PRIVATE-TOKEN` env vars (#54). Until that lands the right behaviour is to fail closed with a clear message, not to half-process the URL.
- v1 LLM prompt rewrites to be host-aware — not worth doing if v1 is staying GitHub-only and v2 is the real future home.