### PR TITLE
feat(v2 indices): freshness sentinel + communities lexical search

### DIFF
--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Depends, Path, Query, Request, status
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
 from rdflib import Graph as RDFGraph
 
 from src.v2.agents import AgentRuntime, ProviderSet, parse_agent_runtime
@@ -69,6 +70,7 @@ from src.v2.indices.oamonitor import (
 from src.v2.indices.openalex import run_openalex_ingest_job, run_openalex_search
 from src.v2.indices.orcid import run_orcid_ingest_job, run_orcid_search
 from src.v2.indices.cli_catalogs import (
+    run_communities_search,
     run_epfl_graph_search,
     run_infoscience_search,
     run_ror_search,
@@ -81,6 +83,7 @@ from src.v2.indices.compact import (
 )
 from src.v2.indices.renkulab import run_renkulab_ingest_job, run_renkulab_search
 from src.v2.indices.stats import (
+    INDEX_STATS_SUPPORTED_PROVIDERS,
     IndexStatsResponse,
     UnknownIndexProviderError,
     collect_index_stats,
@@ -2462,6 +2465,110 @@ async def epfl_graph_search_post(
     return await _search_response_or_unavailable(
         await run_epfl_graph_search(payload, request.app.state),
         index_name="epfl_graph",
+    )
+
+
+@v2_router.post(
+    "/indices/communities/search",
+    response_model=IndexSearchResponse,
+    response_model_exclude_none=True,
+    tags=["Indices"],
+)
+async def communities_search_post(
+    payload: IndexSearchRequest,
+    request: Request,
+    _token: Annotated[str, Depends(verify_token)],
+) -> IndexSearchResponse | JSONResponse:
+    """Lexical (ILIKE) search against the institutional communities registry.
+
+    No semantic infrastructure — communities is a tiny 469-row DuckDB-only
+    registry where substring scans across `title` / `description` /
+    `keywords` finish in milliseconds. Title hits outrank description
+    hits outrank keyword hits.
+    """
+    return await _search_response_or_unavailable(
+        await run_communities_search(payload, request.app.state),
+        index_name="communities",
+    )
+
+
+# --- /v2/indices/freshness ------------------------------------------------
+# Single roll-up over every supported catalog's `last_updated` for the Hub
+# Overview / monitoring. One round-trip instead of 14 separate stats calls.
+
+
+class _CatalogFreshness(BaseModel):
+    provider: str
+    count: int
+    last_updated: datetime | None = None
+    age_seconds: float | None = Field(
+        default=None,
+        description=(
+            "Seconds since `last_updated`. `null` when the catalog is empty "
+            "or has no timestamp-like column to read from."
+        ),
+    )
+
+
+class _FreshnessResponse(BaseModel):
+    as_of: datetime
+    catalogs: list[_CatalogFreshness]
+    oldest_provider: str | None = None
+    oldest_age_seconds: float | None = None
+
+
+@v2_router.get(
+    "/indices/freshness",
+    response_model=_FreshnessResponse,
+    response_model_exclude_none=True,
+    tags=["Indices"],
+)
+async def index_freshness_get(
+    request: Request,
+    _token: Annotated[str, Depends(verify_token)],
+) -> _FreshnessResponse:
+    """Aggregate `last_updated` across every supported catalog.
+
+    Returns one row per provider plus the `oldest_provider` / `oldest_age_seconds`
+    convenience fields that Open Pulse Hub can alert on directly. Providers
+    whose resources are unavailable on this deployment surface with
+    `count=0, last_updated=null` so the response shape is uniform.
+    """
+    now = datetime.now(timezone.utc)
+
+    def _one(provider: str) -> _CatalogFreshness:
+        try:
+            store = fetch_store_for_stats(provider, request.app.state)
+        except UnknownIndexProviderError:
+            return _CatalogFreshness(provider=provider, count=0)
+        if store is None:
+            return _CatalogFreshness(provider=provider, count=0)
+        try:
+            stats = collect_index_stats(provider, store.connect())
+        except Exception:  # noqa: BLE001 — keep the roll-up resilient
+            logger.exception("index freshness: %s collect failed", provider)
+            return _CatalogFreshness(provider=provider, count=0)
+        if stats.last_updated is None:
+            return _CatalogFreshness(provider=provider, count=stats.count)
+        # Both sides timezone-aware (collect_index_stats normalises to UTC).
+        age = (now - stats.last_updated).total_seconds()
+        return _CatalogFreshness(
+            provider=provider,
+            count=stats.count,
+            last_updated=stats.last_updated,
+            age_seconds=age,
+        )
+
+    catalogs = await asyncio.to_thread(
+        lambda: [_one(p) for p in INDEX_STATS_SUPPORTED_PROVIDERS],
+    )
+    aged = [c for c in catalogs if c.age_seconds is not None]
+    oldest = max(aged, key=lambda c: c.age_seconds) if aged else None
+    return _FreshnessResponse(
+        as_of=now,
+        catalogs=catalogs,
+        oldest_provider=oldest.provider if oldest else None,
+        oldest_age_seconds=oldest.age_seconds if oldest else None,
     )
 
 

--- a/src/v2/indices/cli_catalogs.py
+++ b/src/v2/indices/cli_catalogs.py
@@ -213,7 +213,86 @@ async def run_epfl_graph_search(
     )
 
 
+# ---------------------------------------------------------------------------
+# Communities — DuckDB ILIKE across title/description/keywords
+# ---------------------------------------------------------------------------
+# No semantic search infra; this is a tiny 469-row registry where a plain
+# substring scan finishes in milliseconds and is more honest than a vector
+# round-trip would be. Search is title-weighted: title hit > description hit
+# > keywords hit, sum-scored.
+
+
+async def run_communities_search(
+    payload: IndexSearchRequest, app_state: Any,
+) -> IndexSearchResponse | None:
+    del app_state  # we open a fresh read-only handle per request
+    try:
+        from src.index.communities.paths import duckdb_path  # noqa: PLC0415
+        from src.index.communities.storage.duckdb_store import (  # noqa: PLC0415
+            CommunitiesStore,
+        )
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("communities search: module unavailable — %s", exc)
+        return None
+    db_path = duckdb_path()
+    if not db_path.exists():
+        return IndexSearchResponse(
+            index_name="communities",
+            target=payload.target,
+            query=payload.query,
+            hits=[],
+            extra={"error": "communities.duckdb does not exist"},
+        )
+    pattern = f"%{payload.query}%"
+    sql = (
+        "SELECT "
+        "  community_id, source, source_slug, parent_org, title, description, "
+        "  url, visibility, created_at, updated_at, member_count, record_count, "
+        "  curator_names, keywords, "
+        "  (CASE WHEN title ILIKE ? THEN 3 ELSE 0 END) "
+        " + (CASE WHEN description ILIKE ? THEN 2 ELSE 0 END) "
+        " + (CASE WHEN CAST(keywords AS VARCHAR) ILIKE ? THEN 1 ELSE 0 END) "
+        " AS score "
+        "FROM communities "
+        "WHERE title ILIKE ? OR description ILIKE ? "
+        "   OR CAST(keywords AS VARCHAR) ILIKE ? "
+        "ORDER BY score DESC, title ASC "
+        "LIMIT ?"
+    )
+    store = CommunitiesStore.open(db_path)
+    try:
+        with store.read_only() as conn:
+            rows = conn.execute(
+                sql,
+                [pattern, pattern, pattern, pattern, pattern, pattern, payload.top_k],
+            ).fetchall()
+            cols = [d[0] for d in conn.description]
+    finally:
+        pass  # `read_only()` ctx closes the handle
+    # Pack the row under `payload` so clients read fields from the same
+    # location across every `/v2/indices/<name>/search` route, and promote
+    # `community_id` → `id` + `score` → `vector_score` for `IndexSearchHit`.
+    hits: list[Any] = []
+    for row in rows:
+        record = dict(zip(cols, row, strict=False))
+        score = record.pop("score", None)
+        hit_input: dict[str, Any] = {
+            "id": record.get("community_id", ""),
+            "payload": record,
+        }
+        if score is not None:
+            hit_input["vector_score"] = float(score)
+        hits.append(hit_from_raw(hit_input))
+    return IndexSearchResponse(
+        index_name="communities",
+        target=payload.target,
+        query=payload.query,
+        hits=hits,
+    )
+
+
 __all__ = [
+    "run_communities_search",
     "run_epfl_graph_search",
     "run_infoscience_search",
     "run_ror_search",

--- a/tests/v2/test_indices_freshness_and_communities_search.py
+++ b/tests/v2/test_indices_freshness_and_communities_search.py
@@ -1,0 +1,235 @@
+"""Tests for `GET /v2/indices/freshness` + `POST /v2/indices/communities/search`."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.v2.api import v2_router
+
+HTTP_OK = 200
+
+TEST_API_TOKEN = "test-api-token"  # noqa: S105
+_AUTH_HEADERS = {"Authorization": f"Bearer {TEST_API_TOKEN}"}
+
+
+class _FakeStore:
+    """Stats-endpoint-compatible Store wrapper around a tmp DuckDB."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self._conn: duckdb.DuckDBPyConnection | None = None
+
+    def connect(self) -> duckdb.DuckDBPyConnection:
+        if self._conn is None:
+            self._conn = duckdb.connect(str(self.db_path))
+        return self._conn
+
+
+def _seed_stats_db(
+    path: Path, *, count: int = 5, ingested_at: datetime | None = None,
+) -> None:
+    conn = duckdb.connect(str(path))
+    conn.execute("CREATE TABLE rows (id INTEGER PRIMARY KEY, ingested_at TIMESTAMP)")
+    ts = ingested_at or datetime.now(timezone.utc)
+    for i in range(count):
+        conn.execute("INSERT INTO rows VALUES (?, ?)", [i, ts])
+    conn.close()
+
+
+def _build_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(v2_router)
+    return app
+
+
+def _request(app: FastAPI, method: str, path: str, **kwargs: Any) -> tuple[int, Any]:
+    async def _run() -> tuple[int, Any]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.request(
+                method, path, headers=_AUTH_HEADERS, **kwargs,
+            )
+        try:
+            body = resp.json()
+        except Exception:  # noqa: BLE001
+            body = resp.text
+        return resp.status_code, body
+
+    return asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Freshness endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_freshness_endpoint_rolls_up_per_provider(tmp_path: Path, monkeypatch):
+    """One catalog populated, the rest unavailable → roll-up still works."""
+    db = tmp_path / "github.duckdb"
+    yesterday = datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc)
+    _seed_stats_db(db, count=42, ingested_at=yesterday)
+
+    # Stub fetch_store_for_stats: return our store for `github`, None for the
+    # rest. Keeps the test offline — no real DuckDBs need to be on disk.
+    from src.v2 import api as v2_api
+
+    def _fake_fetch(provider: str, app_state: Any) -> Any | None:
+        return _FakeStore(db) if provider == "github" else None
+
+    monkeypatch.setattr(v2_api, "fetch_store_for_stats", _fake_fetch)
+
+    app = _build_test_app()
+    code, body = _request(app, "GET", "/v2/indices/freshness")
+
+    assert code == HTTP_OK
+    assert "as_of" in body
+    assert isinstance(body["catalogs"], list)
+    # All supported providers appear.
+    providers = {c["provider"] for c in body["catalogs"]}
+    assert "github" in providers and "ror" in providers and "communities" in providers
+
+    by_provider = {c["provider"]: c for c in body["catalogs"]}
+    gh = by_provider["github"]
+    assert gh["count"] == 42
+    assert gh["last_updated"] is not None
+    assert gh["age_seconds"] > 0
+
+    # Providers with no store available have count=0, no last_updated.
+    ror = by_provider["ror"]
+    assert ror["count"] == 0
+    assert ror.get("last_updated") is None
+    assert ror.get("age_seconds") is None
+
+    # The oldest_* convenience fields point at the only catalog we seeded.
+    assert body["oldest_provider"] == "github"
+    assert body["oldest_age_seconds"] >= gh["age_seconds"] - 0.001
+
+
+def test_freshness_endpoint_handles_no_aged_catalogs(monkeypatch):
+    """All catalogs empty → response is still well-formed, oldest fields null."""
+    from src.v2 import api as v2_api
+
+    monkeypatch.setattr(
+        v2_api, "fetch_store_for_stats", lambda *_a, **_k: None,
+    )
+
+    app = _build_test_app()
+    code, body = _request(app, "GET", "/v2/indices/freshness")
+
+    assert code == HTTP_OK
+    # `response_model_exclude_none=True` strips null fields from the body
+    # — `oldest_*` may be absent rather than literal null. Either is fine.
+    assert body.get("oldest_provider") is None
+    assert body.get("oldest_age_seconds") is None
+    assert all(c["count"] == 0 for c in body["catalogs"])
+
+
+# ---------------------------------------------------------------------------
+# Communities search endpoint
+# ---------------------------------------------------------------------------
+
+
+def _seed_communities_db(path: Path) -> None:
+    """Seed `communities.duckdb` with three rows the search will hit."""
+    schema = (
+        Path(__file__).resolve().parents[2]
+        / "src" / "index" / "communities" / "storage" / "schema.sql"
+    ).read_text(encoding="utf-8")
+    conn = duckdb.connect(str(path))
+    for stmt in [s.strip() for s in schema.split(";") if s.strip()]:
+        conn.execute(stmt + ";")
+    rows = [
+        ("zenodo:epfl", "zenodo", "epfl", None, "EPFL", "Research at EPFL", None,
+         "public", None, None, None, None, None, '["epfl", "research"]', "{}"),
+        ("zenodo:ethz", "zenodo", "ethz", None, "ETHZ", "ETH Zürich datasets", None,
+         "public", None, None, None, None, None, '["ethz", "data"]', "{}"),
+        ("zenodo:cern", "zenodo", "cern", None, "CERN openlab",
+         "Open data from CERN", None,
+         "public", None, None, None, None, None, '["cern", "physics"]', "{}"),
+    ]
+    cols = (
+        "community_id, source, source_slug, parent_org, title, description, url, "
+        "visibility, created_at, updated_at, curator_names, member_count, "
+        "record_count, keywords, raw"
+    )
+    placeholders = ", ".join("?" for _ in range(15))
+    for row in rows:
+        conn.execute(f"INSERT INTO communities ({cols}) VALUES ({placeholders})", list(row))
+    conn.close()
+
+
+def test_communities_search_title_hits_outrank_description_hits(
+    tmp_path: Path, monkeypatch,
+):
+    """`EPFL` query: title hit on row 1 (score 3), description hit on row 2 (score 2)."""
+    db = tmp_path / "communities.duckdb"
+    _seed_communities_db(db)
+
+    # Point the adapter at the tmp DB.
+    from src.index.communities import paths as communities_paths
+
+    monkeypatch.setattr(communities_paths, "duckdb_path", lambda: db)
+
+    app = _build_test_app()
+    code, body = _request(
+        app, "POST", "/v2/indices/communities/search",
+        json={"query": "EPFL", "top_k": 10},
+    )
+
+    assert code == HTTP_OK
+    assert body["index_name"] == "communities"
+    titles = [h["payload"].get("title") for h in body["hits"]]
+    assert titles[0] == "EPFL"  # title hit ranks first
+
+
+def test_communities_search_falls_back_to_keywords(
+    tmp_path: Path, monkeypatch,
+):
+    """`physics` query: only present in keywords JSON → row 3 (CERN openlab)."""
+    db = tmp_path / "communities.duckdb"
+    _seed_communities_db(db)
+
+    from src.index.communities import paths as communities_paths
+
+    monkeypatch.setattr(communities_paths, "duckdb_path", lambda: db)
+
+    app = _build_test_app()
+    code, body = _request(
+        app, "POST", "/v2/indices/communities/search",
+        json={"query": "physics", "top_k": 10},
+    )
+
+    assert code == HTTP_OK
+    titles = [h["payload"].get("title") for h in body["hits"]]
+    assert "CERN openlab" in titles
+
+
+def test_communities_search_returns_empty_when_db_missing(
+    tmp_path: Path, monkeypatch,
+):
+    """No `communities.duckdb` on disk → hits=[] + `extra.error` filled."""
+    from src.index.communities import paths as communities_paths
+
+    monkeypatch.setattr(
+        communities_paths,
+        "duckdb_path",
+        lambda: tmp_path / "does-not-exist.duckdb",
+    )
+
+    app = _build_test_app()
+    code, body = _request(
+        app, "POST", "/v2/indices/communities/search",
+        json={"query": "anything", "top_k": 5},
+    )
+
+    assert code == HTTP_OK
+    assert body["hits"] == []
+    assert "does not exist" in body.get("extra", {}).get("error", "")


### PR DESCRIPTION
**Stacked on #66.** Merge #66 first; this PR's base will auto-rebase to develop.

Closes the last two operational gaps surfaced in the post-#61 survey:

## `GET /v2/indices/freshness`

Single roll-up endpoint for the Hub Overview / monitoring layer. One API call returns one row per catalog plus the `oldest_provider` / `oldest_age_seconds` convenience fields the Hub can alert on directly:

```json
{
  "as_of": "...",
  "catalogs": [
    {\"provider\": \"ror\", \"count\": 125065, \"last_updated\": \"2026-05-01T07:58Z\", \"age_seconds\": 2295600},
    {\"provider\": \"github\", \"count\": 7099, \"last_updated\": \"2026-05-19T21:57Z\", \"age_seconds\": 644400}
  ],
  \"oldest_provider\": \"ror\",
  \"oldest_age_seconds\": 2295600
}
```

Providers whose resources are unavailable on this deployment (config missing, optional module absent) surface with `count=0` and no timestamp, so the response shape is uniform regardless of how the deployment is wired.

## `POST /v2/indices/communities/search`

Communities is a 469-row institutional registry with no semantic infrastructure (no vectors, no Qdrant collection). Building that just to honour the `/search` naming convention would be theatre, so this PR does the honest thing: a `DuckDB ILIKE` scan across `title` / `description` / `keywords`.

- Title hits weight 3, description 2, keywords 1.
- Ties broken alphabetically by title.
- Finishes in milliseconds (whole table is ~30 KB).
- Result rows packed under `payload` so clients read fields from the same place as every other `/v2/indices/<name>/search` route.

## Tests

5 new tests in `tests/v2/test_indices_freshness_and_communities_search.py`:
- Freshness rolls up one populated catalog + 13 empty providers; oldest fields point at the populated one.
- Freshness with all catalogs empty: `oldest_provider` / `oldest_age_seconds` are null/absent.
- Communities search: title hits outrank description hits.
- Communities search: keyword-only matches still surface.
- Communities search: missing DuckDB → empty hits + `extra.error`.

Full v2 suite: 795 passed (was 790; +5 from this PR).