### PR TITLE
feat(v2 indices): stats + search + compact coverage for CLI-managed catalogs

### DIFF
--- a/justfile
+++ b/justfile
@@ -218,6 +218,25 @@ cache-disable:
     curl -X POST -H "Authorization: Bearer ${API_TOKEN}" http://localhost:{{PORT}}/v1/cache/disable | python -m json.tool
 
 # ============================================================================
+# Index Maintenance
+# ============================================================================
+
+# Compact every `data/index/*/duckdb/*.duckdb` via EXPORT/IMPORT round-trip.
+# Run with the server stopped — DuckDB's file lock is per-process and the
+# helper opens each file directly. Reclaims tombstoned space accumulated
+# by upsert churn (openalex.duckdb sits at ~3.7 GB in current deployments).
+# For an online single-provider variant, use POST /v2/indices/<provider>/compact.
+compact-indexes:
+    python -m src.v2.indices.compact
+
+# Compact a single provider's DuckDB online (server must be running).
+# Example: `just compact-index openalex`. See `compact-indexes` for the
+# offline counterpart that hits every catalog at once.
+compact-index PROVIDER:
+    curl -X POST -H "Authorization: Bearer ${API_TOKEN}" \
+        http://localhost:{{PORT}}/v2/indices/{{PROVIDER}}/compact | python -m json.tool
+
+# ============================================================================
 # Development Utilities
 # ============================================================================
 

--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -68,6 +68,17 @@ from src.v2.indices.oamonitor import (
 )
 from src.v2.indices.openalex import run_openalex_ingest_job, run_openalex_search
 from src.v2.indices.orcid import run_orcid_ingest_job, run_orcid_search
