### PR TITLE
feat(zenodo): promote stats + version + timestamps to first-class columns

### DIFF
--- a/src/index/zenodo/ingest/records.py
+++ b/src/index/zenodo/ingest/records.py
@@ -82,16 +82,42 @@ def _project_record(item: dict[str, Any]) -> dict[str, Any]:
     from src.index.zenodo.iri import record_iri  # noqa: PLC0415
 
     bare_id = str(item.get("id") or item.get("conceptrecid") or "")
+    stats = item.get("stats") if isinstance(item.get("stats"), dict) else {}
+
+    def _int(value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
     return {
         "zenodo_id": record_iri(bare_id) if bare_id else "",
         "concept_recid": str(concept_recid) if concept_recid is not None else None,
         "doi": item.get("doi") or metadata.get("doi"),
+        "concept_doi": item.get("conceptdoi"),
         "title": metadata.get("title"),
         "description": _strip_html(metadata.get("description")),
         "publication_date": _parse_publication_date(metadata.get("publication_date")),
         "resource_type": resource_type,
         "access_right": metadata.get("access_right"),
         "license_id": license_id,
+        "version": metadata.get("version"),
+        "revision": _int(item.get("revision")),
+        # Top-level lifecycle timestamps; the API returns ISO-8601 strings
+        # which DuckDB parses on insert via the column's TIMESTAMP type.
+        "created_at": item.get("created"),
+        "updated_at": item.get("updated"),
+        # Reach metrics. Concept-level totals + this-version-only breakdown.
+        "views": _int(stats.get("views")),
+        "unique_views": _int(stats.get("unique_views")),
+        "downloads": _int(stats.get("downloads")),
+        "unique_downloads": _int(stats.get("unique_downloads")),
+        "version_views": _int(stats.get("version_views")),
+        "version_unique_views": _int(stats.get("version_unique_views")),
+        "version_downloads": _int(stats.get("version_downloads")),
+        "version_unique_downloads": _int(stats.get("version_unique_downloads")),
         "keywords": metadata.get("keywords") or [],
     }
 

--- a/src/index/zenodo/storage/duckdb_store.py
+++ b/src/index/zenodo/storage/duckdb_store.py
@@ -75,6 +75,70 @@ class ZenodoStore:
                     "WHERE raw IS NOT NULL "
                     "  AND json_extract_string(raw, '$.conceptrecid') IS NOT NULL",
                 )
