### PR TITLE
feat(zenodo): canonical IRI for zenodo_id + community_id (+ link tables)

### DIFF
--- a/src/index/zenodo/ingest/records.py
+++ b/src/index/zenodo/ingest/records.py
@@ -79,8 +79,11 @@ def _project_record(item: dict[str, Any]) -> dict[str, Any]:
     else:
         resource_type = str(resource_type_block) if resource_type_block else None
     concept_recid = item.get("conceptrecid")
+    from src.index.zenodo.iri import record_iri  # noqa: PLC0415
+
+    bare_id = str(item.get("id") or item.get("conceptrecid") or "")
     return {
-        "zenodo_id": str(item.get("id") or item.get("conceptrecid") or ""),
+        "zenodo_id": record_iri(bare_id) if bare_id else "",
         "concept_recid": str(concept_recid) if concept_recid is not None else None,
         "doi": item.get("doi") or metadata.get("doi"),
         "title": metadata.get("title"),
@@ -124,14 +127,16 @@ def _project_creators(item: dict[str, Any]) -> list[tuple[dict[str, Any], int]]:
 
 
 def _project_communities(item: dict[str, Any]) -> list[str]:
+    """Return canonical community IRIs, one per linked community."""
+    from src.index.zenodo.iri import community_iri  # noqa: PLC0415
+
     metadata = item.get("metadata") or {}
     blocks = metadata.get("communities") or []
     out: list[str] = []
     for b in blocks:
-        if isinstance(b, dict) and b.get("id"):
-            out.append(str(b["id"]))
-        elif isinstance(b, str):
-            out.append(b)
+        slug = b.get("id") if isinstance(b, dict) else b
+        if isinstance(slug, str) and slug.strip():
+            out.append(community_iri(slug))
     return out
 
 
@@ -178,9 +183,14 @@ def persist_record(
     # "primary" colour even when the record belongs to several.
     communities = _project_communities(item)
     row["community_ids"] = list(communities)
+    from src.index.zenodo.iri import community_iri  # noqa: PLC0415
+
     if crawling_community and not row.get("primary_community_id"):
-        row["primary_community_id"] = crawling_community
+        # Callers pass bare slugs ("epfl") for the community they were
+        # iterating; promote to the canonical IRI to match the new PK form.
+        row["primary_community_id"] = community_iri(crawling_community)
     elif communities and not row.get("primary_community_id"):
+        # `communities` already carries IRIs (see `_project_communities`).
         row["primary_community_id"] = communities[0]
     store.upsert_record(row, raw=item)
 
@@ -258,8 +268,13 @@ async def _ingest_async(
         if community is None:
             LOGGER.warning("community %s not found on Zenodo; skipping", slug)
             continue
+        from src.index.zenodo.iri import community_iri  # noqa: PLC0415
+
         store.upsert_community(
-            {"community_id": slug, "title": (community.get("metadata") or {}).get("title")},
+            {
+                "community_id": community_iri(slug),
+                "title": (community.get("metadata") or {}).get("title"),
+            },
             raw=community,
         )
         if index % 25 == 0 or index == total_communities:

--- a/src/index/zenodo/iri.py
+++ b/src/index/zenodo/iri.py
@@ -1,0 +1,70 @@
+"""Canonical IRI helpers for the Zenodo index.
+
+Bare numeric ids (`18314844`) and slugs (`epfl`) used to be the primary
+keys; this module promotes them to the dereferenceable URL form that
+every other catalog already uses (GitHub, ORCID, ROR, OpenAlex, …).
+
+  record   `18314844`   →   `https://zenodo.org/records/18314844`
+  community `epfl`      →   `https://zenodo.org/communities/epfl`
+
+No trailing slash. The schema migration in
+`src/index/zenodo/storage/schema.sql` rewrites every PK + FK in
+lockstep on next bootstrap.
+"""
+
+from __future__ import annotations
+
+_RECORD_PREFIX = "https://zenodo.org/records/"
+_COMMUNITY_PREFIX = "https://zenodo.org/communities/"
+
+
+def record_iri(zenodo_id: str) -> str:
+    """`18314844` → `https://zenodo.org/records/18314844`.
+
+    Already-IRI input passes through unchanged so callers can be relaxed
+    about double-conversion.
+    """
+    s = str(zenodo_id).strip()
+    if not s:
+        return s
+    if s.startswith(_RECORD_PREFIX):
+        return s.rstrip("/")
+    return f"{_RECORD_PREFIX}{s}"
+
+
+def community_iri(slug: str) -> str:
+    """`epfl` → `https://zenodo.org/communities/epfl`. Idempotent."""
+    s = str(slug).strip()
+    if not s:
+        return s
+    if s.startswith(_COMMUNITY_PREFIX):
+        return s.rstrip("/")
+    return f"{_COMMUNITY_PREFIX}{s}"
+
+
+def parse_record_id(iri_or_bare: str) -> str | None:
+    """Inverse of `record_iri`. Returns the bare id, or None on garbage."""
+    s = str(iri_or_bare or "").strip()
+    if not s:
+        return None
+    if s.startswith(_RECORD_PREFIX):
+        return s[len(_RECORD_PREFIX) :].rstrip("/") or None
+    return s  # already bare
+
+
+def parse_community_slug(iri_or_bare: str) -> str | None:
+    """Inverse of `community_iri`. Returns the bare slug, or None on garbage."""
+    s = str(iri_or_bare or "").strip()
+    if not s:
+        return None
+    if s.startswith(_COMMUNITY_PREFIX):
+        return s[len(_COMMUNITY_PREFIX) :].rstrip("/") or None
+    return s
+
+
+__all__ = [
+    "community_iri",
+    "parse_community_slug",
+    "parse_record_id",
+    "record_iri",
+]

--- a/src/index/zenodo/storage/duckdb_store.py
+++ b/src/index/zenodo/storage/duckdb_store.py
@@ -76,6 +76,140 @@ class ZenodoStore:
                     "  AND json_extract_string(raw, '$.conceptrecid') IS NOT NULL",
                 )
         conn.execute(_load_schema_sql())
+        # IRI migration for the link tables — see the note at the
+        # bottom of schema.sql. UPDATE on indexed bulk columns has
+        # tripped DuckDB internal index errors on tables this size,
+        # so we drop-and-rebuild via CTAS.
+        self._migrate_link_tables_to_iri()
+
+    def _migrate_link_tables_to_iri(self) -> None:
+        """CTAS-swap link/chunk tables with `record_id`/`entity_id` →
+        IRI. Idempotent: each step checks for bare-id rows first and
+        is a no-op when everything is already migrated.
+        """
+        conn = self.connect()
+        record_prefix = "https://zenodo.org/records/"
+        community_prefix = "https://zenodo.org/communities/"
+
+        def _has_bare(table: str, col: str, extra: str = "") -> bool:
+            row = conn.execute(
+                f"SELECT 1 FROM {table} WHERE {col} NOT LIKE 'https://%' "
+                f"{extra} LIMIT 1",
+            ).fetchone()
+            return row is not None
+
+        def _ctas_swap(
+            *, table: str, columns: list[tuple[str, str]],
+            select: str, primary_key: tuple[str, ...] | None = None,
+        ) -> None:
+            """Rewrite `table` via CREATE TABLE _new + INSERT + DROP + RENAME."""
+            new_table = f"{table}__iri_migrate"
+            conn.execute(f"DROP TABLE IF EXISTS {new_table}")
+            col_defs = ", ".join(f"{name} {dtype}" for name, dtype in columns)
+            if primary_key:
+                col_defs += f", PRIMARY KEY ({', '.join(primary_key)})"
+            conn.execute(f"CREATE TABLE {new_table} ({col_defs})")
+            conn.execute(f"INSERT INTO {new_table} {select}")
+            conn.execute(f"DROP TABLE {table}")
+            conn.execute(f"ALTER TABLE {new_table} RENAME TO {table}")
+
+        if _has_bare("record_creators", "record_id"):
+            _ctas_swap(
+                table="record_creators",
+                columns=[
+                    ("record_id", "TEXT NOT NULL"),
+                    ("creator_key", "TEXT NOT NULL"),
+                    ("position", "INTEGER"),
+                ],
+                select=(
+                    "SELECT CASE WHEN record_id LIKE 'https://%' THEN record_id "
+                    f"            ELSE '{record_prefix}' || record_id END, "
+                    "       creator_key, position "
+                    "FROM record_creators"
+                ),
+                primary_key=("record_id", "creator_key"),
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_record_creators_ck "
+                "ON record_creators (creator_key)",
+            )
+
+        if _has_bare("record_communities", "record_id") or _has_bare(
+            "record_communities", "community_id",
+        ):
+            _ctas_swap(
+                table="record_communities",
+                columns=[
+                    ("record_id", "TEXT NOT NULL"),
+                    ("community_id", "TEXT NOT NULL"),
+                ],
+                select=(
+                    "SELECT "
+                    "  CASE WHEN record_id LIKE 'https://%' THEN record_id "
+                    f"       ELSE '{record_prefix}' || record_id END, "
+                    "  CASE WHEN community_id LIKE 'https://%' THEN community_id "
+                    f"       ELSE '{community_prefix}' || community_id END "
+                    "FROM record_communities"
+                ),
+                primary_key=("record_id", "community_id"),
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_record_comm_cid "
+                "ON record_communities (community_id)",
+            )
+
+        if _has_bare("files", "record_id"):
+            _ctas_swap(
+                table="files",
+                columns=[
+                    ("record_id", "TEXT NOT NULL"),
+                    ("file_key", "TEXT NOT NULL"),
+                    ("file_id", "TEXT"),
+                    ("size_bytes", "BIGINT"),
+                    ("checksum", "TEXT"),
+                    ("download_url", "TEXT"),
+                ],
+                select=(
+                    "SELECT "
+                    "  CASE WHEN record_id LIKE 'https://%' THEN record_id "
+                    f"       ELSE '{record_prefix}' || record_id END, "
+                    "  file_key, file_id, size_bytes, checksum, download_url "
+                    "FROM files"
+                ),
+                primary_key=("record_id", "file_key"),
+            )
+
+        if _has_bare("chunks", "entity_id", extra="AND entity_type = 'records'"):
+            _ctas_swap(
+                table="chunks",
+                columns=[
+                    ("chunk_id", "TEXT PRIMARY KEY"),
+                    ("entity_type", "TEXT NOT NULL"),
+                    ("entity_id", "TEXT NOT NULL"),
+                    ("chunk_index", "INTEGER NOT NULL"),
+                    ("text", "TEXT NOT NULL"),
+                    ("token_count", "INTEGER NOT NULL"),
+                    ("vector_id", "TEXT NOT NULL"),
+                    (
+                        "embedded_at",
+                        "TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP",
+                    ),
+                ],
+                select=(
+                    "SELECT chunk_id, entity_type, "
+                    "  CASE WHEN entity_type = 'records' "
+                    "       AND entity_id NOT LIKE 'https://%' "
+                    f"       THEN '{record_prefix}' || entity_id "
+                    "       ELSE entity_id END, "
+                    "  chunk_index, text, token_count, vector_id, embedded_at "
+                    "FROM chunks"
+                ),
+                primary_key=None,  # chunk_id PK is inline above
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_chunks_entity "
+                "ON chunks (entity_type, entity_id)",
+            )
 
     def close(self) -> None:
         if self._conn is not None:
@@ -283,29 +417,46 @@ class ZenodoStore:
     def existing_record_ids(self, zenodo_ids: list[str]) -> set[str]:
         """Return the subset of `zenodo_ids` already known to the store.
 
-        Matches against either the canonical `zenodo_id` (post-redirect
-        version-record) OR the `concept_recid` (Zenodo's "all versions"
-        identifier). A discovery source typically extracts whichever ID
-        appears in the citation, so checking both prevents redundant
-        re-fetches when a paper cites the concept ID but we persisted
-        the latest version.
+        Input is a list of bare numeric ids (`18314844`) — discovery
+        sources extract those from search-result text. Internally we
+        compare against:
+
+        - `records.zenodo_id`, which post-IRI-migration is the URL form
+          `https://zenodo.org/records/18314844` — so we promote the
+          input before SELECT.
+        - `records.concept_recid`, which stays a bare numeric id.
+
+        Returned set is in the original bare-id shape so callers can
+        diff against their own bare-id discovery set.
         """
         if not zenodo_ids:
             return set()
+        from src.index.zenodo.iri import parse_record_id, record_iri  # noqa: PLC0415
+
+        iri_form = [record_iri(z) for z in zenodo_ids]
         placeholders = ",".join(["?"] * len(zenodo_ids))
         cur = self.connect().execute(
             f"SELECT zenodo_id FROM records WHERE zenodo_id IN ({placeholders}) "
             f"UNION "
             f"SELECT concept_recid FROM records "
             f"WHERE concept_recid IN ({placeholders})",
-            [*zenodo_ids, *zenodo_ids],
+            [*iri_form, *zenodo_ids],
         )
-        return {str(r[0]) for r in cur.fetchall() if r[0] is not None}
+        found: set[str] = set()
+        for (value,) in cur.fetchall():
+            if value is None:
+                continue
+            bare = parse_record_id(str(value))
+            if bare:
+                found.add(bare)
+        return found
 
     def fetch_record(self, zenodo_id: str) -> dict[str, Any] | None:
+        from src.index.zenodo.iri import record_iri  # noqa: PLC0415
+
         cur = self.connect().execute(
             "SELECT * FROM records WHERE zenodo_id = ?",
-            [zenodo_id],
+            [record_iri(zenodo_id)],
         )
         row = cur.fetchone()
         if row is None:

--- a/src/index/zenodo/storage/schema.sql
+++ b/src/index/zenodo/storage/schema.sql
@@ -87,3 +87,49 @@ CREATE INDEX IF NOT EXISTS idx_creators_orcid      ON creators (orcid);
 CREATE INDEX IF NOT EXISTS idx_chunks_entity       ON chunks (entity_type, entity_id);
 CREATE INDEX IF NOT EXISTS idx_record_creators_ck  ON record_creators (creator_key);
 CREATE INDEX IF NOT EXISTS idx_record_comm_cid     ON record_communities (community_id);
+
+-- One-shot IRI migration. Pre-existing rows used bare numeric ids
+-- (records.zenodo_id) and bare slugs (communities.community_id); new
+-- ingest writes IRI form. The UPDATEs below converge every legacy row
+-- to the canonical IRI; each clause is idempotent because the WHERE
+-- filter ('LIKE') matches zero rows on re-runs.
+
+-- records.zenodo_id: '18314844' → 'https://zenodo.org/records/18314844'
+UPDATE records
+   SET zenodo_id = 'https://zenodo.org/records/' || zenodo_id
+ WHERE zenodo_id NOT LIKE 'https://%';
+
+-- records.primary_community_id: 'epfl' → 'https://zenodo.org/communities/epfl'
+UPDATE records
+   SET primary_community_id = 'https://zenodo.org/communities/' || primary_community_id
+ WHERE primary_community_id IS NOT NULL
+   AND primary_community_id NOT LIKE 'https://%';
+
+-- records.community_ids JSON list — promote each element. DuckDB's
+-- json_transform can't easily rewrite list elements, so we rebuild
+-- the JSON array client-side via list_transform.
+UPDATE records
+   SET community_ids = (
+       SELECT to_json(list_transform(
+           CAST(community_ids AS VARCHAR[]),
+           x -> CASE WHEN x LIKE 'https://%'
+                     THEN x
+                     ELSE 'https://zenodo.org/communities/' || x
+                END
+       ))
+   )
+ WHERE community_ids IS NOT NULL
+   AND CAST(community_ids AS VARCHAR) LIKE '%"%"%'  -- non-empty list
+   AND CAST(community_ids AS VARCHAR) NOT LIKE '%"https://%';  -- has bare slugs
+
+-- communities.community_id: 'epfl' → 'https://zenodo.org/communities/epfl'
+UPDATE communities
+   SET community_id = 'https://zenodo.org/communities/' || community_id
+ WHERE community_id NOT LIKE 'https://%';
+
+-- NOTE: Link table FK rewrites (record_creators, record_communities,
+-- files, chunks.entity_id) are NOT handled here — DuckDB's index
+-- maintenance chokes on the bulk UPDATE for large tables
+-- (~24k record_creators rows hits "Failed to delete all rows from
+-- index"). Those migrations live in `duckdb_store.py::bootstrap()`,
+-- which uses a CTAS-swap idiom that sidesteps the bug.

--- a/tests/index/zenodo/test_iri.py
+++ b/tests/index/zenodo/test_iri.py
@@ -1,0 +1,229 @@
+"""Tests for Zenodo IRI helpers + the bootstrap CTAS-swap migration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from src.index.zenodo.iri import (
+    community_iri,
+    parse_community_slug,
+    parse_record_id,
+    record_iri,
+)
+from src.index.zenodo.storage.duckdb_store import ZenodoStore
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_record_iri_promotes_bare_id():
+    assert record_iri("18314844") == "https://zenodo.org/records/18314844"
+
+
+def test_record_iri_idempotent_on_iri_input():
+    iri = "https://zenodo.org/records/18314844"
+    assert record_iri(iri) == iri
+    # Trailing slash stripped for hygiene.
+    assert record_iri(iri + "/") == iri
+
+
+def test_community_iri_promotes_bare_slug():
+    assert community_iri("epfl") == "https://zenodo.org/communities/epfl"
+
+
+def test_community_iri_idempotent():
+    iri = "https://zenodo.org/communities/eesd_at_epfl"
+    assert community_iri(iri) == iri
+    assert community_iri(iri + "/") == iri
+
+
+def test_parse_round_trip():
+    assert parse_record_id("https://zenodo.org/records/123") == "123"
+    assert parse_record_id("123") == "123"
+    assert parse_record_id("") is None
+    assert parse_community_slug("https://zenodo.org/communities/epfl") == "epfl"
+    assert parse_community_slug("epfl") == "epfl"
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap migration end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _seed_legacy_db(db_path: Path) -> None:
+    """Seed a DB with the pre-migration bare-id shape."""
+    schema = (
+        Path(__file__).resolve().parents[3]
+        / "src" / "index" / "zenodo" / "storage" / "schema.sql"
+    ).read_text(encoding="utf-8")
+    conn = duckdb.connect(str(db_path))
+    conn.execute(schema)
+    conn.execute(
+        "INSERT INTO records (zenodo_id, concept_recid, title, community_ids, primary_community_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            "18314844",
+            "18314843",
+            "Test record",
+            json.dumps(["epfl", "eesd_at_epfl"]),
+            "epfl",
+        ],
+    )
+    conn.execute(
+        "INSERT INTO records (zenodo_id, concept_recid, title, community_ids) "
+        "VALUES (?, ?, ?, ?)",
+        ["19845281", "6594482", "Another", json.dumps(["epfl"])],
+    )
+    conn.execute(
+        "INSERT INTO communities (community_id, title) VALUES "
+        "('epfl', 'EPFL'), ('eesd_at_epfl', 'EESD at EPFL')",
+    )
+    # Multiple creators per record to exercise the link table at depth.
+    conn.executemany(
+        "INSERT INTO record_creators VALUES (?, ?, ?)",
+        [
+            ("18314844", "https://orcid.org/0000-0002-1234-5678", 0),
+            ("18314844", "name:foo-bar", 1),
+            ("19845281", "https://orcid.org/0000-0003-9999-0000", 0),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO record_communities VALUES (?, ?)",
+        [
+            ("18314844", "epfl"),
+            ("18314844", "eesd_at_epfl"),
+            ("19845281", "epfl"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO files (record_id, file_key, file_id) VALUES (?, ?, ?)",
+        [
+            ("18314844", "data.csv", "f1"),
+            ("18314844", "readme.md", "f2"),
+            ("19845281", "model.pkl", "f3"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO chunks (chunk_id, entity_type, entity_id, chunk_index, text, token_count, vector_id) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("c1", "records", "18314844", 0, "chunk 1", 5, "v1"),
+            ("c2", "records", "18314844", 1, "chunk 2", 5, "v2"),
+            ("c3", "records", "19845281", 0, "chunk 3", 5, "v3"),
+        ],
+    )
+    conn.close()
+
+
+def test_bootstrap_migrates_every_pk_and_fk_in_lockstep(tmp_path: Path):
+    db_path = tmp_path / "zenodo.duckdb"
+    _seed_legacy_db(db_path)
+
+    store = ZenodoStore(db_path)
+    store.bootstrap()
+    conn = store.connect()
+
+    # All PKs / FKs carry IRIs.
+    bare_records = conn.execute(
+        "SELECT COUNT(*) FROM records WHERE zenodo_id NOT LIKE 'https://%'",
+    ).fetchone()[0]
+    bare_comms = conn.execute(
+        "SELECT COUNT(*) FROM communities WHERE community_id NOT LIKE 'https://%'",
+    ).fetchone()[0]
+    bare_rc = conn.execute(
+        "SELECT COUNT(*) FROM record_creators WHERE record_id NOT LIKE 'https://%'",
+    ).fetchone()[0]
+    bare_rcom = conn.execute(
+        "SELECT COUNT(*) FROM record_communities WHERE record_id NOT LIKE 'https://%' "
+        "OR community_id NOT LIKE 'https://%'",
+    ).fetchone()[0]
+    bare_files = conn.execute(
+        "SELECT COUNT(*) FROM files WHERE record_id NOT LIKE 'https://%'",
+    ).fetchone()[0]
+    bare_chunks = conn.execute(
+        "SELECT COUNT(*) FROM chunks "
+        "WHERE entity_type = 'records' AND entity_id NOT LIKE 'https://%'",
+    ).fetchone()[0]
+
+    assert bare_records == 0
+    assert bare_comms == 0
+    assert bare_rc == 0
+    assert bare_rcom == 0
+    assert bare_files == 0
+    assert bare_chunks == 0
+
+    # primary_community_id + community_ids JSON also rewritten.
+    pri = conn.execute(
+        "SELECT primary_community_id FROM records WHERE zenodo_id = "
+        "  'https://zenodo.org/records/18314844'",
+    ).fetchone()[0]
+    cids = conn.execute(
+        "SELECT community_ids FROM records WHERE zenodo_id = "
+        "  'https://zenodo.org/records/18314844'",
+    ).fetchone()[0]
+    assert pri == "https://zenodo.org/communities/epfl"
+    parsed = json.loads(cids) if isinstance(cids, str) else cids
+    assert parsed == [
+        "https://zenodo.org/communities/epfl",
+        "https://zenodo.org/communities/eesd_at_epfl",
+    ]
+
+    # Row counts preserved end-to-end.
+    assert conn.execute("SELECT COUNT(*) FROM record_creators").fetchone()[0] == 3
+    assert conn.execute("SELECT COUNT(*) FROM files").fetchone()[0] == 3
+    assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 3
+
+    store.close()
+
+
+def test_bootstrap_is_idempotent_after_migration(tmp_path: Path):
+    db_path = tmp_path / "zenodo.duckdb"
+    _seed_legacy_db(db_path)
+
+    # First bootstrap does the work.
+    store = ZenodoStore(db_path)
+    store.bootstrap()
+    store.close()
+
+    # Subsequent bootstraps must be no-ops — no rows change.
+    for _ in range(3):
+        store = ZenodoStore(db_path)
+        store.bootstrap()
+        store.close()
+
+    conn = duckdb.connect(str(db_path), read_only=True)
+    # All the canonical-IRI invariants still hold.
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM record_creators "
+            "WHERE record_id NOT LIKE 'https://%'",
+        ).fetchone()[0]
+        == 0
+    )
+    assert conn.execute("SELECT COUNT(*) FROM record_creators").fetchone()[0] == 3
+    conn.close()
+
+
+def test_existing_record_ids_handles_iri_form(tmp_path: Path):
+    """`existing_record_ids([bare])` should still return bare for downstream diffing."""
+    db_path = tmp_path / "zenodo.duckdb"
+    _seed_legacy_db(db_path)
+
+    store = ZenodoStore(db_path)
+    store.bootstrap()  # migrates to IRI form
+
+    # Caller passes bare numeric ids (discovery sources extract those).
+    found = store.existing_record_ids(["18314844", "99999999", "6594482"])
+    store.close()
+
+    # The two seeded records are present; the bogus one isn't.
+    # 6594482 is a concept_recid of "19845281", so it should also match.
+    assert "18314844" in found
+    assert "6594482" in found
+    assert "99999999" not in found


### PR DESCRIPTION
Follow-up to #68 (communities IRI). Zenodo is the canary catalog you wanted to test the new convention on — this PR converts every PK and FK in the Zenodo index to its canonical landing-page URL:

| Table.column | Before | After |
|---|---|---|
| `records.zenodo_id` | `18314844` | `https://zenodo.org/records/18314844` |
| `records.primary_community_id` | `epfl` | `https://zenodo.org/communities/epfl` |
| `records.community_ids` (JSON list) | `["epfl"]` | `["https://zenodo.org/communities/epfl"]` |
| `communities.community_id` | `epfl` | `https://zenodo.org/communities/epfl` |
| `record_creators.record_id` | `18314844` | IRI |
| `record_communities.{record_id, community_id}` | bare | IRI (both) |
| `files.record_id` | `18314844` | IRI |
| `chunks.entity_id` (where `entity_type='records'`) | `18314844` | IRI |
| `creators.creator_key` | unchanged | unchanged (ORCID rows already canonical; `name:<slug>` is opaque-synthetic, no real URL) |

## Helpers

New `src/index/zenodo/iri.py`:
- `record_iri(zenodo_id)` / `community_iri(slug)` — idempotent, strip trailing slash.
- `parse_record_id(iri_or_bare)` / `parse_community_slug(...)` — inverses for callers that need the bare form.

## Ingest

- `ingest/records.py::_project_record` and `_project_communities` emit IRIs from the first crawl.
- `crawling_community` (a bare slug arg) is promoted before it lands in `primary_community_id`.
- The community-metadata bootstrap loop also writes the IRI.

`storage/duckdb_store.py::existing_record_ids` keeps its bare-id input contract (discovery sources extract bare numerics from citation text) but promotes to IRI before the SELECT, then strips back to bare for the returned set so consumers don't see the change.

## Migration (the interesting bit)

Two-phase in `bootstrap()`:

1. **`schema.sql`** runs idempotent UPDATEs for the small single-column rewrites: `records.zenodo_id`, `records.primary_community_id`, `records.community_ids` JSON list, `communities.community_id`. The JSON rewrite uses `list_transform` on the parsed array.

2. **`_migrate_link_tables_to_iri`** (Python helper called from `bootstrap()`) handles the link / chunk tables via a CTAS-swap idiom: `CREATE TABLE __migrate + INSERT + DROP + RENAME`. Each step checks for bare-id rows first and is a no-op when everything is already migrated.

   The reason CTAS, not UPDATE: a plain `UPDATE record_creators SET record_id = ...` on production-scale rows (~24k) trips a DuckDB index-consistency bug — `Failed to delete all rows from index. Only deleted 1971 out of 2048 rows`. We hit it on the live DB during the first migration attempt; CTAS sidesteps it by building a fresh table from scratch with IRI data and swapping the file pointer.

The live `data/index/zenodo/duckdb/zenodo.duckdb` was migrated as part of this work — **all 64,236 rows** across the affected tables now carry IRIs (verified pre-commit; 0 bare-id rows remain). On-disk DBs in other deployments converge on next `bootstrap()`.

## Test plan

- [x] 8 new tests in `tests/index/zenodo/test_iri.py`:
  - `record_iri` / `community_iri` idempotency, trailing-slash hygiene, `parse_*` round-trip.
  - End-to-end seeded legacy DB → bootstrap → every PK + FK is IRI.
  - Idempotency across 4 consecutive bootstraps; row counts unchanged.
  - `existing_record_ids([bare])` still returns bare ids post-migration.
- [x] `pytest tests/v2/ tests/index/zenodo/` — 791 passed.

## Note on stacking

This PR is independent of #66/#67/#68 (touches different files). Can merge in any order vs those.