### PR TITLE
chore(communities): canonical IRI as community_id (drop zenodo:<slug>)

### DIFF
--- a/src/index/_federated/adapters/communities.py
+++ b/src/index/_federated/adapters/communities.py
@@ -104,14 +104,16 @@ class CommunitiesAdapter:
         try:
             s = identifier.strip()
             # Three flavours of identifier we recognise:
-            #   1. `zenodo:<slug>`   (our canonical PK)
+            #   1. Full Zenodo URL   (`https://zenodo.org/communities/<slug>`,
+            #      the canonical PK post-migration)
             #   2. bare `<slug>`     (matches source_slug)
-            #   3. Full Zenodo URL   (`https://zenodo.org/communities/<slug>`)
+            #   3. Legacy `zenodo:<slug>` (pre-migration PK; kept for
+            #      backwards compatibility while consumers update)
             slug = s
-            if s.startswith("zenodo:"):
+            if s.startswith("https://zenodo.org/communities/"):
+                slug = s.rsplit("/", 1)[-1].rstrip("/")
+            elif s.startswith("zenodo:"):
                 slug = s.split(":", 1)[1]
-            elif s.startswith("https://zenodo.org/communities/"):
-                slug = s.rsplit("/", 1)[-1]
             rows = con.execute(
                 """
                 SELECT community_id, source, source_slug, parent_org, title,

--- a/src/index/communities/ingest/zenodo.py
+++ b/src/index/communities/ingest/zenodo.py
@@ -50,8 +50,10 @@ def _normalize_record(payload: dict[str, Any], parent_org: str | None) -> dict[s
         val = metadata.get(key) if isinstance(metadata, dict) else None
         if isinstance(val, list):
             keywords.extend(str(v) for v in val if isinstance(v, (str, dict)))
+    from src.index.communities.iri import canonical_community_id  # noqa: PLC0415
+
     return {
-        "community_id": f"zenodo:{slug}",
+        "community_id": canonical_community_id("zenodo", slug),
         "source": "zenodo",
         "source_slug": slug,
         "parent_org": parent_org,

--- a/src/index/communities/iri.py
+++ b/src/index/communities/iri.py
@@ -1,0 +1,54 @@
+"""Canonical IRI scheme for `community_id` values.
+
+Communities used to be keyed under a `<source>:<slug>` opaque prefix
+(e.g. `zenodo:epfl`). That's namespaced and unique but it's not a
+real identifier — downstream graph consumers can't dereference it,
+and it's confusing next to the other catalogs which already use the
+proper IRI form (`https://github.com/<org>`, `https://orcid.org/...`,
+`https://ror.org/...`).
+
+This module centralises the mapping `source × slug → canonical IRI`
+so every ingest source emits the same shape, and existing rows can
+be migrated by `bootstrap()` on next open.
+
+Convention: no trailing slash, matches IRIs everywhere else in the
+codebase.
+"""
+
+from __future__ import annotations
+
+_IRI_TEMPLATES: dict[str, str] = {
+    # https://zenodo.org/communities/<slug>
+    "zenodo": "https://zenodo.org/communities/{slug}",
+    # Reserved for future sources. Adding one here is the only change
+    # needed to make `canonical_community_id(...)` recognise them.
+    #
+    #   "github":       "https://github.com/{slug}",
+    #   "huggingface":  "https://huggingface.co/{slug}",
+    #   "gitlab_epfl":  "https://gitlab.epfl.ch/{slug}",
+}
+
+
+class UnknownCommunitySource(ValueError):
+    """Raised when no IRI template is registered for `source`."""
+
+
+def canonical_community_id(source: str, slug: str) -> str:
+    """Return the canonical IRI for a community.
+
+    Raises:
+        UnknownCommunitySource: when `source` has no registered template.
+            Callers handling fresh ingest data should add the template
+            above rather than swallow the exception.
+    """
+    template = _IRI_TEMPLATES.get(source)
+    if template is None:
+        msg = (
+            f"No canonical IRI template registered for community source "
+            f"{source!r}. Register one in src/index/communities/iri.py."
+        )
+        raise UnknownCommunitySource(msg)
+    return template.format(slug=slug)
+
+
+__all__ = ["UnknownCommunitySource", "canonical_community_id"]

--- a/src/index/communities/models.py
+++ b/src/index/communities/models.py
@@ -10,9 +10,11 @@ from pydantic import BaseModel, Field
 class CommunityRecord(BaseModel):
     """One row of the `communities` table.
 
-    `community_id` is namespaced by source (`zenodo:epfl-chili`) so we
-    can ingest the same logical community from multiple sources in the
-    future without primary-key clashes.
+    `community_id` is the canonical IRI for the community at its source
+    (e.g. `https://zenodo.org/communities/epfl-chili`). The
+    `src.index.communities.iri.canonical_community_id(source, slug)`
+    helper centralises the mapping; legacy `zenodo:<slug>` rows are
+    migrated in-place by `bootstrap()`.
     """
 
     community_id: str

--- a/src/index/communities/storage/schema.sql
+++ b/src/index/communities/storage/schema.sql
@@ -1,7 +1,10 @@
 -- Communities index schema. Idempotent.
 
 CREATE TABLE IF NOT EXISTS communities (
-    -- Namespaced primary key: '<source>:<source_slug>' (e.g. 'zenodo:epfl-chili').
+    -- Canonical IRI: the dereferenceable landing-page URL for the
+    -- community at its source (`https://zenodo.org/communities/<slug>`,
+    -- `https://github.com/<org>`, …). Built by
+    -- `src.index.communities.iri.canonical_community_id(source, slug)`.
     community_id    TEXT PRIMARY KEY,
     source          TEXT NOT NULL,        -- 'zenodo' (later: 'github', 'openalex', ...)
     source_slug     TEXT NOT NULL,        -- raw slug at the source
@@ -23,3 +26,11 @@ CREATE TABLE IF NOT EXISTS communities (
 CREATE INDEX IF NOT EXISTS idx_comm_parent_org  ON communities (parent_org);
 CREATE INDEX IF NOT EXISTS idx_comm_source      ON communities (source);
 CREATE INDEX IF NOT EXISTS idx_comm_slug        ON communities (source_slug);
+
+-- One-shot migration: legacy rows use `zenodo:<slug>` as the primary key;
+-- new ingests write the full IRI. Re-keying is idempotent — the WHERE
+-- clause matches zero rows on re-runs. `community_id` is a PRIMARY KEY,
+-- but UPDATEs that don't change cardinality work fine in DuckDB.
+UPDATE communities
+   SET community_id = 'https://zenodo.org/communities/' || source_slug
+ WHERE source = 'zenodo' AND community_id LIKE 'zenodo:%';

--- a/tests/index/communities/test_iri.py
+++ b/tests/index/communities/test_iri.py
@@ -1,0 +1,95 @@
+"""Tests for the canonical-IRI helper + the legacy-row migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from src.index.communities.iri import (
+    UnknownCommunitySource,
+    canonical_community_id,
+)
+
+
+def test_canonical_community_id_zenodo_format():
+    assert canonical_community_id("zenodo", "epfl") == (
+        "https://zenodo.org/communities/epfl"
+    )
+    # No trailing slash — matches the rest of the codebase's IRI hygiene.
+    iri = canonical_community_id("zenodo", "eesd_at_epfl")
+    assert iri == "https://zenodo.org/communities/eesd_at_epfl"
+    assert not iri.endswith("/")
+
+
+def test_canonical_community_id_rejects_unknown_source():
+    with pytest.raises(UnknownCommunitySource):
+        canonical_community_id("flickr", "whatever")
+
+
+def _run_schema(db_path: Path) -> None:
+    """Bootstrap the schema (statement-by-statement, like the store does)."""
+    schema = (
+        Path(__file__).resolve().parents[3]
+        / "src" / "index" / "communities" / "storage" / "schema.sql"
+    ).read_text(encoding="utf-8")
+    conn = duckdb.connect(str(db_path))
+    for stmt in [s.strip() for s in schema.split(";") if s.strip()]:
+        conn.execute(stmt + ";")
+    conn.close()
+
+
+def test_legacy_zenodo_rows_are_migrated_on_bootstrap(tmp_path: Path):
+    """Pre-seed a DB with the old `zenodo:<slug>` rows, re-bootstrap, and
+    confirm every row now carries the canonical IRI.
+    """
+    db_path = tmp_path / "communities.duckdb"
+    # First bootstrap creates the table.
+    _run_schema(db_path)
+
+    # Seed legacy rows + one that's already in the new format (idempotency).
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO communities (community_id, source, source_slug) VALUES "
+        "('zenodo:epfl', 'zenodo', 'epfl'), "
+        "('zenodo:cern', 'zenodo', 'cern'), "
+        "('https://zenodo.org/communities/already-migrated', 'zenodo', 'already-migrated')",
+    )
+    conn.close()
+
+    # Re-bootstrap → UPDATE clause rewrites the legacy rows in-place.
+    _run_schema(db_path)
+
+    conn = duckdb.connect(str(db_path), read_only=True)
+    ids = sorted(
+        row[0]
+        for row in conn.execute("SELECT community_id FROM communities").fetchall()
+    )
+    conn.close()
+
+    assert ids == [
+        "https://zenodo.org/communities/already-migrated",
+        "https://zenodo.org/communities/cern",
+        "https://zenodo.org/communities/epfl",
+    ]
+
+
+def test_migration_is_idempotent(tmp_path: Path):
+    """Bootstrap twice on the same DB: row count and ids must be unchanged."""
+    db_path = tmp_path / "communities.duckdb"
+    _run_schema(db_path)
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO communities (community_id, source, source_slug) VALUES "
+        "('zenodo:foo', 'zenodo', 'foo')",
+    )
+    conn.close()
+
+    for _ in range(3):
+        _run_schema(db_path)
+
+    conn = duckdb.connect(str(db_path), read_only=True)
+    rows = conn.execute("SELECT community_id FROM communities").fetchall()
+    conn.close()
+    assert rows == [("https://zenodo.org/communities/foo",)]


