### PR TITLE
feat(huggingface): canonical IRI for orgs / models / datasets / spaces / chunks

### DIFF
--- a/src/index/huggingface/ingest/datasets_ingest.py
+++ b/src/index/huggingface/ingest/datasets_ingest.py
@@ -89,12 +89,17 @@ def ingest_datasets(
 
 
 def _dataset_row(repo_id: str, info: object) -> dict[str, object | None]:
+    from src.index.huggingface.iri import dataset_iri, namespace_iri  # noqa: PLC0415
+
     card_data = card_data_to_dict(getattr(info, "card_data", None) or getattr(info, "cardData", None))
     tags = list(getattr(info, "tags", None) or [])
     dataset_info_payload = getattr(info, "dataset_info", None) or getattr(info, "datasetInfo", None)
+    bare_author = (
+        getattr(info, "author", None) or author_from_repo_id(repo_id)
+    )
     return {
-        "repo_id": repo_id,
-        "author": getattr(info, "author", None) or author_from_repo_id(repo_id),
+        "repo_id": dataset_iri(repo_id),
+        "author": namespace_iri(bare_author) if bare_author else None,
         "sha": getattr(info, "sha", None),
         "license": _license_from(card_data, getattr(info, "license", None)),
         "downloads": _coerce_int(getattr(info, "downloads", None)),

--- a/src/index/huggingface/ingest/models_ingest.py
+++ b/src/index/huggingface/ingest/models_ingest.py
@@ -97,11 +97,16 @@ def ingest_models(
 
 
 def _model_row(repo_id: str, info: object) -> dict[str, object | None]:
+    from src.index.huggingface.iri import model_iri, namespace_iri  # noqa: PLC0415
+
     card_data = card_data_to_dict(getattr(info, "card_data", None) or getattr(info, "cardData", None))
     tags = list(getattr(info, "tags", None) or [])
+    bare_author = (
+        getattr(info, "author", None) or author_from_repo_id(repo_id)
+    )
     return {
-        "repo_id": repo_id,
-        "author": getattr(info, "author", None) or author_from_repo_id(repo_id),
+        "repo_id": model_iri(repo_id),
+        "author": namespace_iri(bare_author) if bare_author else None,
         "sha": getattr(info, "sha", None),
         "pipeline_tag": getattr(info, "pipeline_tag", None),
         "library_name": getattr(info, "library_name", None),

--- a/src/index/huggingface/ingest/spaces_ingest.py
+++ b/src/index/huggingface/ingest/spaces_ingest.py
@@ -89,12 +89,17 @@ def ingest_spaces(
 
 
 def _space_row(repo_id: str, info: object) -> dict[str, object | None]:
+    from src.index.huggingface.iri import namespace_iri, space_iri  # noqa: PLC0415
+
     card_data = card_data_to_dict(getattr(info, "card_data", None) or getattr(info, "cardData", None))
     tags = list(getattr(info, "tags", None) or [])
     runtime = getattr(info, "runtime", None)
+    bare_author = (
+        getattr(info, "author", None) or author_from_repo_id(repo_id)
+    )
     return {
-        "repo_id": repo_id,
-        "author": getattr(info, "author", None) or author_from_repo_id(repo_id),
+        "repo_id": space_iri(repo_id),
+        "author": namespace_iri(bare_author) if bare_author else None,
         "sha": getattr(info, "sha", None),
         "sdk": getattr(info, "sdk", None) or _from_card("sdk", card_data),
         "runtime_stage": _runtime_stage(runtime),

--- a/src/index/huggingface/iri.py
+++ b/src/index/huggingface/iri.py
@@ -1,0 +1,144 @@
+"""Canonical IRI helpers for the HuggingFace index.
+
+The bare keys we used as PKs are namespace-shaped strings — `epfl-llm`
+for an org, `epfl-llm/meditron-7b` for a model. Every other catalog in
+the graph already uses real dereferenceable URLs as its `@id`, so this
+module promotes HF too. URL shapes (mirroring HF's own routing):
+
+  org / user (same URL pattern)  https://huggingface.co/<slug>
+  model                          https://huggingface.co/<author>/<name>
+  dataset                        https://huggingface.co/datasets/<author>/<name>
+  space                          https://huggingface.co/spaces/<author>/<name>
+
+No trailing slash. Helpers are idempotent and tolerate legacy `www.`
+host and trailing slashes on input.
+"""
+
+from __future__ import annotations
+
+_BASE = "https://huggingface.co/"
+_WWW = "https://www.huggingface.co/"
+_DATASETS_PREFIX = _BASE + "datasets/"
+_SPACES_PREFIX = _BASE + "spaces/"
+
+
+def _strip_base(s: str) -> str:
+    if s.startswith(_WWW):
+        return s[len(_WWW) :]
+    if s.startswith(_BASE):
+        return s[len(_BASE) :]
+    return s
+
+
+def _normalise(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    s = str(raw).strip().rstrip("/")
+    return s or None
+
+
+def namespace_iri(slug: str) -> str:
+    """`epfl-llm` → `https://huggingface.co/epfl-llm`. Covers users + orgs."""
+    s = _normalise(slug)
+    if not s:
+        return s or ""
+    if s.startswith(_BASE) or s.startswith(_WWW):
+        return _BASE + _strip_base(s).rstrip("/")
+    return _BASE + s
+
+
+def model_iri(repo_id: str) -> str:
+    """`epfl-llm/meditron-7b` → `https://huggingface.co/epfl-llm/meditron-7b`."""
+    s = _normalise(repo_id)
+    if not s:
+        return s or ""
+    bare = _strip_base(s).rstrip("/")
+    # If a caller mis-typed `datasets/...` / `spaces/...` we still
+    # produce a sane URL — but the caller probably wanted dataset_iri /
+    # space_iri instead, so just return the literal join.
+    return _BASE + bare
+
+
+def dataset_iri(repo_id: str) -> str:
+    """`epfl-llm/guidelines` → `https://huggingface.co/datasets/epfl-llm/guidelines`."""
+    s = _normalise(repo_id)
+    if not s:
+        return s or ""
+    bare = _strip_base(s).rstrip("/")
+    if bare.startswith("datasets/"):
+        return _DATASETS_PREFIX + bare[len("datasets/") :]
+    return _DATASETS_PREFIX + bare
+
+
+def space_iri(repo_id: str) -> str:
+    """`EPFL-VILAB/4M` → `https://huggingface.co/spaces/EPFL-VILAB/4M`."""
+    s = _normalise(repo_id)
+    if not s:
+        return s or ""
+    bare = _strip_base(s).rstrip("/")
+    if bare.startswith("spaces/"):
+        return _SPACES_PREFIX + bare[len("spaces/") :]
+    return _SPACES_PREFIX + bare
+
+
+def iri_for_entity_type(entity_type: str, bare: str) -> str:
+    """Dispatch on a `chunks.entity_type` discriminator value.
+
+    ``entity_type`` is one of ``model | dataset | space | org``.
+    """
+    match entity_type:
+        case "model":
+            return model_iri(bare)
+        case "dataset":
+            return dataset_iri(bare)
+        case "space":
+            return space_iri(bare)
+        case "org":
+            return namespace_iri(bare)
+    # Unknown discriminator: return as-is; safer than fabricating an URL.
+    return bare
+
+
+# --- Inverses -------------------------------------------------------------
+
+
+def parse_namespace_slug(iri_or_bare: str) -> str | None:
+    """`https://huggingface.co/epfl-llm` → `epfl-llm`. Bare input passes through."""
+    s = _normalise(iri_or_bare)
+    if not s:
+        return None
+    s = _strip_base(s)
+    # Trim repo path if caller mis-passed a full repo IRI to the namespace parser.
+    if s.startswith("datasets/"):
+        s = s[len("datasets/") :]
+    elif s.startswith("spaces/"):
+        s = s[len("spaces/") :]
+    # First path segment is the namespace.
+    return s.split("/", 1)[0] or None
+
+
+def parse_repo_id(iri_or_bare: str) -> str | None:
+    """Strip any `huggingface.co[/datasets|/spaces]` prefix from a repo IRI.
+
+    Returns the bare `<author>/<name>` form regardless of input shape.
+    """
+    s = _normalise(iri_or_bare)
+    if not s:
+        return None
+    s = _strip_base(s)
+    for prefix in ("datasets/", "spaces/"):
+        if s.startswith(prefix):
+            s = s[len(prefix) :]
+            break
+    return s or None
+
+
+__all__ = [
+    "dataset_iri",
+    "iri_for_entity_type",
+    "model_iri",
+    "namespace_iri",
+    "parse_namespace_slug",
+    "parse_repo_id",
+    "space_iri",
+]

--- a/src/index/huggingface/storage/duckdb_store.py
+++ b/src/index/huggingface/storage/duckdb_store.py
@@ -23,6 +23,24 @@ SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 ENTITY_TABLES: tuple[str, ...] = ("models", "datasets", "spaces")
 
 
+def _repo_iri_for_table(entity_table: str, repo_id: str) -> str:
+    """Promote a bare `<author>/<name>` to its canonical IRI for the table."""
+    from src.index.huggingface.iri import (  # noqa: PLC0415
+        dataset_iri,
+        model_iri,
+        space_iri,
+    )
+
+    match entity_table:
+        case "models":
+            return model_iri(repo_id)
+        case "datasets":
+            return dataset_iri(repo_id)
+        case "spaces":
+            return space_iri(repo_id)
+    return repo_id  # unknown table — pass through
+
+
 def _load_schema_sql() -> str:
     return SCHEMA_PATH.read_text(encoding="utf-8")
 
@@ -55,6 +73,152 @@ class DuckDBStore:
     def bootstrap(self) -> None:
         conn = self.connect()
         conn.execute(_load_schema_sql())
+        # Promote bare slugs / repo_ids to their canonical
+        # `https://huggingface.co/...` IRI form. Idempotent — rows
+        # already in URL shape match no WHERE clause.
+        self._migrate_to_iri_ids()
+
+    def _migrate_to_iri_ids(self) -> None:
+        """CTAS-swap each table whose PK or FK still carries bare ids.
+
+        DuckDB's `UPDATE … SET <indexed-col> = …` chokes on large indexed
+        tables (we hit it on Zenodo's 24k record_creators), so the link
+        and entity tables get a fresh table + INSERT + DROP + RENAME.
+        Each step checks for at least one bare-id row before doing
+        any work, so the migration is a no-op on already-migrated DBs.
+        """
+        conn = self.connect()
+        ns = "https://huggingface.co/"
+
+        def _table_has_bare(table: str, column: str) -> bool:
+            row = conn.execute(
+                f"SELECT 1 FROM {table} WHERE {column} IS NOT NULL "
+                f"AND {column} NOT LIKE 'https://%' LIMIT 1",
+            ).fetchone()
+            return row is not None
+
+        def _ctas_swap(
+            *, table: str, columns: list[tuple[str, str]], select: str,
+            primary_key: tuple[str, ...] | None = None,
+        ) -> None:
+            new_table = f"{table}__iri_migrate"
+            conn.execute(f"DROP TABLE IF EXISTS {new_table}")
+            col_defs = ", ".join(f"{name} {dtype}" for name, dtype in columns)
+            if primary_key:
+                col_defs += f", PRIMARY KEY ({', '.join(primary_key)})"
+            conn.execute(f"CREATE TABLE {new_table} ({col_defs})")
+            conn.execute(f"INSERT INTO {new_table} {select}")
+            conn.execute(f"DROP TABLE {table}")
+            conn.execute(f"ALTER TABLE {new_table} RENAME TO {table}")
+
+        # --- orgs.slug (PK) → IRI -------------------------------------
+        if _table_has_bare("orgs", "slug"):
+            _ctas_swap(
+                table="orgs",
+                columns=[
+                    ("slug", "TEXT NOT NULL"),
+                    ("namespace_kind", "TEXT NOT NULL DEFAULT 'org'"),
+                    ("source", "TEXT NOT NULL DEFAULT 'seed'"),
+                    ("scope", "TEXT NOT NULL"),
+                    ("fullname", "TEXT"),
+                    ("details", "TEXT"),
+                    ("avatar_url", "TEXT"),
+                    ("num_models", "BIGINT"),
+                    ("num_datasets", "BIGINT"),
+                    ("num_spaces", "BIGINT"),
+                    ("num_followers", "BIGINT"),
+                    ("raw", "JSON"),
+                    (
+                        "ingested_at",
+                        "TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP",
+                    ),
+                ],
+                select=(
+                    "SELECT "
+                    f"  CASE WHEN slug LIKE 'https://%' THEN slug ELSE '{ns}' || slug END, "
+                    "  namespace_kind, source, scope, fullname, details, avatar_url, "
+                    "  num_models, num_datasets, num_spaces, num_followers, raw, ingested_at "
+                    "FROM orgs"
+                ),
+                primary_key=("slug",),
+            )
+
+        # --- {models, datasets, spaces}.{repo_id, author} → IRI -------
+        # Each entity gets its own URL shape: models live at the namespace
+        # root, datasets under /datasets/, spaces under /spaces/. `author`
+        # is always the namespace IRI regardless of entity type.
+        entity_url_prefix = {
+            "models": ns,
+            "datasets": ns + "datasets/",
+            "spaces": ns + "spaces/",
+        }
+        for table, prefix in entity_url_prefix.items():
+            if not _table_has_bare(table, "repo_id"):
+                continue
+            cols = conn.execute(f"PRAGMA table_info('{table}')").fetchall()
+            col_specs = [(r[1], r[2]) for r in cols]  # (name, type)
+            quoted_cols = [name for name, _ in col_specs]
+            select_clause = (
+                "SELECT "
+                + ", ".join(
+                    (
+                        f"CASE WHEN {c} LIKE 'https://%' THEN {c} "
+                        f"     ELSE '{prefix}' || {c} END"
+                        if c == "repo_id"
+                        else (
+                            f"CASE WHEN {c} LIKE 'https://%' OR {c} IS NULL "
+                            f"     THEN {c} ELSE '{ns}' || {c} END"
+                            if c == "author"
+                            else c
+                        )
+                    )
+                    for c in quoted_cols
+                )
+                + f" FROM {table}"
+            )
+            # `repo_id` PK is encoded inline; other indexes get recreated
+            # by the schema run on the next bootstrap pass (the schema
+            # CREATE INDEX IF NOT EXISTS lines are no-ops on tables that
+            # don't have them yet).
+            col_defs = [
+                (name, dtype + (" PRIMARY KEY" if name == "repo_id" else ""))
+                for name, dtype in col_specs
+            ]
+            _ctas_swap(
+                table=table,
+                columns=col_defs,
+                select=select_clause,
+            )
+
+        # --- chunks.repo_id (FK) → IRI ----------------------------------
+        if _table_has_bare("chunks", "repo_id"):
+            cols = conn.execute("PRAGMA table_info('chunks')").fetchall()
+            col_specs = [(r[1], r[2]) for r in cols]
+            quoted_cols = [name for name, _ in col_specs]
+            # entity_type discriminates the URL shape per chunk row.
+            select_clause = (
+                "SELECT "
+                + ", ".join(
+                    (
+                        "CASE "
+                        f"  WHEN {c} LIKE 'https://%' THEN {c} "
+                        f"  WHEN entity_type = 'model'   THEN '{ns}' || {c} "
+                        f"  WHEN entity_type = 'dataset' THEN '{ns}datasets/' || {c} "
+                        f"  WHEN entity_type = 'space'   THEN '{ns}spaces/' || {c} "
+                        f"  WHEN entity_type = 'org'     THEN '{ns}' || {c} "
+                        f"  ELSE {c} END"
+                        if c == "repo_id"
+                        else c
+                    )
+                    for c in quoted_cols
+                )
+                + " FROM chunks"
+            )
+            col_defs = [
+                (name, dtype + (" PRIMARY KEY" if name == "chunk_id" else ""))
+                for name, dtype in col_specs
+            ]
+            _ctas_swap(table="chunks", columns=col_defs, select=select_clause)
 
     def close(self) -> None:
         if self._conn is not None:
@@ -87,6 +251,8 @@ class DuckDBStore:
         num_followers: int | None = None,
         raw: dict[str, Any] | None = None,
     ) -> None:
+        from src.index.huggingface.iri import namespace_iri  # noqa: PLC0415
+
         raw_json = json.dumps(raw, ensure_ascii=False, default=str) if raw is not None else None
         self.connect().execute(
             "INSERT INTO orgs (slug, namespace_kind, source, scope, fullname, "
@@ -106,14 +272,18 @@ class DuckDBStore:
             "raw = COALESCE(excluded.raw, orgs.raw), "
             "ingested_at = excluded.ingested_at",
             [
-                slug, namespace_kind, source, scope, fullname,
+                namespace_iri(slug), namespace_kind, source, scope, fullname,
                 details, avatar_url, num_models, num_datasets, num_spaces,
                 num_followers, raw_json, self._now(),
             ],
         )
 
     def fetch_org(self, slug: str) -> dict[str, Any] | None:
-        cur = self.connect().execute("SELECT * FROM orgs WHERE slug = ?", [slug])
+        from src.index.huggingface.iri import namespace_iri  # noqa: PLC0415
+
+        cur = self.connect().execute(
+            "SELECT * FROM orgs WHERE slug = ?", [namespace_iri(slug)],
+        )
         row = cur.fetchone()
         if row is None:
             return None
@@ -144,11 +314,14 @@ class DuckDBStore:
 
     def list_repo_titles_for_org(self, slug: str) -> dict[str, list[dict[str, Any]]]:
         """Return per-table compact repo info used to compose the org embed text."""
+        from src.index.huggingface.iri import namespace_iri  # noqa: PLC0415
+
+        author_iri = namespace_iri(slug)
         out: dict[str, list[dict[str, Any]]] = {}
         for table in ENTITY_TABLES:
             cur = self.connect().execute(
                 f"SELECT repo_id, tags, card_data FROM {table} WHERE author = ?",  # noqa: S608
-                [slug],
+                [author_iri],
             )
             cols = [d[0] for d in cur.description]
             out[table] = [dict(zip(cols, r, strict=False)) for r in cur.fetchall()]
@@ -227,6 +400,16 @@ class DuckDBStore:
         row: dict[str, Any],
         raw: dict[str, Any],
     ) -> None:
+        from src.index.huggingface.iri import namespace_iri  # noqa: PLC0415
+
+        # Normalise repo_id + author to canonical IRI form so direct
+        # callers (and unit tests) can keep passing bare ids and still
+        # land on the same storage shape as the ingest pipeline.
+        row = dict(row)
+        if row.get("repo_id"):
+            row["repo_id"] = _repo_iri_for_table(table, str(row["repo_id"]))
+        if row.get("author"):
+            row["author"] = namespace_iri(str(row["author"]))
         all_cols = (*cols, *json_cols, "raw", "ingested_at")
         placeholders = ", ".join(["?"] * len(all_cols))
         col_list = ", ".join(all_cols)
@@ -256,6 +439,8 @@ class DuckDBStore:
         token_count: int,
         vector_id: str,
     ) -> None:
+        from src.index.huggingface.iri import iri_for_entity_type  # noqa: PLC0415
+
         self.connect().execute(
             "INSERT INTO chunks "
             "(chunk_id, entity_type, repo_id, chunk_index, text, "
@@ -266,7 +451,7 @@ class DuckDBStore:
             [
                 chunk_id,
                 entity_type,
-                repo_id,
+                iri_for_entity_type(entity_type, repo_id),
                 chunk_index,
                 text,
                 token_count,
@@ -320,7 +505,7 @@ class DuckDBStore:
             return None
         cur = self.connect().execute(
             f"SELECT sha FROM {entity_table} WHERE repo_id = ?",  # noqa: S608
-            [repo_id],
+            [_repo_iri_for_table(entity_table, repo_id)],
         )
         row = cur.fetchone()
         return row[0] if row else None
@@ -330,7 +515,7 @@ class DuckDBStore:
             return None
         cur = self.connect().execute(
             f"SELECT * FROM {entity_table} WHERE repo_id = ?",  # noqa: S608
-            [repo_id],
+            [_repo_iri_for_table(entity_table, repo_id)],
         )
         row = cur.fetchone()
         if row is None:

--- a/tests/index/huggingface/test_duckdb_store.py
+++ b/tests/index/huggingface/test_duckdb_store.py
@@ -31,9 +31,13 @@ def test_upsert_model_round_trip(tmp_store):
         "base_models": ["meta-llama/Llama-2-7b"],
     }
     tmp_store.upsert_model(row, raw={"id": "epfl-llm/meditron-7b"})
+    # Callers can still pass bare ids — `fetch_repo` promotes them to
+    # the canonical IRI form internally, matching what upsert wrote.
     fetched = tmp_store.fetch_repo("models", "epfl-llm/meditron-7b")
     assert fetched is not None
-    assert fetched["author"] == "epfl-llm"
+    # The stored row is in canonical IRI shape for downstream graph consumers.
+    assert fetched["repo_id"] == "https://huggingface.co/epfl-llm/meditron-7b"
+    assert fetched["author"] == "https://huggingface.co/epfl-llm"
     assert fetched["downloads"] == 100
     assert tmp_store.count("models") == 1
 
@@ -42,7 +46,8 @@ def test_upsert_org_round_trip(tmp_store):
     tmp_store.upsert_org(slug="epfl-llm", scope="epfl")
     cur = tmp_store.connect().execute("SELECT slug, scope, source FROM orgs")
     rows = cur.fetchall()
-    assert rows == [("epfl-llm", "epfl", "seed")]
+    # Slug is stored as the canonical IRI (matches the rest of the catalog).
+    assert rows == [("https://huggingface.co/epfl-llm", "epfl", "seed")]
 
 
 def test_stream_rows_skips_already_embedded(tmp_store):
@@ -58,7 +63,10 @@ def test_stream_rows_skips_already_embedded(tmp_store):
         vector_id="cid-1",
     )
     streamed = list(tmp_store.stream_rows_for_embedding("models"))
-    assert {r["repo_id"] for r in streamed} == {"c/d"}
+    # Both upsert + upsert_chunk normalise to the canonical IRI; the
+    # JOIN on `repo_id` lines up, so only "c/d" (still unchunked) is
+    # streamed. The streamed value is the canonical URL form.
+    assert {r["repo_id"] for r in streamed} == {"https://huggingface.co/c/d"}
 
 
 def test_stream_rows_unknown_table(tmp_store):

--- a/tests/index/huggingface/test_iri.py
+++ b/tests/index/huggingface/test_iri.py
@@ -1,0 +1,230 @@
+"""Tests for HuggingFace IRI helpers + the bootstrap CTAS migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from src.index.huggingface.iri import (
+    dataset_iri,
+    iri_for_entity_type,
+    model_iri,
+    namespace_iri,
+    parse_namespace_slug,
+    parse_repo_id,
+    space_iri,
+)
+from src.index.huggingface.storage.duckdb_store import DuckDBStore
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — URL shapes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fn,bare,expected",
+    [
+        (namespace_iri, "epfl-llm", "https://huggingface.co/epfl-llm"),
+        (model_iri, "epfl-llm/meditron-7b",
+         "https://huggingface.co/epfl-llm/meditron-7b"),
+        (dataset_iri, "epfl-llm/guidelines",
+         "https://huggingface.co/datasets/epfl-llm/guidelines"),
+        (space_iri, "EPFL-VILAB/4M",
+         "https://huggingface.co/spaces/EPFL-VILAB/4M"),
+    ],
+)
+def test_iri_helpers_promote_bare_ids(fn, bare, expected):
+    assert fn(bare) == expected
+
+
+def test_iri_helpers_are_idempotent():
+    """Passing an already-IRI input should round-trip unchanged (modulo
+    trailing-slash stripping)."""
+    iri = "https://huggingface.co/datasets/epfl-llm/guidelines"
+    assert dataset_iri(iri) == iri
+    assert dataset_iri(iri + "/") == iri
+
+
+def test_iri_helpers_strip_www_host():
+    assert namespace_iri("https://www.huggingface.co/epfl-llm") == (
+        "https://huggingface.co/epfl-llm"
+    )
+
+
+def test_dataset_iri_does_not_double_prefix():
+    """Caller-passed `datasets/<author>/<name>` is recognised."""
+    assert dataset_iri("datasets/epfl-llm/guidelines") == (
+        "https://huggingface.co/datasets/epfl-llm/guidelines"
+    )
+
+
+def test_iri_for_entity_type_dispatches():
+    bare = "epfl-llm/meditron-7b"
+    assert iri_for_entity_type("model", bare) == model_iri(bare)
+    assert iri_for_entity_type("dataset", bare) == dataset_iri(bare)
+    assert iri_for_entity_type("space", bare) == space_iri(bare)
+    assert iri_for_entity_type("org", "epfl-llm") == namespace_iri("epfl-llm")
+    # Unknown discriminator passes through.
+    assert iri_for_entity_type("garbage", "x") == "x"
+
+
+def test_parse_inverses():
+    assert parse_namespace_slug("https://huggingface.co/epfl-llm") == "epfl-llm"
+    assert parse_namespace_slug("epfl-llm") == "epfl-llm"
+    assert parse_namespace_slug(
+        "https://huggingface.co/datasets/epfl-llm/guidelines",
+    ) == "epfl-llm"  # first path segment after prefix strip
+    assert parse_repo_id("https://huggingface.co/epfl-llm/meditron-7b") == (
+        "epfl-llm/meditron-7b"
+    )
+    assert parse_repo_id(
+        "https://huggingface.co/datasets/epfl-llm/guidelines",
+    ) == "epfl-llm/guidelines"
+    assert parse_repo_id(
+        "https://huggingface.co/spaces/EPFL-VILAB/4M",
+    ) == "EPFL-VILAB/4M"
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap CTAS migration
+# ---------------------------------------------------------------------------
+
+
+def _seed_legacy_hf_db(db_path: Path) -> None:
+    """Build a pre-PR-shape DB seeded with bare ids across every PK and FK."""
+    schema = (
+        Path(__file__).resolve().parents[3]
+        / "src" / "index" / "huggingface" / "storage" / "schema.sql"
+    ).read_text(encoding="utf-8")
+    conn = duckdb.connect(str(db_path))
+    conn.execute(schema)
+    conn.execute(
+        "INSERT INTO orgs (slug, namespace_kind, scope) VALUES "
+        "('epfl-llm', 'org', 'epfl'), "
+        "('caviri', 'user', 'epfl'), "
+        "('EPFL-VILAB', 'org', 'epfl')",
+    )
+    conn.execute(
+        "INSERT INTO models (repo_id, author) VALUES "
+        "('epfl-llm/meditron-7b', 'epfl-llm'), "
+        "('EPFL-VILAB/4M-7-T2I_L_CC12M', 'EPFL-VILAB')",
+    )
+    conn.execute(
+        "INSERT INTO datasets (repo_id, author) VALUES "
+        "('epfl-llm/guidelines', 'epfl-llm')",
+    )
+    conn.execute(
+        "INSERT INTO spaces (repo_id, author) VALUES "
+        "('EPFL-VILAB/4M', 'EPFL-VILAB')",
+    )
+    conn.execute(
+        "INSERT INTO chunks (chunk_id, entity_type, repo_id, chunk_index, text, "
+        "token_count, vector_id) VALUES "
+        "('c1', 'model', 'epfl-llm/meditron-7b', 0, 't', 1, 'v1'), "
+        "('c2', 'dataset', 'epfl-llm/guidelines', 0, 't', 1, 'v2'), "
+        "('c3', 'space', 'EPFL-VILAB/4M', 0, 't', 1, 'v3'), "
+        "('c4', 'org', 'epfl-llm', 0, 't', 1, 'v4')",
+    )
+    conn.close()
+
+
+def test_bootstrap_migrates_every_pk_and_fk(tmp_path: Path):
+    db_path = tmp_path / "hf.duckdb"
+    _seed_legacy_hf_db(db_path)
+
+    store = DuckDBStore(db_path)
+    store.bootstrap()
+    conn = store.connect()
+
+    # No table has any bare id left.
+    for table, column in [
+        ("orgs", "slug"),
+        ("models", "repo_id"),
+        ("models", "author"),
+        ("datasets", "repo_id"),
+        ("datasets", "author"),
+        ("spaces", "repo_id"),
+        ("spaces", "author"),
+        ("chunks", "repo_id"),
+    ]:
+        bare = conn.execute(
+            f"SELECT COUNT(*) FROM {table} "
+            f"WHERE {column} IS NOT NULL AND {column} NOT LIKE 'https://%'",
+        ).fetchone()[0]
+        assert bare == 0, f"{table}.{column}: {bare} bare-id row(s) remain"
+
+    # Each catalog got the right URL shape.
+    assert conn.execute(
+        "SELECT slug FROM orgs WHERE namespace_kind = 'user'",
+    ).fetchone()[0] == "https://huggingface.co/caviri"
+
+    model_id = conn.execute(
+        "SELECT repo_id FROM models WHERE repo_id LIKE '%meditron-7b'",
+    ).fetchone()[0]
+    assert model_id == "https://huggingface.co/epfl-llm/meditron-7b"
+
+    dataset_id = conn.execute("SELECT repo_id FROM datasets").fetchone()[0]
+    assert dataset_id == "https://huggingface.co/datasets/epfl-llm/guidelines"
+
+    space_id = conn.execute("SELECT repo_id FROM spaces").fetchone()[0]
+    assert space_id == "https://huggingface.co/spaces/EPFL-VILAB/4M"
+
+    # Chunks: each entity_type got its own URL shape.
+    chunks = dict(conn.execute(
+        "SELECT entity_type, repo_id FROM chunks ORDER BY entity_type",
+    ).fetchall())
+    assert chunks["model"].startswith("https://huggingface.co/epfl-llm/")
+    assert chunks["dataset"].startswith("https://huggingface.co/datasets/")
+    assert chunks["space"].startswith("https://huggingface.co/spaces/")
+    assert chunks["org"] == "https://huggingface.co/epfl-llm"
+
+    store.close()
+
+
+def test_bootstrap_is_idempotent_after_migration(tmp_path: Path):
+    db_path = tmp_path / "hf.duckdb"
+    _seed_legacy_hf_db(db_path)
+
+    store = DuckDBStore(db_path)
+    store.bootstrap()
+    store.close()
+
+    for _ in range(3):
+        store = DuckDBStore(db_path)
+        store.bootstrap()
+        store.close()
+
+    conn = duckdb.connect(str(db_path), read_only=True)
+    # No bare ids snuck back, and row counts are preserved end-to-end.
+    bare_models = conn.execute(
+        "SELECT COUNT(*) FROM models WHERE repo_id NOT LIKE 'https://%'",
+    ).fetchone()[0]
+    assert bare_models == 0
+    assert conn.execute("SELECT COUNT(*) FROM models").fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 4
+    conn.close()
+
+
+def test_lookup_methods_accept_bare_or_iri_input(tmp_path: Path):
+    """`fetch_org` / `fetch_repo` / `repo_sha` should accept both shapes."""
+    db_path = tmp_path / "hf.duckdb"
+    _seed_legacy_hf_db(db_path)
+    store = DuckDBStore(db_path)
+    store.bootstrap()
+
+    # Bare input — promoted internally.
+    org_row = store.fetch_org("epfl-llm")
+    assert org_row is not None
+    assert org_row["slug"] == "https://huggingface.co/epfl-llm"
+
+    # IRI input — passes through.
+    org_iri = store.fetch_org("https://huggingface.co/epfl-llm")
+    assert org_iri == org_row
+
+    # repo_sha + fetch_repo accept bare.
+    assert store.fetch_repo("models", "epfl-llm/meditron-7b") is not None
+    assert store.fetch_repo("datasets", "epfl-llm/guidelines") is not None
+    store.close()


### PR DESCRIPTION
Same treatment as #68 (communities) and #69 (Zenodo): promote every HuggingFace PK + FK to its dereferenceable `huggingface.co` URL form. Independent of the open Zenodo / communities PRs.

## URL shapes

| Table.column | Bare → IRI |
|---|---|
| `orgs.slug` (users + orgs share the same URL pattern) | `epfl-llm` → `https://huggingface.co/epfl-llm` |
| `models.repo_id` | `epfl-llm/meditron-7b` → `https://huggingface.co/epfl-llm/meditron-7b` |
| `models.author` | `epfl-llm` → `https://huggingface.co/epfl-llm` |
| `datasets.repo_id` | `epfl-llm/guidelines` → `https://huggingface.co/datasets/epfl-llm/guidelines` |
| `datasets.author` | `epfl-llm` → `https://huggingface.co/epfl-llm` |
| `spaces.repo_id` | `EPFL-VILAB/4M` → `https://huggingface.co/spaces/EPFL-VILAB/4M` |
| `spaces.author` | `EPFL-VILAB` → `https://huggingface.co/EPFL-VILAB` |
| `chunks.repo_id` (FK, 4 entity_types) | matches the entity's URL shape via the `entity_type` discriminator |

Note the asymmetric HF routing — **models live at the namespace root** (`/<author>/<name>`), while datasets and spaces sit under their own path prefix. `iri_for_entity_type(entity_type, bare)` encapsulates that asymmetry so chunks (heterogeneous `entity_type`) get the right URL per row.

## Helpers (`src/index/huggingface/iri.py`)

- `namespace_iri(slug)` — users + orgs.
- `model_iri` / `dataset_iri` / `space_iri` — per-entity shapes.
- `iri_for_entity_type(et, b)` — dispatch for chunks.
- `parse_namespace_slug` / `parse_repo_id` — round-trip inverses; tolerant of `www.` host and trailing slashes.

## Storage normalisation

`_upsert_repo` and `upsert_chunk` promote bare ids to canonical IRI form at the storage boundary, so direct callers + unit tests can still pass bare values without bypassing the convention. Lookup methods (`fetch_org`, `fetch_repo`, `repo_sha`, `list_repo_titles_for_org`) accept either shape and promote bare inputs internally.

## Migration

`bootstrap()` runs `_migrate_to_iri_ids()` — CTAS-swap on each affected table when bare ids are detected. Same DuckDB index landmine we hit on Zenodo's 24k-row link tables (#69), worked around with the same drop-and-rebuild pattern. Idempotent: already-migrated DBs are no-ops.

**Live DB result.** All **5,167 rows** carry IRIs:
- 159 orgs
- 1,064 models
- 381 datasets
- 70 spaces
- 3,493 chunks (across 4 entity types)

## Test plan

- [x] 12 new tests in `tests/index/huggingface/test_iri.py`:
  * Each `*_iri` helper promotes its bare form to the right URL.
  * Idempotency on IRI input; trailing-slash hygiene.
  * `www.` host stripping.
  * `dataset_iri("datasets/<author>/<name>")` doesn't double-prefix.
  * `iri_for_entity_type` dispatches correctly per discriminator.
  * Parse inverses round-trip both URL and bare forms.
  * Seeded legacy DB → bootstrap → zero bare-id rows remain across every PK and FK; per-table URL shapes verified.
  * Idempotency across consecutive bootstraps.
  * `fetch_org` / `fetch_repo` accept bare AND IRI inputs.
- [x] 3 existing tests in `test_duckdb_store.py` updated to expect the canonical-URL storage shape.
- [x] `pytest tests/v2/ tests/index/huggingface/` — 825 passed.