+            # Stats + version + timestamp columns. Added in the
+            # `feat/zenodo-stats-and-version-columns` PR; existing DBs
+            # need to ALTER TABLE before the CREATE TABLE IF NOT EXISTS
+            # in schema.sql (a no-op since the table already exists)
+            # can pick them up. Backfill from `raw` for any pre-existing
+            # rows whose new column is still NULL.
+            _ADDED_RECORD_COLUMNS: tuple[tuple[str, str, str], ...] = (
+                # (column, DDL type, JSONPath into `raw` for backfill)
+                ("concept_doi", "TEXT", "$.conceptdoi"),
+                ("version", "TEXT", "$.metadata.version"),
+                ("revision", "INTEGER", "$.revision"),
+                ("created_at", "TIMESTAMP", "$.created"),
+                ("updated_at", "TIMESTAMP", "$.updated"),
+                ("views", "BIGINT", "$.stats.views"),
+                ("unique_views", "BIGINT", "$.stats.unique_views"),
+                ("downloads", "BIGINT", "$.stats.downloads"),
+                ("unique_downloads", "BIGINT", "$.stats.unique_downloads"),
+                ("version_views", "BIGINT", "$.stats.version_views"),
+                (
+                    "version_unique_views",
+                    "BIGINT",
+                    "$.stats.version_unique_views",
+                ),
+                (
+                    "version_downloads",
+                    "BIGINT",
+                    "$.stats.version_downloads",
+                ),
+                (
+                    "version_unique_downloads",
+                    "BIGINT",
+                    "$.stats.version_unique_downloads",
+                ),
+            )
+            for col, ddl_type, json_path in _ADDED_RECORD_COLUMNS:
+                if col in cols:
+                    continue
+                conn.execute(f"ALTER TABLE records ADD COLUMN {col} {ddl_type}")
+                # Backfill from `raw`. Cast appropriately by type — DuckDB
+                # accepts TEXT for json_extract_string + autocoerces from
+                # string for the BIGINT / TIMESTAMP cases.
+                if ddl_type == "TEXT":
+                    cast_expr = (
+                        f"CAST(json_extract_string(raw, '{json_path}') AS TEXT)"
+                    )
+                elif ddl_type == "INTEGER":
+                    cast_expr = (
+                        f"TRY_CAST(json_extract_string(raw, '{json_path}') AS INTEGER)"
+                    )
+                elif ddl_type == "BIGINT":
+                    cast_expr = (
+                        f"TRY_CAST(json_extract_string(raw, '{json_path}') AS BIGINT)"
+                    )
+                elif ddl_type == "TIMESTAMP":
+                    cast_expr = (
+                        f"TRY_CAST(json_extract_string(raw, '{json_path}') AS TIMESTAMP)"
+                    )
+                else:
+                    cast_expr = f"json_extract_string(raw, '{json_path}')"
+                conn.execute(
+                    f"UPDATE records SET {col} = {cast_expr} "
+                    "WHERE raw IS NOT NULL AND "
+                    f"     json_extract_string(raw, '{json_path}') IS NOT NULL",
+                )
         conn.execute(_load_schema_sql())
         # IRI migration for the link tables — see the note at the
         # bottom of schema.sql. UPDATE on indexed bulk columns has