### PR DESCRIPTION
## Why

`community_id` was opaque (`zenodo:epfl`) while every other catalog uses a real dereferenceable IRI:

| Catalog | `id` format |
|---|---|
| GitHub repos / orgs | `https://github.com/<owner>/<name>` |
| ORCID persons | `https://orcid.org/...` |
| ROR orgs | `https://ror.org/...` |
| OpenAlex | `https://openalex.org/W...` |
| **Communities (before)** | `zenodo:epfl-chili` |

That confused downstream graph consumers — `<community_id>` looked like a CURIE that should resolve via @context, but it didn't. New ingest writes the canonical landing-page URL.

## Mapping

`src/index/communities/iri.py::canonical_community_id(source, slug)`:

- `zenodo` → `https://zenodo.org/communities/<slug>` (no trailing slash, matches the rest of the codebase)

Slots reserved for future sources (`github`, `huggingface`, `gitlab_epfl`) are commented in the registry; adding one is a single template entry. The helper raises `UnknownCommunitySource` instead of silently falling back, so a new ingest source can't accidentally re-emit the old `<source>:<slug>` form.

## Migration

`storage/schema.sql` ends with an idempotent `UPDATE`:

```sql
UPDATE communities
   SET community_id = 'https://zenodo.org/communities/' || source_slug
 WHERE source = 'zenodo' AND community_id LIKE 'zenodo:%';
```

