### PR TITLE
feat(huggingface): citation surface — arXiv DOIs for models + dataset citations

### DIFF
--- a/src/index/huggingface/ingest/datasets_ingest.py
+++ b/src/index/huggingface/ingest/datasets_ingest.py
@@ -89,7 +89,12 @@ def ingest_datasets(
 
 
 def _dataset_row(repo_id: str, info: object) -> dict[str, object | None]:
-    from src.index.huggingface.iri import dataset_iri, namespace_iri  # noqa: PLC0415
+    from src.index.huggingface.iri import (  # noqa: PLC0415
+        dataset_iri,
+        dois_from_bibtex,
+        namespace_iri,
+        paperswithcode_url,
+    )
 
     card_data = card_data_to_dict(getattr(info, "card_data", None) or getattr(info, "cardData", None))
     tags = list(getattr(info, "tags", None) or [])
@@ -97,9 +102,18 @@ def _dataset_row(repo_id: str, info: object) -> dict[str, object | None]:
     bare_author = (
         getattr(info, "author", None) or author_from_repo_id(repo_id)
     )
+    citation_text = getattr(info, "citation", None)
+    if not isinstance(citation_text, str):
+        citation_text = None
+    pwc_id = getattr(info, "paperswithcode_id", None) or getattr(
+        info, "paperswithcodeId", None,
+    )
     return {
         "repo_id": dataset_iri(repo_id),
         "author": namespace_iri(bare_author) if bare_author else None,
+        "citation_text": citation_text,
+        "paperswithcode_url": paperswithcode_url(pwc_id),
+        "citation_dois": dois_from_bibtex(citation_text),
         "sha": getattr(info, "sha", None),
         "license": _license_from(card_data, getattr(info, "license", None)),
         "downloads": _coerce_int(getattr(info, "downloads", None)),

--- a/src/index/huggingface/ingest/models_ingest.py
+++ b/src/index/huggingface/ingest/models_ingest.py
@@ -97,7 +97,11 @@ def ingest_models(
 
 
 def _model_row(repo_id: str, info: object) -> dict[str, object | None]:
-    from src.index.huggingface.iri import model_iri, namespace_iri  # noqa: PLC0415
+    from src.index.huggingface.iri import (  # noqa: PLC0415
+        arxiv_dois_from_tags,
+        model_iri,
+        namespace_iri,
+    )
 
     card_data = card_data_to_dict(getattr(info, "card_data", None) or getattr(info, "cardData", None))
     tags = list(getattr(info, "tags", None) or [])
@@ -107,6 +111,10 @@ def _model_row(repo_id: str, info: object) -> dict[str, object | None]:
     return {
         "repo_id": model_iri(repo_id),
         "author": namespace_iri(bare_author) if bare_author else None,
+        # Derived citation surface — arXiv mints a DOI for every preprint
+        # as `10.48550/arXiv.<id>`. Models that cite arxiv via tags get
+        # `https://doi.org/...` URLs here, deduped.
+        "arxiv_dois": arxiv_dois_from_tags(tags),
         "sha": getattr(info, "sha", None),
         "pipeline_tag": getattr(info, "pipeline_tag", None),
         "library_name": getattr(info, "library_name", None),

--- a/src/index/huggingface/iri.py
+++ b/src/index/huggingface/iri.py
@@ -16,6 +16,8 @@ host and trailing slashes on input.
 
 from __future__ import annotations
 
+import re as _re
+
 _BASE = "https://huggingface.co/"
 _WWW = "https://www.huggingface.co/"
 _DATASETS_PREFIX = _BASE + "datasets/"
@@ -133,11 +135,104 @@ def parse_repo_id(iri_or_bare: str) -> str | None:
     return s or None
 
 
+# ---------------------------------------------------------------------------
+# Citation-surface helpers (arXiv DOIs from tags, BibTeX DOI extraction,
+# paperswithcode URLs). HF doesn't expose a `card_data.doi` for any of our
+# 1,515 repos, so these derived fields are the closest we get to a real
+# citation column.
+# ---------------------------------------------------------------------------
+
+_DOI_URL_PREFIX = "https://doi.org/"
+_ARXIV_DOI_PREFIX = "10.48550/arXiv."
+_PAPERSWITHCODE_BASE = "https://paperswithcode.com/dataset/"
+_ARXIV_TAG_RE = _re.compile(r"^arxiv:(.+?)(?:v\d+)?$", _re.IGNORECASE)
+# Conservative DOI shape — `10.<reg>/<suffix>` where suffix is non-greedy
+# up to whitespace, quote, bracket, or `}` (BibTeX delimiter).
+_BIBTEX_DOI_RE = _re.compile(
+    r"\b(10\.\d{4,9}/[^\s\"'<>{}]+)",
+    _re.IGNORECASE,
+)
+
+
+def arxiv_doi_iri(arxiv_id: str) -> str | None:
+    """`2311.16079` → `https://doi.org/10.48550/arXiv.2311.16079`.
+
+    Accepts bare arxiv ids, the `arxiv:<id>` tag form, or already-built
+    DOI URLs. Returns None for empty / unparseable input. Strips an
+    optional version suffix (`v1`, `v2`, …) since DOIs target the
+    abstract record, not a specific version.
+    """
+    s = _normalise(arxiv_id)
+    if not s:
+        return None
+    if s.startswith(_DOI_URL_PREFIX):
+        return s.rstrip("/")
+    match = _ARXIV_TAG_RE.match(s)
+    if match:
+        s = match.group(1)
+    # Strip version suffix when caller passed just `<id>v2`.
+    if not s.startswith(_ARXIV_DOI_PREFIX):
+        s_no_ver = _re.sub(r"v\d+$", "", s, flags=_re.IGNORECASE)
+        s = _ARXIV_DOI_PREFIX + s_no_ver
+    return _DOI_URL_PREFIX + s
+
+
+def arxiv_dois_from_tags(tags: list[str] | None) -> list[str]:
+    """Extract DOI URLs from a model's `tags` list. Order preserved, deduped."""
+    if not tags:
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for tag in tags:
+        if not isinstance(tag, str) or not tag.lower().startswith("arxiv:"):
+            continue
+        iri = arxiv_doi_iri(tag)
+        if iri and iri not in seen:
+            seen.add(iri)
+            out.append(iri)
+    return out
+
+
+def paperswithcode_url(paperswithcode_id: str | None) -> str | None:
+    """`mnist` → `https://paperswithcode.com/dataset/mnist`. Idempotent on URLs."""
+    s = _normalise(paperswithcode_id)
+    if not s:
+        return None
+    if s.startswith(_PAPERSWITHCODE_BASE):
+        return s.rstrip("/")
+    if s.startswith("http://") or s.startswith("https://"):
+        return s.rstrip("/")
+    return _PAPERSWITHCODE_BASE + s
+
+
+def dois_from_bibtex(citation_text: str | None) -> list[str]:
+    """Pull every `10.<reg>/<suffix>` substring out of a BibTeX string.
+
+    Returns canonical `https://doi.org/...` URLs, order preserved, deduped.
+    Empty / non-string input returns `[]` (datasets without a citation).
+    """
+    if not isinstance(citation_text, str) or not citation_text.strip():
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for match in _BIBTEX_DOI_RE.finditer(citation_text):
+        bare = match.group(1).rstrip(".,;:")  # strip trailing punctuation
+        iri = _DOI_URL_PREFIX + bare
+        if iri not in seen:
+            seen.add(iri)
+            out.append(iri)
+    return out
+
+
 __all__ = [
+    "arxiv_doi_iri",
+    "arxiv_dois_from_tags",
     "dataset_iri",
+    "dois_from_bibtex",
     "iri_for_entity_type",
     "model_iri",
     "namespace_iri",
+    "paperswithcode_url",
     "parse_namespace_slug",
     "parse_repo_id",
     "space_iri",

--- a/src/index/huggingface/storage/duckdb_store.py
+++ b/src/index/huggingface/storage/duckdb_store.py
@@ -77,6 +77,90 @@ class DuckDBStore:
         # `https://huggingface.co/...` IRI form. Idempotent — rows
         # already in URL shape match no WHERE clause.
         self._migrate_to_iri_ids()
+        # Backfill the citation-surface columns (`arxiv_dois` on
+        # models, `citation_text` / `paperswithcode_url` /
+        # `citation_dois` on datasets) from existing `raw` payloads.
+        # Skipped when the columns already carry a non-null value.
+        self._migrate_citation_surface()
+
+    def _migrate_citation_surface(self) -> None:
+        """Backfill arxiv DOIs (from model tags) and dataset citation
+        metadata (from `raw.citation` / `raw.paperswithcode_id`).
+        """
+        from src.index.huggingface.iri import (  # noqa: PLC0415
+            arxiv_dois_from_tags,
+            dois_from_bibtex,
+            paperswithcode_url,
+        )
+
+        conn = self.connect()
+
+        # --- models.arxiv_dois -----------------------------------------
+        # The arxiv tags live in `tags` JSON; backfill via Python because
+        # the parsing (strip `arxiv:`, drop `v<n>` suffix, dedupe) is
+        # cleaner here than a SQL CASE.
+        rows = conn.execute(
+            "SELECT repo_id, tags FROM models "
+            "WHERE arxiv_dois IS NULL OR arxiv_dois = '[]' OR arxiv_dois = 'null'",
+        ).fetchall()
+        for repo_id, tags_payload in rows:
+            try:
+                tags = (
+                    json.loads(tags_payload)
+                    if isinstance(tags_payload, str)
+                    else tags_payload
+                )
+            except json.JSONDecodeError:
+                continue
+            dois = arxiv_dois_from_tags(tags or [])
+            if dois:
+                conn.execute(
+                    "UPDATE models SET arxiv_dois = ? WHERE repo_id = ?",
+                    [json.dumps(dois, ensure_ascii=False), repo_id],
+                )
+
+        # --- datasets.citation_text / paperswithcode_url / citation_dois -
+        rows = conn.execute(
+            "SELECT repo_id, raw FROM datasets "
+            "WHERE citation_text IS NULL "
+            "   OR paperswithcode_url IS NULL "
+            "   OR citation_dois IS NULL OR citation_dois = '[]' OR citation_dois = 'null'",
+        ).fetchall()
+        for repo_id, raw_payload in rows:
+            try:
+                raw = (
+                    json.loads(raw_payload)
+                    if isinstance(raw_payload, str)
+                    else raw_payload
+                )
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(raw, dict):
+                continue
+            citation = raw.get("citation") if isinstance(raw.get("citation"), str) else None
+            pwc_id = raw.get("paperswithcode_id") or raw.get("paperswithcodeId")
+            citation_dois = dois_from_bibtex(citation)
+            pwc_url = paperswithcode_url(pwc_id) if pwc_id else None
+            if citation or pwc_url or citation_dois:
+                conn.execute(
+                    "UPDATE datasets SET "
+                    "  citation_text = COALESCE(citation_text, ?), "
+                    "  paperswithcode_url = COALESCE(paperswithcode_url, ?), "
+                    "  citation_dois = COALESCE("
+                    "      CASE WHEN citation_dois IS NULL "
+                    "                OR citation_dois = '[]' "
+                    "                OR citation_dois = 'null' "
+                    "           THEN NULL ELSE citation_dois END, "
+                    "      ?) "
+                    "WHERE repo_id = ?",
+                    [
+                        citation,
+                        pwc_url,
+                        json.dumps(citation_dois, ensure_ascii=False)
+                        if citation_dois else None,
+                        repo_id,
+                    ],
+                )
 
     def _migrate_to_iri_ids(self) -> None:
         """CTAS-swap each table whose PK or FK still carries bare ids.
@@ -345,7 +429,7 @@ class DuckDBStore:
                 "created_at",
                 "last_modified",
             ),
-            json_cols=("tags", "card_data", "base_models"),
+            json_cols=("tags", "card_data", "base_models", "arxiv_dois"),
             row=row,
             raw=raw,
         )
@@ -365,8 +449,10 @@ class DuckDBStore:
                 "private",
                 "created_at",
                 "last_modified",
+                "citation_text",
+                "paperswithcode_url",
             ),
-            json_cols=("tags", "card_data", "dataset_info"),
+            json_cols=("tags", "card_data", "dataset_info", "citation_dois"),
             row=row,
             raw=raw,
         )

--- a/src/index/huggingface/storage/schema.sql
+++ b/src/index/huggingface/storage/schema.sql
@@ -46,6 +46,10 @@ CREATE TABLE IF NOT EXISTS models (
     tags                 JSON,
     card_data            JSON,
     base_models          JSON,
+    -- arXiv DOIs derived from `arxiv:<id>` tags. arXiv mints a DOI for
+    -- every preprint as `10.48550/arXiv.<id>`; we store the canonical
+    -- `https://doi.org/...` form so consumers can dereference directly.
+    arxiv_dois           JSON,
     raw                  JSON,
     ingested_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -65,9 +69,23 @@ CREATE TABLE IF NOT EXISTS datasets (
     tags                 JSON,
     card_data            JSON,
     dataset_info         JSON,
+    -- HF dataset payloads carry a BibTeX `citation` field and an
+    -- optional `paperswithcode_id` linking to paperswithcode.com.
+    -- We keep the raw BibTeX text and pull any DOIs out into a
+    -- separate JSON list of `https://doi.org/...` URLs.
+    citation_text        TEXT,
+    paperswithcode_url   TEXT,
+    citation_dois        JSON,
     raw                  JSON,
     ingested_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Additive migrations for DBs created before the citation-surface
+-- columns landed. Idempotent (`IF NOT EXISTS`).
+ALTER TABLE models   ADD COLUMN IF NOT EXISTS arxiv_dois         JSON;
+ALTER TABLE datasets ADD COLUMN IF NOT EXISTS citation_text      TEXT;
+ALTER TABLE datasets ADD COLUMN IF NOT EXISTS paperswithcode_url TEXT;
+ALTER TABLE datasets ADD COLUMN IF NOT EXISTS citation_dois      JSON;
 
 CREATE TABLE IF NOT EXISTS spaces (
     repo_id              TEXT PRIMARY KEY,

--- a/tests/index/huggingface/test_iri.py
+++ b/tests/index/huggingface/test_iri.py
@@ -8,10 +8,14 @@ import duckdb
 import pytest
 
 from src.index.huggingface.iri import (
+    arxiv_doi_iri,
+    arxiv_dois_from_tags,
     dataset_iri,
+    dois_from_bibtex,
     iri_for_entity_type,
     model_iri,
     namespace_iri,
+    paperswithcode_url,
     parse_namespace_slug,
     parse_repo_id,
     space_iri,
@@ -206,6 +210,184 @@ def test_bootstrap_is_idempotent_after_migration(tmp_path: Path):
     assert conn.execute("SELECT COUNT(*) FROM models").fetchone()[0] == 2
     assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 4
     conn.close()
+
+
+def test_arxiv_doi_iri_handles_every_input_form():
+    """Bare id, `arxiv:` tag, version suffix, full URL — all → canonical DOI URL."""
+    expected = "https://doi.org/10.48550/arXiv.2311.16079"
+    assert arxiv_doi_iri("2311.16079") == expected
+    assert arxiv_doi_iri("arxiv:2311.16079") == expected
+    assert arxiv_doi_iri("ARXIV:2311.16079") == expected
+    # Version suffix stripped (DOI is per-paper, not per-version).
+    assert arxiv_doi_iri("arxiv:2311.16079v3") == expected
+    # Already URL: idempotent.
+    assert arxiv_doi_iri(expected) == expected
+    assert arxiv_doi_iri(expected + "/") == expected
+    # Empty / whitespace → None.
+    assert arxiv_doi_iri("") is None
+    assert arxiv_doi_iri("   ") is None
+
+
+def test_arxiv_dois_from_tags_dedupes_and_orders():
+    tags = [
+        "transformers",
+        "arxiv:2311.16079",
+        "medical",
+        "arxiv:2311.16079",  # duplicate
+        "arxiv:2406.09406v2",
+        "license:llama2",
+    ]
+    out = arxiv_dois_from_tags(tags)
+    assert out == [
+        "https://doi.org/10.48550/arXiv.2311.16079",
+        "https://doi.org/10.48550/arXiv.2406.09406",
+    ]
+    # Empty / None inputs.
+    assert arxiv_dois_from_tags(None) == []
+    assert arxiv_dois_from_tags([]) == []
+    # No arxiv tags → empty.
+    assert arxiv_dois_from_tags(["medical", "license:mit"]) == []
+
+
+def test_paperswithcode_url_builds_and_is_idempotent():
+    assert paperswithcode_url("mnist") == "https://paperswithcode.com/dataset/mnist"
+    iri = "https://paperswithcode.com/dataset/imagenet"
+    assert paperswithcode_url(iri) == iri
+    assert paperswithcode_url(iri + "/") == iri
+    assert paperswithcode_url(None) is None
+    assert paperswithcode_url("") is None
+
+
+def test_dois_from_bibtex_extracts_dedupes_strips_punctuation():
+    bibtex = """
+    @article{foo,
+        title = {Foo},
+        doi = {10.48550/arXiv.2311.16079},
+        url = {https://doi.org/10.5281/zenodo.1234567},
+    }
+    @article{bar,
+        doi = {10.48550/arXiv.2311.16079},  # duplicate
+        note = {See also 10.1234/xyz.42},   # trailing punct + comment
+    }
+    """
+    out = dois_from_bibtex(bibtex)
+    # Order preserved, deduped, all wrapped as URLs.
+    assert out == [
+        "https://doi.org/10.48550/arXiv.2311.16079",
+        "https://doi.org/10.5281/zenodo.1234567",
+        "https://doi.org/10.1234/xyz.42",
+    ]
+    # Empty / None / non-string → [].
+    assert dois_from_bibtex(None) == []
+    assert dois_from_bibtex("") == []
+    assert dois_from_bibtex("no dois in here") == []
+
+
+def test_bootstrap_backfills_citation_surface(tmp_path: Path):
+    """Pre-PR DB shape without the citation columns + a model with arxiv
+    tags + a dataset with raw.citation → bootstrap ALTERs the tables and
+    backfills the derived fields.
+    """
+    db_path = tmp_path / "hf.duckdb"
+    # Pre-PR shape: only the original columns on models/datasets.
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE models ("
+        "  repo_id TEXT PRIMARY KEY, author TEXT, sha TEXT, "
+        "  pipeline_tag TEXT, library_name TEXT, license TEXT, "
+        "  downloads BIGINT, downloads_all_time BIGINT, likes BIGINT, "
+        "  gated BOOLEAN, private BOOLEAN, created_at TIMESTAMP, "
+        "  last_modified TIMESTAMP, tags JSON, card_data JSON, "
+        "  base_models JSON, raw JSON, ingested_at TIMESTAMP)",
+    )
+    conn.execute(
+        "CREATE TABLE datasets ("
+        "  repo_id TEXT PRIMARY KEY, author TEXT, sha TEXT, license TEXT, "
+        "  downloads BIGINT, downloads_all_time BIGINT, likes BIGINT, "
+        "  gated BOOLEAN, private BOOLEAN, created_at TIMESTAMP, "
+        "  last_modified TIMESTAMP, tags JSON, card_data JSON, "
+        "  dataset_info JSON, raw JSON, ingested_at TIMESTAMP)",
+    )
+    # The other tables (referenced by the IRI migration); empty is fine.
+    conn.execute(
+        "CREATE TABLE orgs (slug TEXT PRIMARY KEY, namespace_kind TEXT NOT NULL, "
+        "source TEXT NOT NULL, scope TEXT NOT NULL)",
+    )
+    conn.execute(
+        "CREATE TABLE spaces (repo_id TEXT PRIMARY KEY, author TEXT, sha TEXT, "
+        "sdk TEXT, runtime_stage TEXT, hardware TEXT, license TEXT, "
+        "likes BIGINT, created_at TIMESTAMP, last_modified TIMESTAMP, "
+        "tags JSON, card_data JSON, raw JSON, ingested_at TIMESTAMP)",
+    )
+    conn.execute(
+        "CREATE TABLE chunks (chunk_id TEXT PRIMARY KEY, entity_type TEXT, "
+        "repo_id TEXT, chunk_index INTEGER, text TEXT, token_count INTEGER, "
+        "vector_id TEXT, embedded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+    )
+
+    import json as _json
+    conn.execute(
+        "INSERT INTO models (repo_id, tags, raw) VALUES (?, ?, ?)",
+        [
+            "https://huggingface.co/epfl-llm/meditron-7b",
+            _json.dumps(["arxiv:2311.16079", "medical", "arxiv:2401.00001v2"]),
+            _json.dumps({"id": "epfl-llm/meditron-7b"}),
+        ],
+    )
+    conn.execute(
+        "INSERT INTO datasets (repo_id, raw) VALUES (?, ?)",
+        [
+            "https://huggingface.co/datasets/example/dset",
+            _json.dumps({
+                "id": "example/dset",
+                "citation": "@article{foo, doi={10.5281/zenodo.999}}",
+                "paperswithcode_id": "mnist",
+            }),
+        ],
+    )
+    conn.close()
+
+    store = DuckDBStore(db_path)
+    store.bootstrap()
+    conn = store.connect()
+
+    # New columns exist.
+    m_cols = {r[1] for r in conn.execute("PRAGMA table_info('models')").fetchall()}
+    d_cols = {r[1] for r in conn.execute("PRAGMA table_info('datasets')").fetchall()}
+    assert "arxiv_dois" in m_cols
+    assert {"citation_text", "paperswithcode_url", "citation_dois"} <= d_cols
+
+    # Model backfill: arxiv DOIs derived from tags.
+    arxiv_dois_raw = conn.execute(
+        "SELECT arxiv_dois FROM models WHERE repo_id = "
+        "  'https://huggingface.co/epfl-llm/meditron-7b'",
+    ).fetchone()[0]
+    arxiv_dois = (
+        _json.loads(arxiv_dois_raw)
+        if isinstance(arxiv_dois_raw, str)
+        else arxiv_dois_raw
+    )
+    assert arxiv_dois == [
+        "https://doi.org/10.48550/arXiv.2311.16079",
+        "https://doi.org/10.48550/arXiv.2401.00001",
+    ]
+
+    # Dataset backfill: BibTeX → DOI URL; paperswithcode_id → URL.
+    row = conn.execute(
+        "SELECT citation_text, paperswithcode_url, citation_dois "
+        "FROM datasets WHERE repo_id = "
+        "  'https://huggingface.co/datasets/example/dset'",
+    ).fetchone()
+    citation_text, pwc_url, citation_dois_raw = row
+    assert citation_text.startswith("@article{foo")
+    assert pwc_url == "https://paperswithcode.com/dataset/mnist"
+    citation_dois = (
+        _json.loads(citation_dois_raw)
+        if isinstance(citation_dois_raw, str)
+        else citation_dois_raw
+    )
+    assert citation_dois == ["https://doi.org/10.5281/zenodo.999"]
+    store.close()
 
 
 def test_lookup_methods_accept_bare_or_iri_input(tmp_path: Path):


### PR DESCRIPTION
**Stacked on #73.** Merge #73 first; this PR's base auto-rebases to develop after.

## Why

You asked "can we obtain the doi associated to any of [HF models / datasets / spaces]?" Answer: HF doesn't expose `card_data.doi` for any of our 1,515 EPFL repos. But the raw payload carries two real citation signals we were throwing away:

1. **arXiv tags** on 336 / 1,064 models. arXiv mints a DOI for every preprint as `10.48550/arXiv.<id>`, so we derive a real `https://doi.org/...` URL.
2. **`citation` (BibTeX) + `paperswithcode_id`** on datasets — present in `raw` but never projected. When the BibTeX has a `doi = {…}` field, we extract a canonical DOI URL.

## New columns

| Table.column | Type | Source |
|---|---|---|
| `models.arxiv_dois` | JSON list | tags like `arxiv:2311.16079` → `https://doi.org/10.48550/arXiv.2311.16079` |
| `datasets.citation_text` | TEXT | raw BibTeX from the API |
| `datasets.paperswithcode_url` | TEXT | `https://paperswithcode.com/dataset/<id>` |
| `datasets.citation_dois` | JSON list | DOIs parsed out of `citation_text` |

## Helpers (`src/index/huggingface/iri.py`)

- `arxiv_doi_iri(id_or_tag_or_url)` — accepts bare `2311.16079`, `arxiv:<id>` tag, version suffix (`v2`), already-URL. Returns canonical DOI URL; version stripped.
- `arxiv_dois_from_tags(tags)` — pulls every `arxiv:<id>` out of a tag list. Order preserved, deduped.
- `paperswithcode_url(id)` — `mnist` → `https://paperswithcode.com/dataset/mnist`. Idempotent.
- `dois_from_bibtex(text)` — extracts every `10.<reg>/<suffix>` substring from BibTeX. Order preserved, deduped, trailing punctuation stripped.

## Migration

`schema.sql` declares the new columns + `ALTER TABLE … ADD COLUMN IF NOT EXISTS` lines for existing DBs. `bootstrap()` runs `_migrate_citation_surface()`:

- Models with NULL / `[]` `arxiv_dois` → derive from stored `tags`.
- Datasets with any citation field unset → derive from `raw.citation` / `raw.paperswithcode_id`.

Idempotent — already-populated columns skip.

## Live DB result

- Models with arxiv DOIs: **336 / 1,064** (lossless match with `arxiv:`-tagged count).
- Datasets with `citation_text`: **0 / 381** — the API returns the key with a `null` value across all our EPFL datasets. Columns are in place for whenever upstream fills them.

Samples:
```
epfl-llm/meditron-7b           ["https://doi.org/10.48550/arXiv.2311.16079"]
EPFL-VILAB/4M_tokenizers_…     ["https://doi.org/10.48550/arXiv.2312.06647",
                                "https://doi.org/10.48550/arXiv.2406.09406"]
```

## Test plan

- [x] 5 new tests in `tests/index/huggingface/test_iri.py`:
  - `arxiv_doi_iri` handles every input form, strips version, idempotent.
  - `arxiv_dois_from_tags` dedupes + orders.
  - `paperswithcode_url` builds + idempotent.
  - `dois_from_bibtex` extracts every DOI shape, strips trailing punctuation.
  - End-to-end migration: seeded pre-PR DB → bootstrap → both ALTERs land and both backfills produce correct derived values.
- [x] `pytest tests/v2/ tests/index/huggingface/` — 830 passed (was 825 pre-PR; +5).