### PR TITLE
fix(resolve_company_to_ror): read `_company` (pipeline shape) too

### DIFF
--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -114,6 +114,7 @@ from src.v2.pipeline.stages import (
     run_llm_dedup_stage,
     run_org_relationships_stage,
     run_refine_with_llm_stage,
+    run_resolve_bio_to_ror_stage,
     run_resolve_company_to_ror_stage,
     validate_articles,
     validate_author_classes,
@@ -185,6 +186,7 @@ STAGE_JSONLD_BUILD = "jsonld_build"
 STAGE_LINK_VERACITY = "link_veracity"
 STAGE_REFINE_WITH_LLM = "refine_with_llm"
 STAGE_RESOLVE_COMPANY_TO_ROR = "resolve_company_to_ror"
+STAGE_RESOLVE_BIO_TO_ROR = "resolve_bio_to_ror"
 
 v2_router = APIRouter(prefix="/v2")
 
@@ -243,6 +245,22 @@ def _resolve_company_to_ror_enabled() -> bool:
     unchanged.
     """
     raw = os.getenv("V2_RESOLVE_COMPANY_TO_ROR")
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "f", "no", "n", "off"}
+
+
+def _resolve_bio_to_ror_enabled() -> bool:
+    """Read `V2_RESOLVE_BIO_TO_ROR` env var (default true).
+
+    When true (the default), the bio → ROR resolver runs right after
+    `resolve_company_to_ror` and stamps `schema:affiliation` on persons
+    whose `_company` was empty but whose `_bio` / `_orcid_biography` /
+    `_blog` carry an institution signal that the strict ROR gate accepts.
+    Set to `false` (or `0`/`no`/`off`) to skip; useful when a catalog
+    backfill wants the structured-field-only behaviour.
+    """
+    raw = os.getenv("V2_RESOLVE_BIO_TO_ROR")
     if raw is None:
         return True
     return raw.strip().lower() not in {"0", "false", "f", "no", "n", "off"}
@@ -790,6 +808,39 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
             _append_unique_warning(
                 warnings,
                 f"resolve_company_to_ror stage failed: {exc}",
+            )
+
+    # === resolve_bio_to_ror stage ================================
+    # Backstop for persons the company-string stage missed: pulls
+    # affiliation hints from `_bio` / `_orcid_biography` / `_blog`.
+    # Runs in the same slot as company-resolution (after reconciliation,
+    # before critic) and reuses the same strict acceptance gate, so its
+    # output looks identical to the critic / refiner — they see the same
+    # `schema:affiliation` triples regardless of which extractor stamped
+    # them.
+    if _resolve_bio_to_ror_enabled():
+        stage_started_at = perf_counter()
+        try:
+            bio_result = await run_resolve_bio_to_ror_stage(
+                reconciled=reconciled,
+                provider=getattr(providers, "ror_rag", None),
+            )
+            logger.info(
+                "%s: persons_examined=%d persons_resolved=%d "
+                "candidates=%d queries=%d accepted=%d in %.2fs",
+                STAGE_RESOLVE_BIO_TO_ROR,
+                bio_result.persons_examined,
+                bio_result.persons_resolved,
+                bio_result.candidates_extracted,
+                bio_result.queries_attempted,
+                bio_result.queries_accepted,
+                perf_counter() - stage_started_at,
+            )
+        except Exception as exc:  # noqa: BLE001 — never fail the run on this stage
+            logger.exception("%s stage failed", STAGE_RESOLVE_BIO_TO_ROR)
+            _append_unique_warning(
+                warnings,
+                f"resolve_bio_to_ror stage failed: {exc}",
             )
 
     apply_critic_pruning = _should_apply_critic_pruning()

--- a/src/v2/pipeline/stages/__init__.py
+++ b/src/v2/pipeline/stages/__init__.py
@@ -59,6 +59,10 @@ from src.v2.pipeline.stages.refine_with_llm import (
     RefineWithLLMResult,
     run_refine_with_llm_stage,
 )
+from src.v2.pipeline.stages.resolve_bio_to_ror import (
+    BioAffiliationResult,
+    run_resolve_bio_to_ror_stage,
+)
 from src.v2.pipeline.stages.resolve_company_to_ror import (
     CompanyAffiliationResult,
     run_resolve_company_to_ror_stage,
@@ -74,6 +78,7 @@ __all__ = [
     "BACKEND_WIKIPEDIA",
     "SUPPORTED_BACKENDS",
     "AssembledOutput",
+    "BioAffiliationResult",
     "CompanyAffiliationResult",
     "ConceptTaggingResult",
     "ContextBundle",
@@ -109,6 +114,7 @@ __all__ = [
     "run_llm_dedup_stage",
     "run_org_relationships_stage",
     "run_refine_with_llm_stage",
+    "run_resolve_bio_to_ror_stage",
     "run_resolve_company_to_ror_stage",
     "tag_rule_based_disciplines",
     "validate_articles",

--- a/src/v2/pipeline/stages/resolve_bio_to_ror.py
+++ b/src/v2/pipeline/stages/resolve_bio_to_ror.py
@@ -1,0 +1,366 @@
+"""Stage A of the "infer affiliation from richer Person signals" track.
+
+The first deterministic pass (`resolve_company_to_ror`) only reads the
+single structured `_company` field. That misses a large class of
+profiles where the affiliation lives in `_bio` (free text), in
+`_orcid_biography` (ORCID's longer-form bio), or in `_blog` (a personal
+website whose host already names the institution).
+
+Concrete examples we saw on real profiles:
+
+  github.com/joshabramson — bio: "Senior Research Engineer at Google DeepMind"
+                            (`_company` empty)
+  github.com/nikita-smetanin — bio explicit about employer, `_company`
+                               sometimes empty or stale
+  github.com/lyskov         — bio names lab + university affiliation,
+                              `_company` is a personal handle
+
+This stage:
+
+  1. Pulls candidate org strings out of `_bio` and `_orcid_biography`
+     using a small set of regexes:
+       - ``at <Capitalized phrase>`` ("Research Scientist at DeepMind")
+       - ``@<handle>`` ("@DeepMind", "@google")
+       - ``, <Capitalized phrase>`` after a role
+         ("PhD candidate, ETH Zurich")
+       - ``from <Capitalized phrase>`` ("PhD from MIT")
+  2. Maps `_blog` URLs through a small `DOMAIN_HINTS` table. We do NOT
+     hardcode ROR ids — the table is `host → search query` and the
+     same strict ROR resolver evaluates the hit. So a new
+     domain entry doesn't need a ROR id lookup at code-edit time.
+  3. Sends every candidate through the **same** `_resolve_one`
+     resolver `resolve_company_to_ror` uses. So the acceptance gate
+     (score ≥ 0.55, gap ≥ 0.02, org-type allowlist, exact-name
+     override) is identical — no second decision rule to keep in sync.
+  4. Stamps `schema:affiliation` (no role / no dates), matching the
+     `resolve_company_to_ror` contract.
+
+By default the stage **skips persons already affiliated** by an earlier
+stage — it's a backstop for the `_company`-empty case, not a re-runner.
+Call with ``skip_if_already_affiliated=False`` to additively enrich
+already-affiliated persons (when bio surfaces a co-affiliation the
+company field missed).
+
+This stage is meant to run **right after** `resolve_company_to_ror` in
+`api.py`, so the company-resolver cache and decision rule stay
+authoritative for the easy case.
+
+LLM stage B (per-person agent over the remaining `_bio` text) is a
+separate stage, added later in the same pipeline slot when the
+hybrid LLM runtime is enabled.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
+
+from src.v2.ingest.providers.ror_rag import RorRagProvider, build_default_provider
+from src.v2.pipeline.stages.resolve_company_to_ror import (
+    SCHEMA_AFFILIATION,
+    _resolve_one,
+)
+
+if TYPE_CHECKING:
+    from src.v2.pipeline.stages.reconciliation import ReconciledEntities
+
+logger = logging.getLogger(__name__)
+
+
+# Same multi-key fallback pattern as resolve_company_to_ror — the Person
+# dict carries these fields under different keys depending on whether
+# the stage runs in-pipeline (`_bio`) or post-jsonld-build
+# (`gme-internal:bio`) or post-hoc SPARQL (full IRI).
+def _multi_key(field: str) -> tuple[str, ...]:
+    return (
+        f"_{field}",
+        f"gme-internal:{field}",
+        f"https://openpulse.science/git-metadata-extractor#{field}",
+    )
+
+
+BIO_KEYS = _multi_key("bio")
+ORCID_BIO_KEYS = _multi_key("orcid_biography")
+BLOG_KEYS = _multi_key("blog")
+
+
+# Host → ROR search query. Values are the institution NAME (not a ROR
+# id) so the strict resolver still gates the match — a stale entry
+# can't introduce a wrong ROR link, just an unhelpful query.
+#
+# Add more entries by appending one line. The blog host match is
+# left-to-right suffix-aware (`lab.epfl.ch` finds `epfl.ch`), so
+# subdomain entries are unnecessary.
+DOMAIN_HINTS: dict[str, str] = {
+    # EPFL ecosystem
+    "epfl.ch": "EPFL",
+    # ETH Zurich
+    "ethz.ch": "ETH Zurich",
+    "eth.ch": "ETH Zurich",
+    # Swiss universities + research orgs
+    "unige.ch": "University of Geneva",
+    "unil.ch": "University of Lausanne",
+    "unibe.ch": "University of Bern",
+    "unibas.ch": "University of Basel",
+    "uzh.ch": "University of Zurich",
+    "usi.ch": "Università della Svizzera italiana",
+    "psi.ch": "Paul Scherrer Institute",
+    "cern.ch": "CERN",
+    "empa.ch": "Empa",
+    "eawag.ch": "Eawag",
+    # US universities — common in the EPFL-heavy contributor pool
+    "mit.edu": "Massachusetts Institute of Technology",
+    "stanford.edu": "Stanford University",
+    "berkeley.edu": "University of California, Berkeley",
+    "cmu.edu": "Carnegie Mellon University",
+    "harvard.edu": "Harvard University",
+    "princeton.edu": "Princeton University",
+    "caltech.edu": "California Institute of Technology",
+    "columbia.edu": "Columbia University",
+    "cornell.edu": "Cornell University",
+    "yale.edu": "Yale University",
+    "uchicago.edu": "University of Chicago",
+    "umich.edu": "University of Michigan",
+    "washington.edu": "University of Washington",
+    # UK
+    "cam.ac.uk": "University of Cambridge",
+    "ox.ac.uk": "University of Oxford",
+    "imperial.ac.uk": "Imperial College London",
+    "ucl.ac.uk": "University College London",
+    "ed.ac.uk": "University of Edinburgh",
+    # Germany
+    "mpg.de": "Max Planck Society",
+    "tum.de": "Technical University of Munich",
+    "kit.edu": "Karlsruhe Institute of Technology",
+    # France
+    "inria.fr": "Inria",
+    "cnrs.fr": "CNRS",
+    # Tech research labs — bios commonly link to corporate pages
+    "google.com": "Google",
+    "research.google": "Google Research",
+    "deepmind.com": "DeepMind",
+    "microsoft.com": "Microsoft Research",
+    "research.facebook.com": "Meta AI Research",
+    "ai.meta.com": "Meta AI Research",
+    "nvidia.com": "NVIDIA",
+    "openai.com": "OpenAI",
+    "anthropic.com": "Anthropic",
+    "ibm.com": "IBM Research",
+}
+
+
+# Patterns that pull candidate org strings out of free-text bios.
+# Each captures a single group containing the candidate phrase.
+_BIO_CANDIDATE_RES: tuple[re.Pattern[str], ...] = (
+    # "at <Cap phrase>" — by far the most common bio shape
+    re.compile(
+        r"\bat\s+(@?[A-Z][\w&\-]*(?:\s+[A-Z][\w&\-]*){0,4})",
+        re.UNICODE,
+    ),
+    # "@<handle>" — GitHub org / Twitter style references
+    re.compile(r"(?<!\w)@([A-Za-z][\w\-]+)", re.UNICODE),
+    # "<comma> <Cap phrase>" after a role
+    re.compile(
+        r",\s+(@?[A-Z][\w&\-]*(?:\s+[A-Z][\w&\-]*){0,4})\s*(?:[.,;]|$)",
+        re.UNICODE,
+    ),
+    # "from <Cap phrase>" — "PhD from MIT"
+    re.compile(
+        r"\bfrom\s+(@?[A-Z][\w&\-]*(?:\s+[A-Z][\w&\-]*){0,4})",
+        re.UNICODE,
+    ),
+)
+
+# Single-token captures that aren't org names (the regex above is
+# permissive — these are the most common false-positive captures).
+_STOPWORD_CANDIDATES: frozenset[str] = frozenset({
+    "i", "we", "a", "an", "the", "and", "or",
+    "phd", "ms", "msc", "ba", "bsc", "dr",
+    "research", "engineer", "scientist", "professor", "candidate",
+    "student", "postdoc", "postdoctoral", "alumnus", "alumni",
+    "founder", "co-founder", "ceo", "cto", "cso", "lead",
+    "interested", "working", "building", "learning",
+    "ml", "ai", "nlp", "cv", "se",
+    "github", "twitter", "linkedin",
+})
+
+
+@dataclass(slots=True)
+class BioAffiliationResult:
+    """Summary of one stage run."""
+
+    persons_examined: int
+    persons_resolved: int
+    candidates_extracted: int
+    queries_attempted: int
+    queries_accepted: int
+    rejection_reasons: dict[str, int]
+
+
+def _read_first(person: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    """Return the first non-empty string value across the candidate keys."""
+    for key in keys:
+        value = person.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _extract_bio_candidates(text: str) -> list[str]:
+    """Pull candidate org strings out of free-text bio. Returns in
+    order, deduped, with single-word stopwords filtered."""
+    if not text:
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for pattern in _BIO_CANDIDATE_RES:
+        for match in pattern.finditer(text):
+            candidate = (match.group(1) or "").strip().rstrip(".,;:")
+            if not candidate:
+                continue
+            lower = candidate.lower()
+            if lower in _STOPWORD_CANDIDATES:
+                continue
+            # Drop solo `@phd`, `@ml`, etc. — handle-shaped stopwords.
+            bare = lower.lstrip("@")
+            if bare in _STOPWORD_CANDIDATES:
+                continue
+            if lower in seen:
+                continue
+            seen.add(lower)
+            out.append(candidate)
+    return out
+
+
+def _blog_to_query(blog_url: str | None) -> str | None:
+    """Parse a blog URL and return the ROR search query when the host
+    matches a known institution suffix. Returns None on unknown hosts."""
+    if not blog_url:
+        return None
+    s = blog_url.strip()
+    if not s:
+        return None
+    if "://" not in s:
+        s = "https://" + s
+    try:
+        host = (urlparse(s).hostname or "").lower()
+    except Exception:  # noqa: BLE001 — best-effort parse
+        return None
+    if not host:
+        return None
+    parts = host.split(".")
+    # Walk left → right: `lab.compbio.epfl.ch` tries `lab.compbio.epfl.ch`,
+    # then `compbio.epfl.ch`, then `epfl.ch`. First DOMAIN_HINTS hit wins.
+    for i in range(len(parts) - 1):
+        candidate = ".".join(parts[i:])
+        if candidate in DOMAIN_HINTS:
+            return DOMAIN_HINTS[candidate]
+    return None
+
+
+async def run_resolve_bio_to_ror_stage(
+    *,
+    reconciled: "ReconciledEntities",
+    provider: RorRagProvider | None = None,
+    skip_if_already_affiliated: bool = True,
+) -> BioAffiliationResult:
+    """Stage entry. Mutates each Person dict in ``reconciled.entities['persons']``
+    that has an extractable affiliation signal in bio / orcid bio / blog.
+
+    The function is idempotent: re-running on already-stamped persons
+    leaves their `schema:affiliation` unchanged and (with
+    ``skip_if_already_affiliated=True``, the default) won't even re-query.
+    """
+    provider = provider or build_default_provider()
+    if provider is None:
+        logger.warning(
+            "resolve_bio_to_ror: RorRagProvider unavailable (check "
+            "V2_ROR_RAG_ENABLED + INDEX_QDRANT_URL); stage skipped",
+        )
+        return BioAffiliationResult(0, 0, 0, 0, 0, {"provider_unavailable": 1})
+
+    persons = reconciled.entities.get("persons") or []
+    cache: dict[str, str | None] = {}
+    reasons: dict[str, int] = {}
+    candidates_extracted = 0
+    resolved = 0
+
+    for person in persons:
+        if not isinstance(person, dict):
+            continue
+        if skip_if_already_affiliated and person.get(SCHEMA_AFFILIATION):
+            continue
+
+        bio = _read_first(person, BIO_KEYS) or ""
+        orcid_bio = _read_first(person, ORCID_BIO_KEYS) or ""
+        blog = _read_first(person, BLOG_KEYS) or ""
+
+        candidates: list[str] = []
+        seen_candidates: set[str] = set()
+        for text in (bio, orcid_bio):
+            for candidate in _extract_bio_candidates(text):
+                if candidate.lower() in seen_candidates:
+                    continue
+                seen_candidates.add(candidate.lower())
+                candidates.append(candidate)
+        domain_query = _blog_to_query(blog)
+        if domain_query and domain_query.lower() not in seen_candidates:
+            candidates.append(domain_query)
+            seen_candidates.add(domain_query.lower())
+        if not candidates:
+            continue
+        candidates_extracted += len(candidates)
+
+        candidate_rors: list[str] = []
+        for candidate in candidates:
+            ror_id, reason = await _resolve_one(provider, cache, candidate)
+            if ror_id:
+                if ror_id not in candidate_rors:
+                    candidate_rors.append(ror_id)
+            else:
+                reasons[reason] = reasons.get(reason, 0) + 1
+
+        if not candidate_rors:
+            continue
+
+        existing = person.get(SCHEMA_AFFILIATION)
+        if isinstance(existing, str):
+            merged = [existing] + [r for r in candidate_rors if r != existing]
+        elif isinstance(existing, list):
+            merged = list(existing) + [r for r in candidate_rors if r not in existing]
+        else:
+            merged = candidate_rors
+        person[SCHEMA_AFFILIATION] = merged[0] if len(merged) == 1 else merged
+        resolved += 1
+
+    result = BioAffiliationResult(
+        persons_examined=len(persons),
+        persons_resolved=resolved,
+        candidates_extracted=candidates_extracted,
+        queries_attempted=len(cache),
+        queries_accepted=sum(1 for v in cache.values() if v is not None),
+        rejection_reasons=reasons,
+    )
+    logger.info(
+        "resolve_bio_to_ror: persons_examined=%d persons_resolved=%d "
+        "candidates=%d queries=%d accepted=%d",
+        result.persons_examined,
+        result.persons_resolved,
+        result.candidates_extracted,
+        result.queries_attempted,
+        result.queries_accepted,
+    )
+    return result
+
+
+__all__ = [
+    "BIO_KEYS",
+    "BLOG_KEYS",
+    "BioAffiliationResult",
+    "DOMAIN_HINTS",
+    "ORCID_BIO_KEYS",
+    "run_resolve_bio_to_ror_stage",
+]

--- a/src/v2/pipeline/stages/resolve_company_to_ror.py
+++ b/src/v2/pipeline/stages/resolve_company_to_ror.py
@@ -84,7 +84,30 @@ NON_ORG_KEYS: frozenset[str] = frozenset({
 
 # Schema IRIs (kept inline to avoid a pipeline-wide constants module).
 SCHEMA_AFFILIATION = "http://schema.org/affiliation"
-GME_INTERNAL_COMPANY = "https://openpulse.science/git-metadata-extractor#company"
+# The Person dict carries the company under different keys depending on
+# where in the pipeline we run. In-pipeline (between reconciliation and
+# the LLM critic) it's the rule-based agent's `_company`. The
+# `gme-internal:` prefixed form lands later in `jsonld_build`. The
+# full IRI is only present in post-hoc SPARQL queries against the
+# already-expanded JSON-LD graph. We read whichever is set.
+COMPANY_KEYS: tuple[str, ...] = (
+    "_company",
+    "gme-internal:company",
+    "https://openpulse.science/git-metadata-extractor#company",
+)
+# Back-compat alias for callers that imported this name from the
+# pre-fix version of the module.
+GME_INTERNAL_COMPANY = COMPANY_KEYS[2]
+
+
+def _read_company(person: dict[str, Any]) -> Any:
+    """Return the first non-empty company value across every key shape
+    the Person dict might carry it under (see ``COMPANY_KEYS``)."""
+    for key in COMPANY_KEYS:
+        value = person.get(key)
+        if value:
+            return value
+    return None
 
 
 _COUNTRY_SUFFIX_RE = re.compile(r"\s*\([^)]+\)\s*$")
@@ -209,7 +232,7 @@ async def run_resolve_company_to_ror_stage(
     for person in persons:
         if not isinstance(person, dict):
             continue
-        raw_companies = person.get(GME_INTERNAL_COMPANY)
+        raw_companies = _read_company(person)
         if not raw_companies:
             continue
         if isinstance(raw_companies, str):

--- a/tests/v2/test_resolve_bio_to_ror.py
+++ b/tests/v2/test_resolve_bio_to_ror.py
@@ -1,0 +1,453 @@
+"""Tests for `resolve_bio_to_ror` stage + its `api.py` wiring.
+
+The stage is the deterministic Stage A of the "infer affiliation from
+richer Person signals" track. Stage B (LLM agent) lives behind a
+separate flag and is tested in its own file when it lands.
+
+Coverage focus:
+  - Pure helpers (`_extract_bio_candidates`, `_blog_to_query`).
+  - Stage entry: bio strings, ORCID bios, and blog domain hints each
+    drive a resolution; missing signals → no-op; non-org candidates
+    rejected without a search.
+  - `skip_if_already_affiliated`: defaults True; can additively enrich
+    when False.
+  - All three key shapes (`_bio` / `gme-internal:bio` / full IRI).
+  - The `V2_RESOLVE_BIO_TO_ROR` env flag — defaults on, opt-out off.
+  - Stub provider — never hits Qdrant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.v2.pipeline.stages.models import ReconciledEntities
+from src.v2.pipeline.stages.resolve_bio_to_ror import (
+    BIO_KEYS,
+    BLOG_KEYS,
+    DOMAIN_HINTS,
+    ORCID_BIO_KEYS,
+    BioAffiliationResult,
+    _blog_to_query,
+    _extract_bio_candidates,
+    run_resolve_bio_to_ror_stage,
+)
+from src.v2.pipeline.stages.resolve_company_to_ror import SCHEMA_AFFILIATION
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_extract_bio_candidates_pulls_at_phrase():
+    cands = _extract_bio_candidates("Research Engineer at Google DeepMind")
+    assert "Google DeepMind" in cands
+
+
+def test_extract_bio_candidates_pulls_handle():
+    cands = _extract_bio_candidates("Hacking on diffusion models @DeepMind")
+    assert "DeepMind" in cands
+
+
+def test_extract_bio_candidates_pulls_comma_phrase_after_role():
+    cands = _extract_bio_candidates("PhD candidate, ETH Zurich.")
+    assert "ETH Zurich" in cands
+
+
+def test_extract_bio_candidates_pulls_from_phrase():
+    cands = _extract_bio_candidates("ML researcher, PhD from MIT")
+    # Both the `, MIT`-ish pattern and `from MIT` may match; we just
+    # need MIT in the candidate set somewhere.
+    assert any("MIT" in c for c in cands)
+
+
+def test_extract_bio_candidates_filters_stopwords():
+    """Single-word stopword captures must be dropped — they would
+    waste a vector-search round trip otherwise."""
+    cands = _extract_bio_candidates("@PhD, @ML, @Research")
+    # All three captures match a stopword, so nothing should leak through.
+    assert cands == []
+
+
+def test_extract_bio_candidates_returns_empty_on_no_signal():
+    assert _extract_bio_candidates("") == []
+    assert _extract_bio_candidates("just rambling here") == []
+
+
+def test_extract_bio_candidates_dedups_case_insensitive():
+    cands = _extract_bio_candidates("at MIT. From MIT.")
+    lowered = [c.lower() for c in cands]
+    assert lowered.count("mit") == 1
+
+
+def test_blog_to_query_matches_known_domain():
+    assert _blog_to_query("https://people.epfl.ch/some.person") == "EPFL"
+
+
+def test_blog_to_query_handles_missing_scheme():
+    assert _blog_to_query("ethz.ch/~someone") == "ETH Zurich"
+
+
+def test_blog_to_query_walks_subdomains():
+    """`lab.compbio.epfl.ch` should fall through to `epfl.ch`."""
+    assert _blog_to_query("https://lab.compbio.epfl.ch") == "EPFL"
+
+
+def test_blog_to_query_returns_none_on_unknown_host():
+    assert _blog_to_query("https://example.com/blog") is None
+
+
+def test_blog_to_query_returns_none_on_blank_or_garbage():
+    assert _blog_to_query(None) is None
+    assert _blog_to_query("") is None
+    assert _blog_to_query("not a url") is None
+
+
+def test_domain_hints_keys_are_lowercase():
+    """Hostnames from urlparse are lowercased, so the lookup table
+    must match — otherwise a perfectly good entry silently misses."""
+    for key in DOMAIN_HINTS:
+        assert key == key.lower(), f"DOMAIN_HINTS key {key!r} must be lowercase"
+
+
+# ---------------------------------------------------------------------------
+# Stage entry with a stub provider
+# ---------------------------------------------------------------------------
+
+
+class _StubProvider:
+    """Lookup table: cleaned query → list of hit dicts. Mirrors the
+    company-stage test stub so we exercise the same `_resolve_one`
+    code path with the same interface."""
+
+    def __init__(self, hits: dict[str, list[dict[str, Any]]]) -> None:
+        self._hits = hits
+        self.queries: list[str] = []
+
+    async def search(
+        self,
+        *,
+        query: str,
+        scope_mode: str = "worldwide",
+        top_k: int = 5,
+        rerank: bool = False,
+    ) -> list[dict[str, Any]]:
+        self.queries.append(query)
+        return list(self._hits.get(query, []))
+
+
+def _run(reconciled: ReconciledEntities, provider: Any, **kwargs: Any) -> BioAffiliationResult:
+    return asyncio.run(
+        run_resolve_bio_to_ror_stage(
+            reconciled=reconciled, provider=provider, **kwargs,
+        ),
+    )
+
+
+def test_stage_resolves_from_bio_at_phrase():
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", "_bio": "Senior Research Engineer at Google DeepMind"},
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "Google DeepMind": [
+                {"score": 0.93, "types": ["company"], "name": "Google DeepMind", "ror_id": "https://ror.org/deepmind"},
+                {"score": 0.50, "types": ["company"], "name": "Google"},
+            ],
+        },
+    )
+    result = _run(reconciled, provider)
+    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/deepmind"
+    assert result.persons_resolved == 1
+    assert result.queries_accepted == 1
+
+
+def test_stage_resolves_from_orcid_bio():
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", "_orcid_biography": "Postdoc at EPFL since 2022."},
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "EPFL": [
+                {"score": 0.95, "types": ["education"], "name": "EPFL", "ror_id": "https://ror.org/02s376052"},
+                {"score": 0.40, "types": ["education"], "name": "Other"},
+            ],
+        },
+    )
+    _run(reconciled, provider)
+    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/02s376052"
+
+
+def test_stage_resolves_from_blog_domain():
+    """Blog domain alone (no bio) should still pull an affiliation."""
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", "_blog": "https://people.epfl.ch/jane.doe"},
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "EPFL": [
+                {"score": 0.95, "types": ["education"], "name": "EPFL", "ror_id": "https://ror.org/02s376052"},
+                {"score": 0.40, "types": ["education"], "name": "Other"},
+            ],
+        },
+    )
+    _run(reconciled, provider)
+    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/02s376052"
+
+
+def test_stage_no_op_when_no_signals():
+    reconciled = ReconciledEntities(
+        entities={"persons": [{"id": "p1"}, {"id": "p2", "_bio": ""}]},
+    )
+    provider = _StubProvider(hits={})
+    result = _run(reconciled, provider)
+    assert provider.queries == []
+    assert result.persons_resolved == 0
+
+
+def test_stage_skips_already_affiliated_by_default():
+    """The stage is a backstop — when company-stage already stamped
+    an affiliation, the bio stage stays out of the way."""
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {
+                    "id": "p1",
+                    "_bio": "Now at Google DeepMind",
+                    SCHEMA_AFFILIATION: "https://ror.org/companyx",
+                },
+            ],
+        },
+    )
+    provider = _StubProvider(hits={})
+    _run(reconciled, provider)
+    # Untouched: still just the company-stage value, no queries issued.
+    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/companyx"
+    assert provider.queries == []
+
+
+def test_stage_enriches_when_skip_disabled():
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {
+                    "id": "p1",
+                    "_bio": "Now at Google DeepMind",
+                    SCHEMA_AFFILIATION: "https://ror.org/companyx",
+                },
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "Google DeepMind": [
+                {"score": 0.93, "types": ["company"], "name": "Google DeepMind", "ror_id": "https://ror.org/deepmind"},
+                {"score": 0.40, "types": ["company"], "name": "Other"},
+            ],
+        },
+    )
+    _run(reconciled, provider, skip_if_already_affiliated=False)
+    affiliations = reconciled.entities["persons"][0][SCHEMA_AFFILIATION]
+    assert isinstance(affiliations, list)
+    assert "https://ror.org/companyx" in affiliations
+    assert "https://ror.org/deepmind" in affiliations
+
+
+@pytest.mark.parametrize("bio_key", BIO_KEYS)
+def test_stage_reads_bio_under_every_key_shape(bio_key):
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", bio_key: "Research Engineer at Google DeepMind"},
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "Google DeepMind": [
+                {"score": 0.93, "types": ["company"], "name": "Google DeepMind", "ror_id": "https://ror.org/deepmind"},
+                {"score": 0.40, "types": ["company"], "name": "Other"},
+            ],
+        },
+    )
+    _run(reconciled, provider)
+    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/deepmind"
+
+
+@pytest.mark.parametrize("blog_key", BLOG_KEYS)
+def test_stage_reads_blog_under_every_key_shape(blog_key):
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", blog_key: "https://people.epfl.ch/x"},
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "EPFL": [
+                {"score": 0.95, "types": ["education"], "name": "EPFL", "ror_id": "https://ror.org/02s376052"},
+                {"score": 0.40, "types": ["education"], "name": "Other"},
+            ],
+        },
+    )
+    _run(reconciled, provider)
+    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/02s376052"
+
+
+@pytest.mark.parametrize("orcid_key", ORCID_BIO_KEYS)
+def test_stage_reads_orcid_bio_under_every_key_shape(orcid_key):
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", orcid_key: "PhD candidate, ETH Zurich"},
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "ETH Zurich": [
+                {"score": 0.95, "types": ["education"], "name": "ETH Zurich", "ror_id": "https://ror.org/05a28rw58"},
+                {"score": 0.40, "types": ["education"], "name": "Other"},
+            ],
+        },
+    )
+    _run(reconciled, provider)
+    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/05a28rw58"
+
+
+def test_stage_dedups_candidates_across_sources():
+    """When bio + blog point at the same institution, we only issue
+    one search (cached by cleaned query)."""
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {
+                    "id": "p1",
+                    "_bio": "PhD candidate, EPFL",
+                    "_blog": "https://people.epfl.ch/x",
+                },
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "EPFL": [
+                {"score": 0.95, "types": ["education"], "name": "EPFL", "ror_id": "https://ror.org/02s376052"},
+                {"score": 0.40, "types": ["education"], "name": "Other"},
+            ],
+        },
+    )
+    _run(reconciled, provider)
+    # Cleaned query "EPFL" is asked once, then served from the cache.
+    assert provider.queries.count("EPFL") == 1
+
+
+def test_stage_rejects_low_confidence_bio_candidate():
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", "_bio": "Engineer at Something"},
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "Something": [
+                {"score": 0.40, "types": ["company"], "name": "Something Co"},
+            ],
+        },
+    )
+    result = _run(reconciled, provider)
+    assert SCHEMA_AFFILIATION not in reconciled.entities["persons"][0]
+    assert result.persons_resolved == 0
+
+
+def test_stage_is_idempotent_on_re_run_unaffiliated():
+    """Person carries no prior affiliation. Re-running after a first
+    run leaves the resolved affiliation unchanged."""
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", "_bio": "Research Engineer at Google DeepMind"},
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "Google DeepMind": [
+                {"score": 0.93, "types": ["company"], "name": "Google DeepMind", "ror_id": "https://ror.org/deepmind"},
+                {"score": 0.40, "types": ["company"], "name": "Other"},
+            ],
+        },
+    )
+    # First run skips no one (no prior affiliation). Second run hits
+    # the skip_if_already_affiliated guard and short-circuits.
+    _run(reconciled, provider)
+    first = reconciled.entities["persons"][0][SCHEMA_AFFILIATION]
+    queries_after_first = len(provider.queries)
+    _run(reconciled, provider)
+    second = reconciled.entities["persons"][0][SCHEMA_AFFILIATION]
+    assert first == second
+    assert len(provider.queries) == queries_after_first  # skip path → no new query
+
+
+def test_stage_returns_zero_when_provider_missing():
+    reconciled = ReconciledEntities(entities={"persons": [{"id": "p1"}]})
+    result = asyncio.run(
+        run_resolve_bio_to_ror_stage(reconciled=reconciled, provider=None),
+    )
+    assert isinstance(result, BioAffiliationResult)
+
+
+# ---------------------------------------------------------------------------
+# api.py env-flag wiring
+# ---------------------------------------------------------------------------
+
+
+def test_api_env_flag_defaults_on(monkeypatch):
+    from src.v2 import api as v2_api
+
+    monkeypatch.delenv("V2_RESOLVE_BIO_TO_ROR", raising=False)
+    assert v2_api._resolve_bio_to_ror_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "off", "n", "f"])
+def test_api_env_flag_recognises_off_values(value, monkeypatch):
+    from src.v2 import api as v2_api
+
+    monkeypatch.setenv("V2_RESOLVE_BIO_TO_ROR", value)
+    assert v2_api._resolve_bio_to_ror_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on", "anything-else"])
+def test_api_env_flag_treats_other_values_as_on(value, monkeypatch):
+    from src.v2 import api as v2_api
+
+    monkeypatch.setenv("V2_RESOLVE_BIO_TO_ROR", value)
+    assert v2_api._resolve_bio_to_ror_enabled() is True
+
+
+def test_api_constant_and_export_are_in_place():
+    from src.v2 import api as v2_api
+    from src.v2.pipeline import stages
+
+    assert v2_api.STAGE_RESOLVE_BIO_TO_ROR == "resolve_bio_to_ror"
+    assert callable(stages.run_resolve_bio_to_ror_stage)
+    assert "run_resolve_bio_to_ror_stage" in stages.__all__
+    assert "BioAffiliationResult" in stages.__all__

--- a/tests/v2/test_resolve_company_to_ror.py
+++ b/tests/v2/test_resolve_company_to_ror.py
@@ -141,11 +141,22 @@ def _run(reconciled: ReconciledEntities, provider: Any) -> CompanyAffiliationRes
     )
 
 
-def test_stage_stamps_confident_affiliation():
+@pytest.mark.parametrize(
+    "key",
+    [
+        "_company",  # rule-based agent shape — what the pipeline really carries
+        "gme-internal:company",  # jsonld-build mid-form
+        GME_INTERNAL_COMPANY,  # full IRI — post-hoc SPARQL shape
+    ],
+)
+def test_stage_reads_company_under_every_key_shape(key):
+    """The stage must work whether the Person dict carries the company
+    under `_company` (in-pipeline), `gme-internal:company` (post jsonld-build
+    rewrite), or the full IRI (post-hoc SPARQL graph)."""
     reconciled = ReconciledEntities(
         entities={
             "persons": [
-                {"id": "p1", GME_INTERNAL_COMPANY: "Google"},
+                {"id": "p1", key: "Google"},
             ],
         },
     )


### PR DESCRIPTION
The verbatim source only looked up the full IRI key
`https://openpulse.science/git-metadata-extractor#company`. That works
in the **post-hoc** SPARQL path where the JSON-LD `@context` has
already expanded the gme-internal prefix to the full IRI, but it does
NOT work at the stage's actual in-pipeline call point.

Inside the pipeline — between `reconcile_entities` and the LLM critic
— Person dicts carry the company under the **underscore-prefixed**
key `_company` written by `rule_based/person_agent.py`. The
`_` → `gme-internal:` rewrite happens later in `jsonld_build`. So as
integrated, the stage was silently finding zero companies and
stamping zero affiliations on real pipeline data.

(The author's post-hoc validation reporting 857 person→ROR triples
came from a SPARQL query against the already-expanded graph, not
from the in-pipeline path — which is why the gap was invisible
until end-to-end testing.)

Fix: new `_read_company(person)` falls back through every key shape
the dict might carry it under: `_company`, `gme-internal:company`,
and the full IRI (kept as `GME_INTERNAL_COMPANY` for back-compat
with anything that imported the constant by name).

Tests now parametrise across all three shapes so the regression can't
recur. `pytest tests/v2/test_resolve_company_to_ror.py` — 30 passed
(was 28; +2 from the parametrize fanout).