### PR TITLE
feat(zenodo): canonical doi.org URL for doi + concept_doi

### DIFF
--- a/src/index/zenodo/ingest/records.py
+++ b/src/index/zenodo/ingest/records.py
@@ -79,10 +79,15 @@ def _project_record(item: dict[str, Any]) -> dict[str, Any]:
     else:
         resource_type = str(resource_type_block) if resource_type_block else None
     concept_recid = item.get("conceptrecid")
-    from src.index.zenodo.iri import record_iri  # noqa: PLC0415
+    from src.index.zenodo.iri import doi_iri, record_iri  # noqa: PLC0415
 
     bare_id = str(item.get("id") or item.get("conceptrecid") or "")
     stats = item.get("stats") if isinstance(item.get("stats"), dict) else {}
+
+    def _doi_url(value: Any) -> str | None:
+        if not isinstance(value, str) or not value.strip():
+            return None
+        return doi_iri(value)
 
     def _int(value: Any) -> int | None:
         if value is None:
@@ -95,8 +100,8 @@ def _project_record(item: dict[str, Any]) -> dict[str, Any]:
     return {
         "zenodo_id": record_iri(bare_id) if bare_id else "",
         "concept_recid": str(concept_recid) if concept_recid is not None else None,
-        "doi": item.get("doi") or metadata.get("doi"),
-        "concept_doi": item.get("conceptdoi"),
+        "doi": _doi_url(item.get("doi") or metadata.get("doi")),
+        "concept_doi": _doi_url(item.get("conceptdoi")),
         "title": metadata.get("title"),
         "description": _strip_html(metadata.get("description")),
         "publication_date": _parse_publication_date(metadata.get("publication_date")),

--- a/src/index/zenodo/iri.py
+++ b/src/index/zenodo/iri.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 _RECORD_PREFIX = "https://zenodo.org/records/"
 _COMMUNITY_PREFIX = "https://zenodo.org/communities/"
+_DOI_PREFIX = "https://doi.org/"
 
 
 def record_iri(zenodo_id: str) -> str:
@@ -62,9 +63,43 @@ def parse_community_slug(iri_or_bare: str) -> str | None:
     return s
 
 
+def doi_iri(doi: str) -> str:
+    """`10.5281/zenodo.18314844` → `https://doi.org/10.5281/zenodo.18314844`.
+
+    Idempotent. Tolerates the legacy `doi:` scheme prefix and an existing
+    `https://dx.doi.org/...` form.
+    """
+    s = str(doi or "").strip()
+    if not s:
+        return s
+    if s.startswith("https://dx.doi.org/"):
+        s = _DOI_PREFIX + s[len("https://dx.doi.org/") :]
+    if s.startswith(_DOI_PREFIX):
+        return s.rstrip("/")
+    if s.lower().startswith("doi:"):
+        s = s[len("doi:") :]
+    return f"{_DOI_PREFIX}{s}"
+
+
+def parse_doi(iri_or_bare: str) -> str | None:
+    """Inverse of `doi_iri`. Returns the bare DOI ("10.…"), or None."""
+    s = str(iri_or_bare or "").strip()
+    if not s:
+        return None
+    if s.startswith(_DOI_PREFIX):
+        return s[len(_DOI_PREFIX) :].rstrip("/") or None
+    if s.startswith("https://dx.doi.org/"):
+        return s[len("https://dx.doi.org/") :].rstrip("/") or None
+    if s.lower().startswith("doi:"):
+        return s[len("doi:") :].rstrip("/") or None
+    return s
+
+
 __all__ = [
     "community_iri",
+    "doi_iri",
     "parse_community_slug",
+    "parse_doi",
     "parse_record_id",
     "record_iri",
 ]

--- a/src/index/zenodo/storage/duckdb_store.py
+++ b/src/index/zenodo/storage/duckdb_store.py
@@ -145,6 +145,49 @@ class ZenodoStore:
         # tripped DuckDB internal index errors on tables this size,
         # so we drop-and-rebuild via CTAS.
         self._migrate_link_tables_to_iri()
+        # DOIs → canonical doi.org URL form. Idempotent.
+        self._migrate_dois_to_url()
+
+    def _migrate_dois_to_url(self) -> None:
+        """Promote `records.doi` / `records.concept_doi` to the
+        `https://doi.org/<bare>` URL form. Idempotent — rows already in
+        URL form match no WHERE clause.
+        """
+        conn = self.connect()
+        # Detect schema readiness — `concept_doi` was added by the
+        # stats-and-version PR; older DBs without it skip silently.
+        cols = {
+            r[1] for r in conn.execute("PRAGMA table_info('records')").fetchall()
+        }
+        if "doi" in cols:
+            conn.execute(
+                "UPDATE records "
+                "   SET doi = 'https://doi.org/' || doi "
+                " WHERE doi IS NOT NULL "
+                "   AND doi NOT LIKE 'https://doi.org/%' "
+                "   AND doi NOT LIKE 'https://dx.doi.org/%'",
+            )
+            # Normalise the legacy `dx.doi.org` host while we're here.
+            conn.execute(
+                "UPDATE records "
+                "   SET doi = 'https://doi.org/' || "
+                "             SUBSTRING(doi, LENGTH('https://dx.doi.org/') + 1) "
+                " WHERE doi LIKE 'https://dx.doi.org/%'",
+            )
+        if "concept_doi" in cols:
+            conn.execute(
+                "UPDATE records "
+                "   SET concept_doi = 'https://doi.org/' || concept_doi "
+                " WHERE concept_doi IS NOT NULL "
+                "   AND concept_doi NOT LIKE 'https://doi.org/%' "
+                "   AND concept_doi NOT LIKE 'https://dx.doi.org/%'",
+            )
+            conn.execute(
+                "UPDATE records "
+                "   SET concept_doi = 'https://doi.org/' || "
+                "             SUBSTRING(concept_doi, LENGTH('https://dx.doi.org/') + 1) "
+                " WHERE concept_doi LIKE 'https://dx.doi.org/%'",
+            )
 
     def _migrate_link_tables_to_iri(self) -> None:
         """CTAS-swap link/chunk tables with `record_id`/`entity_id` →

--- a/tests/index/zenodo/test_iri.py
+++ b/tests/index/zenodo/test_iri.py
@@ -10,7 +10,9 @@ import pytest
 
 from src.index.zenodo.iri import (
     community_iri,
+    doi_iri,
     parse_community_slug,
+    parse_doi,
     parse_record_id,
     record_iri,
 )
@@ -49,6 +51,155 @@ def test_parse_round_trip():
     assert parse_record_id("") is None
     assert parse_community_slug("https://zenodo.org/communities/epfl") == "epfl"
     assert parse_community_slug("epfl") == "epfl"
+
+
+def test_doi_iri_promotes_bare_doi():
+    assert doi_iri("10.5281/zenodo.18314844") == (
+        "https://doi.org/10.5281/zenodo.18314844"
+    )
+
+
+def test_doi_iri_is_idempotent_and_strips_trailing_slash():
+    iri = "https://doi.org/10.5281/zenodo.18314844"
+    assert doi_iri(iri) == iri
+    assert doi_iri(iri + "/") == iri
+
+
+def test_doi_iri_normalises_dx_doi_org_legacy_host():
+    """Older ingest paths sometimes emit `https://dx.doi.org/…` — promote
+    to the canonical `https://doi.org/…` host.
+    """
+    legacy = "https://dx.doi.org/10.1234/abcd"
+    assert doi_iri(legacy) == "https://doi.org/10.1234/abcd"
+
+
+def test_doi_iri_strips_doi_scheme_prefix():
+    assert doi_iri("doi:10.1234/abcd") == "https://doi.org/10.1234/abcd"
+    assert doi_iri("DOI:10.1234/abcd") == "https://doi.org/10.1234/abcd"
+
+
+def test_parse_doi_round_trip():
+    assert parse_doi("https://doi.org/10.5281/zenodo.123") == "10.5281/zenodo.123"
+    assert parse_doi("https://dx.doi.org/10.5281/zenodo.123") == "10.5281/zenodo.123"
+    assert parse_doi("doi:10.1234/abcd") == "10.1234/abcd"
+    assert parse_doi("10.1234/abcd") == "10.1234/abcd"
+    assert parse_doi("") is None
+
+
+def test_bootstrap_migrates_dois_to_url_form(tmp_path: Path):
+    """Pre-PR rows carry bare DOI / legacy dx.doi.org host → bootstrap
+    rewrites both to the canonical `https://doi.org/…` form.
+    """
+    db_path = tmp_path / "zenodo.duckdb"
+    # Pre-PR table shape: original columns only (no concept_doi yet —
+    # exercise the case where the new ALTER + DOI migration both fire
+    # in the same bootstrap pass).
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE records ("
+        "  zenodo_id TEXT PRIMARY KEY, concept_recid TEXT, doi TEXT, "
+        "  title TEXT, description TEXT, publication_date DATE, "
+        "  resource_type TEXT, access_right TEXT, license_id TEXT, "
+        "  keywords_json JSON, community_ids JSON, primary_community_id TEXT, "
+        "  raw JSON, ingested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+        ")",
+    )
+    conn.executemany(
+        "INSERT INTO records (zenodo_id, doi, title, raw) VALUES (?, ?, ?, ?)",
+        [
+            (
+                "https://zenodo.org/records/A",
+                "10.5281/zenodo.A",
+                "bare",
+                json.dumps({"id": "A", "conceptdoi": "10.5281/zenodo.X"}),
+            ),
+            (
+                "https://zenodo.org/records/B",
+                "https://dx.doi.org/10.5281/zenodo.B",
+                "legacy dx host",
+                json.dumps({"id": "B"}),
+            ),
+            (
+                "https://zenodo.org/records/C",
+                "https://doi.org/10.5281/zenodo.C",
+                "already url",
+                json.dumps({"id": "C"}),
+            ),
+            (
+                "https://zenodo.org/records/D",
+                None,
+                "no doi at all",
+                json.dumps({"id": "D"}),
+            ),
+        ],
+    )
+    # Tables the link-table migration touches must exist; empty is fine.
+    for ddl in (
+        "CREATE TABLE communities (community_id TEXT PRIMARY KEY)",
+        "CREATE TABLE record_creators (record_id TEXT, creator_key TEXT, position INTEGER, PRIMARY KEY (record_id, creator_key))",
+        "CREATE TABLE record_communities (record_id TEXT, community_id TEXT, PRIMARY KEY (record_id, community_id))",
+        "CREATE TABLE files (record_id TEXT, file_key TEXT, file_id TEXT, size_bytes BIGINT, checksum TEXT, download_url TEXT, PRIMARY KEY (record_id, file_key))",
+        "CREATE TABLE creators (creator_key TEXT PRIMARY KEY, display_name TEXT, orcid TEXT, affiliation TEXT, raw JSON, ingested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+        "CREATE TABLE chunks (chunk_id TEXT PRIMARY KEY, entity_type TEXT, entity_id TEXT, chunk_index INTEGER, text TEXT, token_count INTEGER, vector_id TEXT, embedded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+    ):
+        conn.execute(ddl)
+    conn.close()
+
+    store = ZenodoStore(db_path)
+    store.bootstrap()
+    conn = store.connect()
+
+    rows = {
+        zid: (doi, cdoi)
+        for zid, doi, cdoi in conn.execute(
+            "SELECT zenodo_id, doi, concept_doi FROM records",
+        ).fetchall()
+    }
+    # Every populated DOI is now the canonical URL form.
+    assert rows["https://zenodo.org/records/A"][0] == "https://doi.org/10.5281/zenodo.A"
+    assert rows["https://zenodo.org/records/B"][0] == "https://doi.org/10.5281/zenodo.B"
+    assert rows["https://zenodo.org/records/C"][0] == "https://doi.org/10.5281/zenodo.C"
+    # NULL DOIs stay NULL (no surprise rewrite).
+    assert rows["https://zenodo.org/records/D"][0] is None
+    # concept_doi backfilled from `raw` (record A had `conceptdoi`) and
+    # is also in URL form.
+    assert rows["https://zenodo.org/records/A"][1] == "https://doi.org/10.5281/zenodo.X"
+    assert rows["https://zenodo.org/records/B"][1] is None
+    store.close()
+
+
+def test_doi_migration_is_idempotent(tmp_path: Path):
+    """Bootstrap N times; URLs stay URLs and no double-prefixing happens."""
+    db_path = tmp_path / "zenodo.duckdb"
+    conn = duckdb.connect(str(db_path))
+    schema = (
+        Path(__file__).resolve().parents[3]
+        / "src" / "index" / "zenodo" / "storage" / "schema.sql"
+    ).read_text(encoding="utf-8")
+    conn.execute(schema)
+    conn.execute(
+        "INSERT INTO records (zenodo_id, doi, concept_doi, title, raw) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            "https://zenodo.org/records/A",
+            "10.5281/zenodo.A",  # bare on entry
+            "10.5281/zenodo.X",
+            "test",
+            json.dumps({"id": "A"}),
+        ],
+    )
+    conn.close()
+
+    for _ in range(3):
+        store = ZenodoStore(db_path)
+        store.bootstrap()
+        store.close()
+
+    conn = duckdb.connect(str(db_path), read_only=True)
+    doi, cdoi = conn.execute("SELECT doi, concept_doi FROM records").fetchone()
+    conn.close()
+    assert doi == "https://doi.org/10.5281/zenodo.A"
+    assert cdoi == "https://doi.org/10.5281/zenodo.X"
 
 
 # ---------------------------------------------------------------------------
@@ -308,7 +459,9 @@ def test_bootstrap_backfills_stats_and_version_columns(tmp_path: Path):
      views, unique_views, downloads, unique_downloads,
      ver_views, ver_unique_views, ver_downloads, ver_unique_downloads,
      created_at, updated_at) = row
-    assert concept_doi == "10.5281/zenodo.18314843"
+    # `concept_doi` is promoted to the canonical URL form by the
+    # DOI migration that runs as part of bootstrap.
+    assert concept_doi == "https://doi.org/10.5281/zenodo.18314843"
     assert version == "v2.1"
     assert revision == 5
     assert views == 4242


### PR DESCRIPTION
**Stacked on #70 → #69 → develop.** Merge order: #69 → #70 → #71.

Promotes both DOI columns to the dereferenceable URL form, matching the IRI convention applied to `zenodo_id` and `community_id` (#69) and the `stats`/`version` expansion (#70). Now **every** external-id column in `records` is a real URL — `doi`, `zenodo_id`, `concept_doi`, `primary_community_id` all click through to a landing page.

| Before | After |
|---|---|
| `10.5281/zenodo.18314844` | `https://doi.org/10.5281/zenodo.18314844` |
| `https://dx.doi.org/10.1234/abcd` (legacy host) | `https://doi.org/10.1234/abcd` (canonical host) |
| `doi:10.1234/abcd` | `https://doi.org/10.1234/abcd` |
| `https://doi.org/10.5281/zenodo.18314844` (already URL) | unchanged |

## Helpers (`src/index/zenodo/iri.py`)

`doi_iri()` + `parse_doi()`:
- Promotes bare DOIs to `https://doi.org/<doi>`.
- Idempotent on URL input; strips trailing slash.
- Normalises the legacy `https://dx.doi.org/<doi>` host to `doi.org`.
- Strips `doi:` scheme prefix (case-insensitive).
- `parse_doi(any_form)` round-trips back to the bare `10.…` form.

## Ingest

`_project_record` wraps both `item.get('doi')` and `item.get('conceptdoi')` through `doi_iri()` before they land in the row. Null inputs stay null (no `https://doi.org/` artefacts on records without a DOI).

## Migration

New `_migrate_dois_to_url()` step in `bootstrap()`:
- Idempotent UPDATEs for both `doi` and `concept_doi`.
- Per-column existence check so older DBs (predating `concept_doi`) are handled fine.
- Handles the legacy `dx.doi.org` host (rewrites to `doi.org`).
- Skips NULL rows.

**Live DB result.** All 6,758/6,758 `doi` values + 6,511 `concept_doi` values (out of 6,758 — some records have no concept-level DOI minted) are in `https://doi.org/…` form. Sample:

```
zenodo_id:   https://zenodo.org/records/7347926
doi:         https://doi.org/10.5281/zenodo.7347926
concept_doi: https://doi.org/10.5281/zenodo.3908559
version:     v7.0
```

## Tests

7 new tests in `tests/index/zenodo/test_iri.py`:
- `doi_iri` promotes bare → URL.
- Idempotent on URL input; trailing-slash stripped.
- Normalises `https://dx.doi.org/…`.
- Strips `doi:` scheme prefix (case-insensitive).
- `parse_doi` round-trips every form back to bare.
- Bootstrap migrates bare + dx-host + already-URL rows into one canonical form; null rows untouched.
- Idempotency across 3 consecutive bootstraps.

`pytest tests/v2/ tests/index/zenodo/` — 799 passed.

The pre-existing `test_bootstrap_backfills_stats_and_version_columns` assertion was updated to expect the URL form for `concept_doi` since the DOI migration now runs as part of the same `bootstrap()` pass.