@@ -239,18 +303,33 @@ class ZenodoStore:
             community_ids = []
         sql = (
             "INSERT INTO records "
-            "(zenodo_id, concept_recid, doi, title, description, publication_date, "
-            " resource_type, access_right, license_id, keywords_json, "
+            "(zenodo_id, concept_recid, doi, concept_doi, title, description, "
+            " publication_date, resource_type, access_right, license_id, "
+            " version, revision, created_at, updated_at, "
+            " views, unique_views, downloads, unique_downloads, "
+            " version_views, version_unique_views, version_downloads, "
+            " version_unique_downloads, keywords_json, "
             " community_ids, primary_community_id, raw, ingested_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+            "        ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT (zenodo_id) DO UPDATE SET "
             "  concept_recid = excluded.concept_recid, "
-            "  doi = excluded.doi, title = excluded.title, "
-            "  description = excluded.description, "
+            "  doi = excluded.doi, concept_doi = excluded.concept_doi, "
+            "  title = excluded.title, description = excluded.description, "
             "  publication_date = excluded.publication_date, "
             "  resource_type = excluded.resource_type, "
             "  access_right = excluded.access_right, "
             "  license_id = excluded.license_id, "
+            "  version = excluded.version, revision = excluded.revision, "
+            "  created_at = excluded.created_at, "
+            "  updated_at = excluded.updated_at, "
+            "  views = excluded.views, unique_views = excluded.unique_views, "
+            "  downloads = excluded.downloads, "
+            "  unique_downloads = excluded.unique_downloads, "
+            "  version_views = excluded.version_views, "
+            "  version_unique_views = excluded.version_unique_views, "
+            "  version_downloads = excluded.version_downloads, "
+            "  version_unique_downloads = excluded.version_unique_downloads, "
             "  keywords_json = excluded.keywords_json, "
             "  community_ids = excluded.community_ids, "
             "  primary_community_id = COALESCE("
@@ -263,12 +342,25 @@ class ZenodoStore:
                 row["zenodo_id"],
                 row.get("concept_recid"),
                 row.get("doi"),
+                row.get("concept_doi"),
                 row.get("title"),
                 row.get("description"),
                 row.get("publication_date"),
                 row.get("resource_type"),
                 row.get("access_right"),
                 row.get("license_id"),
+                row.get("version"),
+                row.get("revision"),
+                row.get("created_at"),
+                row.get("updated_at"),
+                row.get("views"),
+                row.get("unique_views"),
+                row.get("downloads"),
+                row.get("unique_downloads"),
+                row.get("version_views"),
+                row.get("version_unique_views"),
+                row.get("version_downloads"),
+                row.get("version_unique_downloads"),
                 json.dumps(row.get("keywords") or [], ensure_ascii=False),
                 json.dumps(community_ids, ensure_ascii=False),
                 row.get("primary_community_id"),

--- a/src/index/zenodo/storage/schema.sql
+++ b/src/index/zenodo/storage/schema.sql
@@ -4,13 +4,44 @@
 CREATE TABLE IF NOT EXISTS records (
     zenodo_id          TEXT PRIMARY KEY,            -- canonical version-record ID (post-redirect)
     concept_recid      TEXT,                         -- Zenodo concept record (groups all versions)
+    -- DOIs. `doi` is the version-level DOI; `concept_doi` (Zenodo's
+    -- `conceptdoi`) resolves to "all versions" and is the citation
+    -- consumers usually want long-term. Both are nullable — older
+    -- records pre-DOI minting carry neither.
     doi                TEXT,
+    concept_doi        TEXT,
     title              TEXT,
     description        TEXT,                         -- HTML-stripped
     publication_date   DATE,
     resource_type      TEXT,                         -- e.g. publication-article, dataset, software
     access_right       TEXT,                         -- open | embargoed | restricted | closed
     license_id         TEXT,
+    -- Free-text `metadata.version` ("1.2.3", "v1", …). Distinct from
+    -- `revision` which is Zenodo's internal monotonically-increasing
+    -- counter incremented on any metadata edit.
+    version            TEXT,
+    revision           INTEGER,
+    -- Lifecycle timestamps from the Zenodo API. `created_at` is the
+    -- record's first publication; `updated_at` flips on every revision
+    -- (metadata edit, file replacement). Both come from the top-level
+    -- `created` / `updated` fields on the API payload, NOT from
+    -- `metadata.publication_date` (which is the human-set publication
+    -- date and can lag/lead the record itself).
+    created_at         TIMESTAMP,
+    updated_at         TIMESTAMP,
+    -- Aggregated reach metrics from the Zenodo `stats` sub-block.
+    -- `*_views` and `*_downloads` are total counts; the `unique_`
+    -- variants dedupe by visitor / downloader IP+UA. The non-prefixed
+    -- columns are the concept-level totals (sum across every version
+    -- of the record); `version_*` is just this specific version.
+    views              BIGINT,
+    unique_views       BIGINT,
+    downloads          BIGINT,
+    unique_downloads   BIGINT,
+    version_views      BIGINT,
+    version_unique_views BIGINT,
+    version_downloads  BIGINT,
+    version_unique_downloads BIGINT,
     keywords_json      JSON,
     -- Denormalised list of community slugs the record belongs to.
     -- Mirrors `record_communities` so consumers can filter
@@ -83,6 +114,9 @@ CREATE INDEX IF NOT EXISTS idx_records_type        ON records (resource_type);
 CREATE INDEX IF NOT EXISTS idx_records_access      ON records (access_right);
 CREATE INDEX IF NOT EXISTS idx_records_concept     ON records (concept_recid);
 CREATE INDEX IF NOT EXISTS idx_records_primary_comm ON records (primary_community_id);
+CREATE INDEX IF NOT EXISTS idx_records_updated     ON records (updated_at);
+CREATE INDEX IF NOT EXISTS idx_records_views       ON records (views);
+CREATE INDEX IF NOT EXISTS idx_records_downloads   ON records (downloads);
 CREATE INDEX IF NOT EXISTS idx_creators_orcid      ON creators (orcid);
 CREATE INDEX IF NOT EXISTS idx_chunks_entity       ON chunks (entity_type, entity_id);
 CREATE INDEX IF NOT EXISTS idx_record_creators_ck  ON record_creators (creator_key);

--- a/tests/index/zenodo/test_iri.py
+++ b/tests/index/zenodo/test_iri.py
@@ -210,6 +210,120 @@ def test_bootstrap_is_idempotent_after_migration(tmp_path: Path):
     conn.close()
 
 
+def test_bootstrap_backfills_stats_and_version_columns(tmp_path: Path):
+    """Pre-PR DB without the new columns + an existing row with `raw` →
+    bootstrap must ALTER the table, run the migration, and backfill every
+    new column from the raw API payload.
+    """
+    db_path = tmp_path / "zenodo.duckdb"
+    # Hand-craft a pre-migration table shape — only the original columns.
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE records ("
+        "  zenodo_id TEXT PRIMARY KEY, concept_recid TEXT, doi TEXT, "
+        "  title TEXT, description TEXT, publication_date DATE, "
+        "  resource_type TEXT, access_right TEXT, license_id TEXT, "
+        "  keywords_json JSON, community_ids JSON, primary_community_id TEXT, "
+        "  raw JSON, ingested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+        ")",
+    )
+    raw_payload = {
+        "id": "18314844",
+        "conceptrecid": "18314843",
+        "conceptdoi": "10.5281/zenodo.18314843",
+        "doi": "10.5281/zenodo.18314844",
+        "revision": 5,
+        "created": "2024-01-15T10:30:00+00:00",
+        "updated": "2026-02-20T09:00:00+00:00",
+        "metadata": {"title": "Test", "version": "v2.1"},
+        "stats": {
+            "views": 4242,
+            "unique_views": 3000,
+            "downloads": 128,
+            "unique_downloads": 100,
+            "version_views": 1000,
+            "version_unique_views": 750,
+            "version_downloads": 30,
+            "version_unique_downloads": 28,
+        },
+    }
+    conn.execute(
+        "INSERT INTO records (zenodo_id, concept_recid, doi, title, raw) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ["18314844", "18314843", "10.5281/zenodo.18314844", "Test",
+         json.dumps(raw_payload)],
+    )
+    # The other tables required for the link-table migration to no-op.
+    conn.execute(
+        "CREATE TABLE communities (community_id TEXT PRIMARY KEY, title TEXT, "
+        "raw JSON, ingested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+    )
+    conn.execute(
+        "CREATE TABLE record_creators (record_id TEXT, creator_key TEXT, "
+        "position INTEGER, PRIMARY KEY (record_id, creator_key))",
+    )
+    conn.execute(
+        "CREATE TABLE record_communities (record_id TEXT, community_id TEXT, "
+        "PRIMARY KEY (record_id, community_id))",
+    )
+    conn.execute(
+        "CREATE TABLE files (record_id TEXT, file_key TEXT, file_id TEXT, "
+        "size_bytes BIGINT, checksum TEXT, download_url TEXT, "
+        "PRIMARY KEY (record_id, file_key))",
+    )
+    conn.execute(
+        "CREATE TABLE creators (creator_key TEXT PRIMARY KEY, "
+        "display_name TEXT, orcid TEXT, affiliation TEXT, raw JSON, "
+        "ingested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+    )
+    conn.execute(
+        "CREATE TABLE chunks (chunk_id TEXT PRIMARY KEY, entity_type TEXT, "
+        "entity_id TEXT, chunk_index INTEGER, text TEXT, token_count INTEGER, "
+        "vector_id TEXT, embedded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+    )
+    conn.close()
+
+    store = ZenodoStore(db_path)
+    store.bootstrap()
+    conn = store.connect()
+
+    new_cols = [r[1] for r in conn.execute("PRAGMA table_info('records')").fetchall()]
+    for expected in (
+        "concept_doi", "version", "revision", "created_at", "updated_at",
+        "views", "unique_views", "downloads", "unique_downloads",
+        "version_views", "version_unique_views",
+        "version_downloads", "version_unique_downloads",
+    ):
+        assert expected in new_cols, f"new column {expected!r} missing"
+
+    row = conn.execute(
+        "SELECT concept_doi, version, revision, "
+        "       views, unique_views, downloads, unique_downloads, "
+        "       version_views, version_unique_views, "
+        "       version_downloads, version_unique_downloads, "
+        "       created_at, updated_at "
+        "FROM records WHERE zenodo_id = 'https://zenodo.org/records/18314844'",
+    ).fetchone()
+    (concept_doi, version, revision,
+     views, unique_views, downloads, unique_downloads,
+     ver_views, ver_unique_views, ver_downloads, ver_unique_downloads,
+     created_at, updated_at) = row
+    assert concept_doi == "10.5281/zenodo.18314843"
+    assert version == "v2.1"
+    assert revision == 5
+    assert views == 4242
+    assert unique_views == 3000
+    assert downloads == 128
+    assert unique_downloads == 100
+    assert ver_views == 1000
+    assert ver_unique_views == 750
+    assert ver_downloads == 30
+    assert ver_unique_downloads == 28
+    assert created_at.isoformat().startswith("2024-01-15T10:30")
+    assert updated_at.isoformat().startswith("2026-02-20T09:00")
+    store.close()
+
+
 def test_existing_record_ids_handles_iri_form(tmp_path: Path):
     """`existing_record_ids([bare])` should still return bare for downstream diffing."""
     db_path = tmp_path / "zenodo.duckdb"


### PR DESCRIPTION
**Stacked on #69.** Merge #69 first; this PR's base auto-rebases to develop after.

Zenodo's `/api/records` payload carries far more than what we kept in DuckDB. This PR pulls the high-value bits out of `raw` and into queryable columns so consumers don't need to `json_extract_string` in every dashboard query.

## New columns on `records`

| Column | Source | Notes |
|---|---|---|
| `concept_doi` | `conceptdoi` top-level | "All versions" DOI — the long-term citation |
| `version` | `metadata.version` | Free-text (`"1.2.3"`, `"v1"`) |
| `revision` | `revision` top-level | Zenodo's monotonic internal edit counter — distinct from `version` |
| `created_at` | `created` top-level | First publication of the record |
| `updated_at` | `updated` top-level | Flips on any revision / file replacement. **Indexed.** |
| `views` | `stats.views` | Concept-level total (sum across every version). **Indexed.** |
| `unique_views` | `stats.unique_views` | Visitor-deduped |
| `downloads` | `stats.downloads` | Concept-level total. **Indexed.** |
| `unique_downloads` | `stats.unique_downloads` | Downloader-deduped |
| `version_views` | `stats.version_views` | This version only |
| `version_unique_views` | `stats.version_unique_views` | This version only |
| `version_downloads` | `stats.version_downloads` | This version only |
| `version_unique_downloads` | `stats.version_unique_downloads` | This version only |

## Migration

`bootstrap()` runs `ALTER TABLE records ADD COLUMN <name> <type>` for each missing column (per-column existence check via `PRAGMA table_info`), then immediately backfills from the existing `raw` JSON via `TRY_CAST(json_extract_string(raw, '<path>') AS <type>)`. Existing deployments converge automatically on next open — no operator action.

**Live DB result.** All 6,758 rows in `data/index/zenodo/duckdb/zenodo.duckdb` were backfilled across all 13 new columns. Top-viewed records:

```
ultralytics/yolov5: v7.0 - YOLOv5 SOTA Realtime Instance Segmentation   1,336,847
Scientific colour maps                                                     152,939
pandas-dev/pandas: Pandas                                                  120,956
pandas-dev/pandas: Pandas 1.4.1                                            120,956
python-pillow/Pillow 8.0.1                                                 104,194
```

## Ingest

`_project_record` emits every new field; `upsert_record` writes them with a matching ON CONFLICT clause so re-ingests update the metrics in place (which is what you want — `views` should advance over time).

## Test plan

- [x] New `test_bootstrap_backfills_stats_and_version_columns`: builds a pre-PR table shape with one record carrying a synthetic `raw` payload, bootstraps, asserts every new column got both the ALTER and the JSON-derived value.
- [x] `pytest tests/v2/ tests/index/zenodo/` — 792 passed (was 791; +1 backfill test).