### PR TITLE
chore(index): drop dead chunks DuckDB table + delete orphan Qdrant collections

### DIFF
--- a/src/index/ethz_research_collection/storage/schema.sql
+++ b/src/index/ethz_research_collection/storage/schema.sql
@@ -2,6 +2,14 @@
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 -- Mirrors the openalex / huggingface sister-index pattern.
 
+-- One-shot cleanup of the dead `chunks` table: chunks live exclusively
+-- in Qdrant (`ethz_research_collection_chunks` collection) and the
+-- DuckDB table never received any rows. Bootstrap now drops it on
+-- every run so existing on-disk DBs converge to the new shape; new
+-- DBs see it as a no-op.
+DROP INDEX IF EXISTS idx_chunks_entity;
+DROP TABLE IF EXISTS chunks;
+
 CREATE TABLE IF NOT EXISTS articles (
     article_uuid       TEXT PRIMARY KEY,
     title              TEXT,
@@ -68,21 +76,6 @@ CREATE TABLE IF NOT EXISTS article_links (
     PRIMARY KEY (article_uuid, host_label, url, source)
 );
 
--- chunk_id is deterministic: uuid5(NAMESPACE_URL, "<entity_type>|<entity_id>|<index>")
--- so the primary key alone provides the (entity_type, entity_id, chunk_index)
--- uniqueness guarantee. See `embed/pipeline.py:_chunk_id` for the canonical helper
--- (or build/store.py if it lives there for infoscience).
-CREATE TABLE IF NOT EXISTS chunks (
-    chunk_id        TEXT PRIMARY KEY,
-    entity_type     TEXT NOT NULL,
-    entity_id       TEXT NOT NULL,
-    chunk_index     INTEGER NOT NULL,
-    text            TEXT NOT NULL,
-    token_count     INTEGER NOT NULL,
-    vector_id       TEXT NOT NULL,
-    embedded_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
 CREATE INDEX IF NOT EXISTS idx_articles_year      ON articles (publication_year);
 CREATE INDEX IF NOT EXISTS idx_articles_doi       ON articles (doi);
 CREATE INDEX IF NOT EXISTS idx_persons_orcid      ON persons (orcid);
@@ -91,4 +84,3 @@ CREATE INDEX IF NOT EXISTS idx_orgs_ror           ON organizations (ror_id);
 CREATE INDEX IF NOT EXISTS idx_orgs_parent        ON organizations (parent_org_uuid);
 CREATE INDEX IF NOT EXISTS idx_article_links_host ON article_links (host_label);
 CREATE INDEX IF NOT EXISTS idx_article_links_url  ON article_links (url);
-CREATE INDEX IF NOT EXISTS idx_chunks_entity      ON chunks (entity_type, entity_id);

--- a/src/index/infoscience/storage/schema.sql
+++ b/src/index/infoscience/storage/schema.sql
@@ -2,6 +2,14 @@
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 -- Mirrors the openalex / huggingface sister-index pattern.
 
+-- One-shot cleanup of the dead `chunks` table: chunks live exclusively
+-- in Qdrant (`infoscience_chunks` collection) and the DuckDB table
+-- never received any rows. Bootstrap now drops it on every run so
+-- existing on-disk DBs converge to the new shape; new DBs see it as
+-- a no-op.
+DROP INDEX IF EXISTS idx_chunks_entity;
+DROP TABLE IF EXISTS chunks;
+
 CREATE TABLE IF NOT EXISTS articles (
     article_uuid       TEXT PRIMARY KEY,
     title              TEXT,
@@ -85,21 +93,6 @@ CREATE TABLE IF NOT EXISTS article_links (
     PRIMARY KEY (article_uuid, host_label, url, source)
 );
 
--- chunk_id is deterministic: uuid5(NAMESPACE_URL, "<entity_type>|<entity_id>|<index>")
--- so the primary key alone provides the (entity_type, entity_id, chunk_index)
--- uniqueness guarantee. See `embed/pipeline.py:_chunk_id` for the canonical helper
--- (or build/store.py if it lives there for infoscience).
-CREATE TABLE IF NOT EXISTS chunks (
-    chunk_id        TEXT PRIMARY KEY,
-    entity_type     TEXT NOT NULL,
-    entity_id       TEXT NOT NULL,
-    chunk_index     INTEGER NOT NULL,
-    text            TEXT NOT NULL,
-    token_count     INTEGER NOT NULL,
-    vector_id       TEXT NOT NULL,
-    embedded_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
 CREATE INDEX IF NOT EXISTS idx_articles_year      ON articles (publication_year);
 CREATE INDEX IF NOT EXISTS idx_articles_doi       ON articles (doi);
 CREATE INDEX IF NOT EXISTS idx_persons_orcid      ON persons (orcid);
@@ -108,4 +101,3 @@ CREATE INDEX IF NOT EXISTS idx_orgs_ror           ON organizations (ror_id);
 CREATE INDEX IF NOT EXISTS idx_orgs_parent        ON organizations (parent_org_uuid);
 CREATE INDEX IF NOT EXISTS idx_article_links_host ON article_links (host_label);
 CREATE INDEX IF NOT EXISTS idx_article_links_url  ON article_links (url);
-CREATE INDEX IF NOT EXISTS idx_chunks_entity      ON chunks (entity_type, entity_id);


### PR DESCRIPTION
Two cleanups surfaced by cross-checking DuckDB tables against Qdrant collection sizes.

## 1. Dead `chunks` DuckDB table — dropped

`src/index/infoscience` and `src/index/ethz_research_collection` both declared a `chunks` table + `idx_chunks_entity` index in their schema, but `upsert_chunks(...)` in their `store.py` writes only to Qdrant (`infoscience_chunks` and `ethz_research_collection_chunks` collections). The DuckDB table received zero rows in production and only added schema noise:

- It inflated `information_schema.tables` for the new `/v2/indices/{provider}/stats` endpoint (PR #61) — `_meta.json` would report a `chunks: 0` row that means nothing.
- It confused anyone reading the schema for the first time.

**Fix.** Each `schema.sql` now leads with `DROP INDEX IF EXISTS …; DROP TABLE IF EXISTS chunks;` so bootstrap drops the legacy table on every run. Fresh DBs never create it. The two live DuckDBs in `data/index/{infoscience,ethz-research-collection}/duckdb/` were already converged by running the new schema once locally.

## 2. Orphan `spinoff_pliegos` + `spinoff_tenders` Qdrant collections — deleted

78,232 + 7,220 points across two Qdrant collections with **zero references anywhere in the repo** (`git grep -i spinoff` is empty across py/yaml/md/json/sh/just). No matching DuckDB. No CLI module. Leftovers from a deleted project.

Removed via `curl -X DELETE http://gme-qdrant:6333/collections/{spinoff_pliegos,spinoff_tenders}` on the deployment Qdrant. Confirmed gone via `GET /collections` post-delete.

## Verification

- Bootstrap smoke:
  - Fresh DB with new schema: no `chunks` table (correct).
  - Legacy DB pre-seeded with `CREATE TABLE chunks` + a row, then re-bootstrapped with the new schema: `chunks` table is gone.
- `pytest tests/v2/ tests/v1/ tests/index/` — 1,016 passed. The 2 failures are pre-existing on develop and unrelated:
  - `tests/index/openalex/test_config.py::test_defaults_from_yaml` reads the live `INDEX_QDRANT_URL` from `.devcontainer/.env` (env-leak, not behaviour drift).
  - `tests/v1/test_gimie_empty_github_repo.py` — fixed by the open #59 PR.

## No production code changed

`upsert_chunks(...)` already wrote only to Qdrant; no code path read `SELECT FROM chunks`; no schema migrations referenced the column. Pure schema cleanup.