The store's `bootstrap()` runs the schema on every `open()`, so any on-disk DB converges on the next open. Live `data/index/communities/duckdb/communities.duckdb` already converged locally — all 469 rows carry IRIs (verified pre-commit).

## Other touches

- `models.CommunityRecord` docstring updated to point at the IRI helper.
- The federated `lookup` adapter in `src/index/_federated/adapters/communities.py` recognised three identifier shapes; the canonical URL is now listed first, with the `zenodo:<slug>` form kept as a backwards-compat fallback (external dashboards may still emit it during the transition).

## Test plan

- [x] `pytest tests/index/communities/test_iri.py` — 4 new tests:
  - `canonical_community_id("zenodo", "epfl")` returns the URL, no trailing slash.
  - Unknown sources raise `UnknownCommunitySource`.
  - DB seeded with mixed legacy + already-migrated rows ends up with only IRI-form ids after bootstrap.
  - Migration is idempotent across three consecutive bootstraps.
- [x] `pytest tests/v2/ tests/index/` — 973 passed (single unrelated failure is the pre-existing openalex `test_defaults_from_yaml` env-leak fixed by PR #65).

## Forward-looking note

Future sources (github communities, huggingface orgs, gitlab groups) can be added by appending one line to `_IRI_TEMPLATES` in `iri.py` — the format expectation is now baked into a single registry.