+from src.v2.indices.cli_catalogs import (
+    run_epfl_graph_search,
+    run_infoscience_search,
+    run_ror_search,
+    run_snsf_search,
+)
+from src.v2.indices.compact import (
+    CompactResult,
+    close_cached_resources_for,
+    compact_duckdb,
+)
 from src.v2.indices.renkulab import run_renkulab_ingest_job, run_renkulab_search
 from src.v2.indices.stats import (
     IndexStatsResponse,
@@ -2369,6 +2380,157 @@ async def oamonitor_search_post(
         await run_oamonitor_search(payload, request.app.state),
         index_name="oamonitor",
     )
+
+
+# --- /v2/indices/<name>/search for the CLI-managed catalogs ---------------
+# These catalogs are populated by `python -m src.index.<name>` from cron
+# (no v2 ingest route) but have populated Qdrant collections. The thin
+# shims in `src.v2.indices.cli_catalogs` translate `IndexSearchRequest`
+# to each catalog's existing query function.
+
+
+@v2_router.post(
+    "/indices/ror/search",
+    response_model=IndexSearchResponse,
+    response_model_exclude_none=True,
+    tags=["Indices"],
+)
+async def ror_search_post(
+    payload: IndexSearchRequest,
+    request: Request,
+    _token: Annotated[str, Depends(verify_token)],
+) -> IndexSearchResponse | JSONResponse:
+    """Semantic search against the ROR organisation index (125k+ orgs)."""
+    return await _search_response_or_unavailable(
+        await run_ror_search(payload, request.app.state),
+        index_name="ror",
+    )
+
+
+@v2_router.post(
+    "/indices/infoscience/search",
+    response_model=IndexSearchResponse,
+    response_model_exclude_none=True,
+    tags=["Indices"],
+)
+async def infoscience_search_post(
+    payload: IndexSearchRequest,
+    request: Request,
+    _token: Annotated[str, Depends(verify_token)],
+) -> IndexSearchResponse | JSONResponse:
+    """Semantic search against the Infoscience publications index.
+
+    Use ``target`` to pick the collection: ``chunks`` (default),
+    ``articles``, ``persons``, ``organizations``.
+    """
+    return await _search_response_or_unavailable(
+        await run_infoscience_search(payload, request.app.state),
+        index_name="infoscience",
+    )
+
+
+@v2_router.post(
+    "/indices/snsf/search",
+    response_model=IndexSearchResponse,
+    response_model_exclude_none=True,
+    tags=["Indices"],
+)
+async def snsf_search_post(
+    payload: IndexSearchRequest,
+    request: Request,
+    _token: Annotated[str, Depends(verify_token)],
+) -> IndexSearchResponse | JSONResponse:
+    """Semantic search against the SNSF grants index."""
+    return await _search_response_or_unavailable(
+        await run_snsf_search(payload, request.app.state),
+        index_name="snsf",
+    )
+
+
+@v2_router.post(
+    "/indices/epfl_graph/search",
+    response_model=IndexSearchResponse,
+    response_model_exclude_none=True,
+    tags=["Indices"],
+)
+async def epfl_graph_search_post(
+    payload: IndexSearchRequest,
+    request: Request,
+    _token: Annotated[str, Depends(verify_token)],
+) -> IndexSearchResponse | JSONResponse:
+    """Semantic search against the EPFL Graph disciplines ontology."""
+    return await _search_response_or_unavailable(
+        await run_epfl_graph_search(payload, request.app.state),
+        index_name="epfl_graph",
+    )
+
+
+# --- /v2/indices/<name>/compact -------------------------------------------
+# Operator endpoint: EXPORT/IMPORT round-trip the per-provider DuckDB
+# file to reclaim space tombstoned by upsert churn. Mirrors what
+# `just compact-indexes` does offline, but online and per-provider.
+
+
+@v2_router.post(
+    "/indices/{provider}/compact",
+    response_model=CompactResult,
+    response_model_exclude_none=True,
+    tags=["Indices"],
+)
+async def index_compact_post(
+    provider: Annotated[str, Path(description="One of the supported index providers.")],
+    request: Request,
+    _token: Annotated[str, Depends(verify_token)],
+) -> CompactResult | JSONResponse:
+    """Run an EXPORT/IMPORT round-trip on `provider`'s DuckDB.
+
+    Closes the in-process Store cached on `app.state` so the file lock
+    is released, then opens a fresh connection, exports every table to
+    a sibling tempdir, swaps the DuckDB atomically with a `.bak`
+    fallback, and reports `bytes_before` / `bytes_after`. The next
+    stats / search call lazily re-opens.
+
+    This is a maintenance operation — call when the server is quiet.
+    `openalex` (3.7 GB) can take a couple of minutes.
+    """
+    try:
+        store = fetch_store_for_stats(provider, request.app.state)
+    except UnknownIndexProviderError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": str(exc)},
+        )
+    if store is None:
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={
+                "detail": f"{provider} index resources unavailable on this deployment",
+            },
+        )
+    db_path = getattr(store, "db_path", None)
+    if db_path is None:
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={
+                "detail": f"{provider} Store does not expose `db_path`; compact unsupported",
+            },
+        )
+    # Close any in-process write handle so EXPORT can re-open the file.
+    close_cached_resources_for(provider, request.app.state)
+    try:
+        result = await asyncio.to_thread(compact_duckdb, provider, db_path)
+    except FileNotFoundError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": str(exc)},
+        )
+    except Exception as exc:  # noqa: BLE001 — surface as 500 with the message
+        logger.exception("index compact failed: provider=%s", provider)
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"detail": f"compact failed: {exc}"},
+        )
+    return result
 
 
 @v2_router.get(

--- a/src/v2/api_models/contracts.py
+++ b/src/v2/api_models/contracts.py
@@ -348,6 +348,14 @@ IndexName = Literal[
     "swissubase",
     "ethz_research_collection",
     "oamonitor",
+    # CLI-managed catalogs — search routes added in the stats/search
+    # coverage extension PR. No v2 ingest route (ingest happens via
+    # `python -m src.index.<name> ingest`).
+    "ror",
+    "infoscience",
+    "snsf",
+    "epfl_graph",
+    "communities",
 ]
 
 

--- a/src/v2/indices/cli_catalogs.py
+++ b/src/v2/indices/cli_catalogs.py
@@ -1,0 +1,221 @@
+"""`POST /v2/indices/{provider}/search` shims for the CLI-managed catalogs.
+
+The 9 mature v2 catalogs each ship their own `src/v2/indices/<name>.py`
+with `run_<name>_search` + `run_<name>_ingest_job` + a tuple cached on
+`app_state.v2_<name>_resources`. The 5 CLI-only catalogs (ror,
+infoscience, snsf, epfl_graph, communities) don't have that surface
+because they're driven by `python -m src.index.<name> …` from cron, not
+by per-record v2 ingest calls.
+
+This module fills in the gap with minimal-viable `run_<name>_search`
+adapters: they translate `IndexSearchRequest` → the catalog's
+existing CLI-level query function, then wrap the result in
+`IndexSearchResponse`. The extra catalog-specific filters (ROR
+country, SNSF discipline_l1, …) are NOT exposed; callers that need
+them keep using the CLI. The intent here is to give the open-pulse
+Hub a uniform `/v2/indices/{provider}/search` for every catalog
+whose Qdrant collection already exists.
+
+`communities` is intentionally absent — it has no semantic search
+infrastructure (DuckDB-only registry, no embeddings, no Qdrant
+collection). Adding it would mean building a search path from
+scratch, which belongs in a separate PR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from src.v2.api_models import IndexSearchRequest, IndexSearchResponse
+from src.v2.indices._search_common import hit_from_raw
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _hits_from_records(records: Iterable[Any]) -> list[Any]:
+    """Coerce per-catalog scored-record types into `IndexSearchHit`s.
+
+    The four `query_rag` / `semantic_search` functions return slightly
+    different result types — pydantic models, dataclasses, plain dicts.
+    Normalise to a flat dict shape that `hit_from_raw` understands.
+    """
+    out: list[Any] = []
+    for record in records:
+        if isinstance(record, dict):
+            raw = record
+        elif hasattr(record, "model_dump"):
+            raw = record.model_dump()
+        elif hasattr(record, "__dataclass_fields__"):
+            from dataclasses import asdict  # noqa: PLC0415
+
+            raw = asdict(record)
+        else:
+            raw = {"id": str(record)}
+        if "id" not in raw and "ror_id" in raw:
+            raw["id"] = raw["ror_id"]
+        out.append(hit_from_raw(raw))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# ROR — `query_rag(cfg, text, *, top_k, rerank_top_k, country)`
+# ---------------------------------------------------------------------------
+
+
+async def run_ror_search(
+    payload: IndexSearchRequest, app_state: Any,
+) -> IndexSearchResponse | None:
+    del app_state
+    try:
+        from src.index.ror.config import load_config as load_ror_config  # noqa: PLC0415
+        from src.index.ror.query import query_rag  # noqa: PLC0415
+    except Exception as exc:  # noqa: BLE001 — optional dependency
+        LOGGER.warning("ror search: module unavailable — %s", exc)
+        return None
+    try:
+        cfg = load_ror_config()
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("ror search: config init failed — %s", exc)
+        return None
+    records = await query_rag(cfg, payload.query, top_k=payload.top_k)
+    return IndexSearchResponse(
+        index_name="ror",
+        target=payload.target,
+        query=payload.query,
+        hits=_hits_from_records(records),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SNSF — `query_rag(cfg, text, *, top_k, rerank_top_k, …filters)`
+# ---------------------------------------------------------------------------
+
+
+async def run_snsf_search(
+    payload: IndexSearchRequest, app_state: Any,
+) -> IndexSearchResponse | None:
+    del app_state
+    try:
+        from src.index.snsf.config import load_config as load_snsf_config  # noqa: PLC0415
+        from src.index.snsf.query import query_rag  # noqa: PLC0415
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("snsf search: module unavailable — %s", exc)
+        return None
+    try:
+        cfg = load_snsf_config()
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("snsf search: config init failed — %s", exc)
+        return None
+    records = await query_rag(cfg, payload.query, top_k=payload.top_k)
+    return IndexSearchResponse(
+        index_name="snsf",
+        target=payload.target,
+        query=payload.query,
+        hits=_hits_from_records(records),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Infoscience — `pipeline.query(cfg, text, *, target, top_k, top_n, mode)`
+# ---------------------------------------------------------------------------
+
+
+async def run_infoscience_search(
+    payload: IndexSearchRequest, app_state: Any,
+) -> IndexSearchResponse | None:
+    del app_state
+    try:
+        from src.index.infoscience.config import (  # noqa: PLC0415
+            load_config as load_infoscience_config,
+        )
+        from src.index.infoscience.pipeline import query as infoscience_query  # noqa: PLC0415
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("infoscience search: module unavailable — %s", exc)
+        return None
+    try:
+        cfg = load_infoscience_config()
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("infoscience search: config init failed — %s", exc)
+        return None
+    target = payload.target or "chunks"
+    try:
+        result = await infoscience_query(
+            cfg, payload.query, target=target, top_n=payload.top_k,
+        )
+    except ValueError as exc:
+        # Bad `target`, missing collection — surface as a hits=[] result.
+        LOGGER.warning("infoscience search: %s", exc)
+        return IndexSearchResponse(
+            index_name="infoscience",
+            target=target,
+            query=payload.query,
+            hits=[],
+            extra={"error": str(exc)},
+        )
+    records: Iterable[Any]
+    if hasattr(result, "results"):
+        records = result.results
+    elif hasattr(result, "hits"):
+        records = result.hits
+    elif isinstance(result, (list, tuple)):
+        records = result
+    else:
+        records = [result]
+    return IndexSearchResponse(
+        index_name="infoscience",
+        target=target,
+        query=payload.query,
+        hits=_hits_from_records(records),
+    )
+
+
+# ---------------------------------------------------------------------------
+# EPFL Graph disciplines — sync `semantic_search(*, config, query, top_k, …)`
+# ---------------------------------------------------------------------------
+
+
+async def run_epfl_graph_search(
+    payload: IndexSearchRequest, app_state: Any,
+) -> IndexSearchResponse | None:
+    del app_state
+    try:
+        from src.index.epfl_graph.config import (  # noqa: PLC0415
+            load_config as load_epfl_graph_config,
+        )
+        from src.index.epfl_graph.retrieval.semantic import (  # noqa: PLC0415
+            semantic_search,
+        )
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("epfl_graph search: module unavailable — %s", exc)
+        return None
+    try:
+        cfg = load_epfl_graph_config()
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("epfl_graph search: config init failed — %s", exc)
+        return None
+    candidate_k = payload.candidate_k or max(payload.top_k * 5, 50)
+    records = await asyncio.to_thread(
+        semantic_search,
+        config=cfg, query=payload.query,
+        top_k=payload.top_k,
+        candidate_k=candidate_k,
+    )
+    return IndexSearchResponse(
+        index_name="epfl_graph",
+        target=payload.target,
+        query=payload.query,
+        hits=_hits_from_records(records),
+    )
+
+
+__all__ = [
+    "run_epfl_graph_search",
+    "run_infoscience_search",
+    "run_ror_search",
+    "run_snsf_search",
+]

--- a/src/v2/indices/compact.py
+++ b/src/v2/indices/compact.py
@@ -1,0 +1,313 @@
+"""DuckDB compaction via `EXPORT DATABASE` + `IMPORT DATABASE` round-trip.
+
+DuckDB upserts accumulate tombstones; over the lifetime of an index
+catalog the file can grow well past the size of its live rows.
+`openalex.duckdb` ballooned to 3.7 GB in our deployment, `snsf.duckdb`
+to 1 GB. There is no `VACUUM` in DuckDB's SQL dialect; the supported
+idiom is to dump the whole catalog and re-import it into a fresh file.
+
+Two entry points share this helper:
+
+- `just compact-indexes` (the offline operator path): loops over every
+  catalog and calls `compact_duckdb(provider, path)` directly.
+- `POST /v2/indices/{provider}/compact` (the online operator path):
+  closes the in-process Store cached on `app_state`, runs the same
+  helper, then lets the next stats / search call re-open the file.
+
+The round-trip is crash-safe: we EXPORT to a tempdir first, then write
+the rebuilt DB to `<path>.compacting`, atomically rename the original
+to `<path>.bak`, swap in the compacted file, and only then delete the
+backup. If any step before the final rename fails, the original file
+is untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import duckdb
+from pydantic import BaseModel, Field
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CompactResult(BaseModel):
+    """API response for `POST /v2/indices/{provider}/compact`."""
+
+    provider: str
+    db_path: str
+    bytes_before: int = Field(..., ge=0)
+    bytes_after: int = Field(..., ge=0)
+    reclaimed_bytes: int = Field(..., description="Always `bytes_before - bytes_after`.")
+    compression_ratio: float = Field(
+        ...,
+        description="`bytes_after / bytes_before` — 1.0 means no gain, 0.5 means halved.",
+    )
+    table_count: int = Field(..., ge=0)
+    elapsed_seconds: float = Field(..., ge=0)
+
+
+@dataclass(slots=True)
+class _Internal:
+    """Just enough to break compaction into testable steps."""
+    db_path: Path
+    bytes_before: int
+    start_monotonic: float
+
+
+def _bytes(path: Path) -> int:
+    return path.stat().st_size if path.exists() else 0
+
+
+def compact_duckdb(provider: str, db_path: Path | str) -> CompactResult:
+    """EXPORT/IMPORT a DuckDB file in place, reclaiming tombstoned space.
+
+    Raises:
+        FileNotFoundError: when `db_path` does not exist.
+        RuntimeError: when EXPORT or IMPORT fail (the original file is
+            left untouched in either case).
+    """
+    db_path = Path(db_path)
+    if not db_path.exists():
+        msg = f"compact_duckdb: {db_path} does not exist"
+        raise FileNotFoundError(msg)
+    state = _Internal(
+        db_path=db_path,
+        bytes_before=_bytes(db_path),
+        start_monotonic=time.monotonic(),
+    )
+    parent = db_path.parent
+    tmp_db_path = db_path.with_name(db_path.name + ".compacting")
+    backup_path = db_path.with_name(db_path.name + ".bak")
+    table_count = 0
+
+    with tempfile.TemporaryDirectory(
+        prefix=f"compact-{provider}-", dir=str(parent),
+    ) as export_dir:
+        # 1. EXPORT from the live file
+        try:
+            conn = duckdb.connect(str(db_path))
+        except duckdb.IOException as exc:
+            msg = f"compact_duckdb: cannot open {db_path}: {exc}"
+            raise RuntimeError(msg) from exc
+        try:
+            table_count = int(conn.execute(
+                "SELECT COUNT(*) FROM information_schema.tables "
+                "WHERE table_schema='main' AND table_type='BASE TABLE'",
+            ).fetchone()[0])
+            conn.execute(f"EXPORT DATABASE '{export_dir}'")
+        except duckdb.Error as exc:
+            conn.close()
+            msg = f"compact_duckdb: EXPORT failed for {db_path}: {exc}"
+            raise RuntimeError(msg) from exc
+        conn.close()
+
+        # 2. IMPORT into a sibling file (atomic swap to come).
+        if tmp_db_path.exists():
+            tmp_db_path.unlink()
+        try:
+            new_conn = duckdb.connect(str(tmp_db_path))
+            new_conn.execute(f"IMPORT DATABASE '{export_dir}'")
+            new_conn.close()
+        except duckdb.Error as exc:
+            if tmp_db_path.exists():
+                tmp_db_path.unlink()
+            msg = f"compact_duckdb: IMPORT failed for {db_path}: {exc}"
+            raise RuntimeError(msg) from exc
+
+    # 3. Atomic swap. If we fall over here, the .bak file is the
+    #    original; the operator can move it back manually.
+    if backup_path.exists():
+        backup_path.unlink()
+    db_path.rename(backup_path)
+    try:
+        tmp_db_path.rename(db_path)
+    except OSError:
+        # Restore from backup before re-raising.
+        backup_path.rename(db_path)
+        raise
+
+    # 4. Drop the backup (success means we don't need it anymore).
+    backup_path.unlink()
+
+    bytes_after = _bytes(db_path)
+    elapsed = time.monotonic() - state.start_monotonic
+    ratio = (bytes_after / state.bytes_before) if state.bytes_before else 1.0
+    result = CompactResult(
+        provider=provider,
+        db_path=str(db_path),
+        bytes_before=state.bytes_before,
+        bytes_after=bytes_after,
+        reclaimed_bytes=state.bytes_before - bytes_after,
+        compression_ratio=ratio,
+        table_count=table_count,
+        elapsed_seconds=elapsed,
+    )
+    LOGGER.info(
+        "compacted %s: %d -> %d bytes (%.1f%% reclaimed) in %.2fs",
+        db_path, state.bytes_before, bytes_after,
+        (1 - ratio) * 100, elapsed,
+    )
+    return result
+
+
+def _close_cached_store(app_state: Any, attr: str) -> None:
+    store = getattr(app_state, attr, None)
+    if store is None:
+        return
+    close = getattr(store, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            LOGGER.warning("compact: failed to close cached %s: %s", attr, exc)
+    try:
+        setattr(app_state, attr, None)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("compact: failed to clear cached %s: %s", attr, exc)
+
+
+_RESOURCE_ATTRS_BY_PROVIDER: dict[str, tuple[str, ...]] = {
+    "github": ("v2_github_resources",),
+    "zenodo": ("v2_zenodo_resources",),
+    "huggingface": ("v2_huggingface_resources",),
+    "openalex": ("v2_openalex_resources",),
+    "orcid": ("v2_orcid_resources",),
+    "renkulab": ("v2_renkulab_resources",),
+    "swissubase": ("v2_swissubase_resources",),
+    "oamonitor": ("v2_oamonitor_resources",),
+    "ethz_research_collection": ("v2_ethz_research_collection_resources",),
+    "ror": ("v2_ror_store",),
+    "infoscience": ("v2_infoscience_store",),
+    "snsf": ("v2_snsf_store",),
+    "epfl_graph": ("v2_epfl_graph_store",),
+    "communities": ("v2_communities_store",),
+}
+
+
+def close_cached_resources_for(provider: str, app_state: Any) -> None:
+    """Drop the in-process write handle so EXPORT can re-open the file.
+
+    The per-provider `get_or_create_<provider>_resources` helpers cache
+    the Store on `app_state`. Closing it lets `compact_duckdb` open the
+    DuckDB without contesting the lock, and the next stats/search call
+    will lazily re-init.
+    """
+    for attr in _RESOURCE_ATTRS_BY_PROVIDER.get(provider, ()):
+        # Some providers cache a tuple (config, store, …) on a single attr.
+        cached = getattr(app_state, attr, None)
+        if cached is None:
+            continue
+        if isinstance(cached, tuple):
+            for item in cached:
+                close = getattr(item, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except Exception as exc:  # noqa: BLE001
+                        LOGGER.warning(
+                            "compact: failed to close item in %s: %s", attr, exc,
+                        )
+            try:
+                setattr(app_state, attr, None)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("compact: failed to clear %s: %s", attr, exc)
+        else:
+            _close_cached_store(app_state, attr)
+
+
+def compact_all_indexes(
+    data_root: Path | str | None = None, *, verbose: bool = True,
+) -> list[CompactResult]:
+    """Compact every `*.duckdb` under `<data_root>` (default: `data/index`).
+
+    The offline counterpart to `POST /v2/indices/{provider}/compact` — used
+    by `just compact-indexes` while the server is offline. Skips any file
+    whose name matches a `.bak` / `.compacting` sibling left over from a
+    prior interrupted run; those are the operator's call to resolve.
+    """
+    if data_root is None:
+        data_root = Path(__file__).resolve().parents[3] / "data" / "index"
+    data_root = Path(data_root)
+    if not data_root.exists():
+        msg = f"compact_all_indexes: {data_root} does not exist"
+        raise FileNotFoundError(msg)
+
+    results: list[CompactResult] = []
+    for db_path in sorted(data_root.rglob("*.duckdb")):
+        # Derive the provider name from the immediate parent dir
+        # (data/index/<provider>/duckdb/<name>.duckdb), falling back to
+        # the file stem if the layout is non-standard.
+        parts = db_path.relative_to(data_root).parts
+        provider = parts[0] if parts else db_path.stem
+        if verbose:
+            LOGGER.info("compacting %s …", db_path)
+        try:
+            result = compact_duckdb(provider, db_path)
+        except Exception as exc:  # noqa: BLE001 — keep going on partial failure
+            LOGGER.warning("compact %s: FAILED — %s", db_path, exc)
+            continue
+        results.append(result)
+        if verbose:
+            LOGGER.info(
+                "  %s: %.1f MB → %.1f MB (%.1f%% reclaimed) in %.2fs",
+                provider,
+                result.bytes_before / (1024 * 1024),
+                result.bytes_after / (1024 * 1024),
+                (1 - result.compression_ratio) * 100,
+                result.elapsed_seconds,
+            )
+    return results
+
+
+def _cli_main() -> int:
+    """Entry point for `python -m src.v2.indices.compact`."""
+    import argparse  # noqa: PLC0415
+    import json  # noqa: PLC0415
+
+    parser = argparse.ArgumentParser(
+        prog="python -m src.v2.indices.compact",
+        description=(
+            "Compact every DuckDB under data/index/ via EXPORT/IMPORT. "
+            "Used by `just compact-indexes`."
+        ),
+    )
+    parser.add_argument(
+        "--data-root", default=None,
+        help="Root directory to scan (default: <repo>/data/index).",
+    )
+    parser.add_argument(
+        "--quiet", action="store_true",
+        help="Suppress per-file progress logs.",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    )
+    results = compact_all_indexes(args.data_root, verbose=not args.quiet)
+    json.dump(
+        {
+            "compacted": [r.model_dump() for r in results],
+            "total_reclaimed_bytes": sum(r.reclaimed_bytes for r in results),
+        },
+        __import__("sys").stdout, indent=2, default=str,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI entry point
+    raise SystemExit(_cli_main())
+
+
+__all__ = [
+    "CompactResult",
+    "close_cached_resources_for",
+    "compact_all_indexes",
+    "compact_duckdb",
+]

--- a/src/v2/indices/stats.py
+++ b/src/v2/indices/stats.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     import duckdb
 
 INDEX_STATS_SUPPORTED_PROVIDERS: tuple[str, ...] = (
+    # Providers that already have a v2 ingest/search surface and a
+    # long-lived `get_or_create_<provider>_resources()` cache on `app_state`.
     "zenodo",
     "github",
     "huggingface",
@@ -35,6 +37,14 @@ INDEX_STATS_SUPPORTED_PROVIDERS: tuple[str, ...] = (
     "swissubase",
     "ethz_research_collection",
     "oamonitor",
+    # CLI-managed catalogs (no v2 ingest/search route). We open their
+    # DuckDB on demand and cache on `app_state.v2_<provider>_store` so
+    # subsequent stats polls reuse the open connection.
+    "ror",
+    "infoscience",
+    "snsf",
+    "epfl_graph",
+    "communities",
 )
 
 # Common "this row was last touched" column names, in priority order.
@@ -211,7 +221,95 @@ def fetch_store_for_stats(provider: str, app_state: Any) -> Any | None:
             return DuckDBStore.open()
         except Exception:  # noqa: BLE001 — config / disk issues
             return None
+
+    # CLI-managed catalogs: no v2 ingest/search route → no
+    # `get_or_create_*_resources` helper. Open once, cache on `app_state`.
+    if provider == "ror":
+        return _cli_store(
+            app_state, "v2_ror_store",
+            "src.index.ror.storage.duckdb_store", "DuckDBStore",
+        )
+    if provider == "infoscience":
+        return _cli_store(
+            app_state, "v2_infoscience_store",
+            "src.index.infoscience.storage.duckdb_store", "DuckDBStore",
+        )
+    if provider == "snsf":
+        return _cli_store(
+            app_state, "v2_snsf_store",
+            "src.index.snsf.storage.duckdb_store", "DuckDBStore",
+        )
+    if provider == "epfl_graph":
+        return _cli_store(
+            app_state, "v2_epfl_graph_store",
+            "src.index.epfl_graph.storage.duckdb_store", "EpflGraphStore",
+        )
+    if provider == "communities":
+        return _open_communities_store(app_state)
     return None
+
+
+def _cli_store(
+    app_state: Any, attr: str, module: str, class_name: str,
+) -> Any | None:
+    """Lazy-open a CLI-managed Store and cache it on `app_state.<attr>`."""
+    cached = getattr(app_state, attr, None)
+    if cached is not None:
+        return cached
+    try:
+        mod = __import__(module, fromlist=[class_name])
+        store_cls = getattr(mod, class_name)
+    except Exception:  # noqa: BLE001 — optional dependency missing
+        return None
+    try:
+        store = store_cls.open()
+    except Exception:  # noqa: BLE001 — config / disk error
+        return None
+    try:
+        setattr(app_state, attr, store)
+    except Exception:  # noqa: BLE001 — app_state may be frozen in tests
+        return store
+    return store
+
+
+def _open_communities_store(app_state: Any) -> Any | None:
+    """`CommunitiesStore` lacks `.connect()` (uses `_connect()` + `read_only()`),
+    so the stats endpoint can't call it directly. Wrap it in a tiny shim that
+    exposes a cached read-only handle as `.connect()`.
+    """
+    cached = getattr(app_state, "v2_communities_store", None)
+    if cached is not None:
+        return cached
+    try:
+        from src.index.communities.paths import duckdb_path  # noqa: PLC0415
+        import duckdb as _duckdb  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return None
+
+    class _CommunitiesStoreShim:
+        def __init__(self, path: Any) -> None:
+            self.db_path = path  # surfaced for compact_duckdb()
+            self._conn: Any = None
+
+        def connect(self) -> Any:
+            if self._conn is None:
+                self._conn = _duckdb.connect(str(self.db_path), read_only=True)
+            return self._conn
+
+        def close(self) -> None:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+
+    try:
+        shim = _CommunitiesStoreShim(duckdb_path())
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        setattr(app_state, "v2_communities_store", shim)
+    except Exception:  # noqa: BLE001
+        return shim
+    return shim
 
 
 __all__ = [

--- a/tests/v2/test_indices_compact.py
+++ b/tests/v2/test_indices_compact.py
@@ -1,0 +1,149 @@
+"""Tests for `src/v2/indices/compact.py` — DuckDB EXPORT/IMPORT round-trip."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from src.v2.indices.compact import (
+    CompactResult,
+    close_cached_resources_for,
+    compact_all_indexes,
+    compact_duckdb,
+)
+
+
+def _seed_duckdb(path: Path, *, rows: int = 100) -> None:
+    """Seed a DuckDB with one table + repeated upsert churn so there's
+    something for the EXPORT/IMPORT cycle to reclaim."""
+    conn = duckdb.connect(str(path))
+    conn.execute("CREATE TABLE widgets (id INTEGER PRIMARY KEY, payload TEXT)")
+    for _ in range(5):
+        # Repeated inserts + deletes accumulate tombstones DuckDB only
+        # reclaims via EXPORT/IMPORT round-trip.
+        conn.execute(
+            f"INSERT OR REPLACE INTO widgets VALUES "
+            f"{', '.join(f'({i}, repeat(chr(65 + ({i} % 26)), 4096))' for i in range(rows))}",
+        )
+        if rows > 50:
+            conn.execute(f"DELETE FROM widgets WHERE id >= {rows // 2}")
+            conn.execute(
+                f"INSERT INTO widgets VALUES "
+                f"{', '.join(f'({i}, repeat(chr(90 - ({i} % 26)), 4096))' for i in range(rows // 2, rows))}",
+            )
+    conn.close()
+
+
+def test_compact_duckdb_returns_metrics_and_preserves_data(tmp_path: Path):
+    db_path = tmp_path / "widgets.duckdb"
+    _seed_duckdb(db_path, rows=200)
+
+    pre_bytes = db_path.stat().st_size
+    pre_count = duckdb.connect(str(db_path), read_only=True).execute(
+        "SELECT COUNT(*) FROM widgets",
+    ).fetchone()[0]
+
+    result = compact_duckdb("test_widgets", db_path)
+
+    # File still exists, .bak / .compacting siblings are gone.
+    assert db_path.exists()
+    assert not (db_path.with_name(db_path.name + ".bak")).exists()
+    assert not (db_path.with_name(db_path.name + ".compacting")).exists()
+
+    # Row count preserved end-to-end.
+    post_count = duckdb.connect(str(db_path), read_only=True).execute(
+        "SELECT COUNT(*) FROM widgets",
+    ).fetchone()[0]
+    assert post_count == pre_count
+
+    # Metrics make sense.
+    assert isinstance(result, CompactResult)
+    assert result.provider == "test_widgets"
+    assert result.db_path == str(db_path)
+    assert result.bytes_before == pre_bytes
+    assert result.bytes_after == db_path.stat().st_size
+    assert result.reclaimed_bytes == result.bytes_before - result.bytes_after
+    assert 0.0 <= result.compression_ratio <= 1.5  # usually < 1, but DBs can grow if tiny
+    assert result.table_count == 1
+    assert result.elapsed_seconds >= 0
+
+
+def test_compact_duckdb_raises_for_missing_file(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        compact_duckdb("nope", tmp_path / "does-not-exist.duckdb")
+
+
+def test_compact_all_indexes_walks_data_root(tmp_path: Path):
+    """`compact_all_indexes(<dir>)` finds every *.duckdb under the dir."""
+    a = tmp_path / "provider_a" / "duckdb"
+    a.mkdir(parents=True)
+    _seed_duckdb(a / "a.duckdb", rows=50)
+    b = tmp_path / "provider_b" / "duckdb"
+    b.mkdir(parents=True)
+    _seed_duckdb(b / "b.duckdb", rows=50)
+
+    results = compact_all_indexes(tmp_path, verbose=False)
+
+    providers = sorted(r.provider for r in results)
+    assert providers == ["provider_a", "provider_b"]
+    for r in results:
+        assert r.bytes_after > 0  # file still exists
+        assert r.table_count == 1
+
+
+def test_compact_all_indexes_raises_on_missing_root(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        compact_all_indexes(tmp_path / "missing")
+
+
+def test_close_cached_resources_for_unsets_attr_and_calls_close():
+    """The endpoint relies on this to release the file lock before compaction."""
+    class _Closeable:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _AppState:
+        pass
+
+    app_state = _AppState()
+    closeable = _Closeable()
+    # Tuple shape (mirrors `app_state.v2_<provider>_resources`).
+    app_state.v2_github_resources = (None, closeable, None)
+
+    close_cached_resources_for("github", app_state)
+
+    assert closeable.closed is True
+    assert app_state.v2_github_resources is None
+
+
+def test_close_cached_resources_for_handles_unknown_provider_silently():
+    """Unknown providers are a no-op — endpoint already 404s elsewhere."""
+    class _AppState:
+        pass
+
+    close_cached_resources_for("not-a-provider", _AppState())  # should not raise
+
+
+def test_close_cached_resources_for_single_store_attr():
+    """CLI-managed catalogs cache a single Store on `app_state.v2_<name>_store`."""
+    class _Closeable:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _AppState:
+        pass
+
+    app_state = _AppState()
+    closeable = _Closeable()
+    app_state.v2_ror_store = closeable
+
+    close_cached_resources_for("ror", app_state)
+
+    assert closeable.closed is True
+    assert app_state.v2_ror_store is None


### PR DESCRIPTION
Picks up the survey findings from PR #61 follow-up: 5 CLI-built catalogs (`ror`, `infoscience`, `snsf`, `epfl_graph`, `communities`) had populated DuckDB + Qdrant artifacts but no uniform v2 REST surface, leaving the Hub Overview blind to them and external clients without a way to search them. Also tackles the openalex/snsf DuckDB bloat (3.7 GB / 1 GB) flagged in the same survey.

## Stats — 5 new providers

`INDEX_STATS_SUPPORTED_PROVIDERS` now covers all 14 catalogs. CLI-only catalogs open their DuckDB on demand (no `app_state` resources tuple to share) and cache the Store on `app_state.v2_<provider>_store`. `communities` lacks `.connect()` so we wrap it in a thin shim that exposes the same surface.

Verified end-to-end against the live deployment DuckDBs — all 13 reachable providers return real counts (`github` 503s only because the test env had no `GME_GITHUB_TOKEN`).

## Search — 4 new providers

New `POST /v2/indices/{ror,infoscience,snsf,epfl_graph}/search` routes. Thin adapters in `src/v2/indices/cli_catalogs.py` translate `IndexSearchRequest` to each catalog's existing CLI-level query function. Top-k only — catalog-specific filters (ROR country, SNSF discipline_l1, …) stay CLI-only. Communities skipped — no semantic-search infra to wire up.

## DuckDB compaction

- **Helper:** `compact_duckdb(provider, path)` — EXPORT to tempdir → write `<path>.compacting` sibling → atomic rename original to `.bak` → swap → drop backup on success. Crash-safe; the original file survives any mid-flight failure.
- **Batch:** `compact_all_indexes(data_root)` walks every `*.duckdb` under `data/index/`.
- **`just` recipes:**
  - `just compact-indexes` — offline batch via `python -m src.v2.indices.compact`.
  - `just compact-index <PROVIDER>` — online single-provider via the new endpoint.
- **`POST /v2/indices/{provider}/compact`** — closes the cached writer on `app.state` so EXPORT can re-open the file lock-free, runs compaction in a worker thread, returns `CompactResult` with `bytes_before` / `bytes_after` / `reclaimed_bytes` / `table_count` / `elapsed_seconds`. Next stats/search call lazily re-inits.

## Tests

7 new tests in `tests/v2/test_indices_compact.py` covering metric correctness, file lifecycle (no `.bak` / `.compacting` leftovers), row-count preservation, error paths, and the resource-cache closer for both tuple and single-store shapes.

`pytest tests/v2/ -n 4 --dist=loadfile -m 'not live_provider and not llm_integration'` → **790 passed** (was 773 pre-PR; +7 compact tests + matrix expansion).

## Out of scope (already flagged earlier)

- Communities `/search` — no semantic infra yet.
- Embedding backfill (ORCID-Switzerland educations missing entirely, employments + ETHZ-RC articles half-embedded) — operator action.
- Freshness sentinel on top of the new `last_updated` field — observability PR.

## Plus: tiny host cleanup

Removed `data/index/ethz-research-collection/ethz_research_collection.duckdb` (12 KB stray, leftover from before the `duckdb/` subdir convention landed). The canonical 290 MB sibling under `duckdb/` is untouched. `data/` is gitignored — one-time host cleanup, not a tracked change.