### PR TITLE
feat(resolve_bio_to_ror): also resolve via institutional email domain

### DIFF
--- a/src/v2/agents/llm/refiners/bio_resolver/__init__.py
+++ b/src/v2/agents/llm/refiners/bio_resolver/__init__.py
@@ -1,0 +1,21 @@
+"""Bio resolver — LLM-driven affiliation resolution for persons whose
+`_company` was empty and whose bio / orcid / readme text the
+deterministic stage could not parse."""
+
+from src.v2.agents.llm.refiners.bio_resolver.agent import (
+    CONFIDENCE_FLOOR,
+    PROFILE_README_CAP_CHARS,
+    BioResolverAgent,
+    BioResolverInput,
+    BioResolverPatch,
+    UnresolvedPerson,
+)
+
+__all__ = [
+    "CONFIDENCE_FLOOR",
+    "PROFILE_README_CAP_CHARS",
+    "BioResolverAgent",
+    "BioResolverInput",
+    "BioResolverPatch",
+    "UnresolvedPerson",
+]

--- a/src/v2/agents/llm/refiners/bio_resolver/agent.py
+++ b/src/v2/agents/llm/refiners/bio_resolver/agent.py
@@ -1,0 +1,199 @@
+"""Bio resolver — LLM uses ROR RAG to anchor persons whose affiliation
+only surfaces in free-text bio / profile-readme / ORCID biography.
+
+Companion to the deterministic ``resolve_bio_to_ror`` stage. The
+regex / domain-hints pass catches every easy case (verbatim "at X" in
+bio, institutional email/blog host). What's left after that is the
+long tail — bios that name an affiliation in prose the rule-based
+extractor can't reliably parse:
+
+  - "Currently a Senior Software Engineer Manager working in Identity"
+    (no `at <Org>` shape)
+  - "Building distributed systems for the next-gen LIGO collaboration"
+    (the org is "LIGO" but it's syntactically buried)
+  - Long GitHub profile READMEs where the affiliation lives 800
+    characters in.
+
+This LLM stage runs only under the hybrid / LLM runtime. The acceptance
+gate is the same as the deterministic stage's (top-1 ROR >= 0.55,
+org-type allowlist, plus ≥ 0.7 LLM confidence and a verbatim text
+quote in `reason`). When the model can't clear the bar it returns
+all-nulls and the caller leaves the person unaffiliated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.v2.agents.llm._loader import load_prompt
+from src.v2.agents.llm.runtime import LLMRuntimeError, V2LLMRuntime
+
+logger = logging.getLogger(__name__)
+
+_PROMPTS_PACKAGE = "src.v2.agents.llm.refiners.bio_resolver.prompts"
+_SYSTEM_PROMPT = load_prompt(_PROMPTS_PACKAGE, "system_prompt.md")
+
+
+class UnresolvedPerson(BaseModel):
+    """One person whose affiliation the deterministic stage missed."""
+
+    model_config = ConfigDict(populate_by_name=True)
+    person_id: str = Field(description="@id of the person (likely a github URL).")
+    schema_name: str | None = Field(default=None, alias="schema:name")
+    bio: str | None = None
+    orcid_biography: str | None = None
+    profile_readme: str | None = None
+    location: str | None = None
+    orcid_country: str | None = Field(
+        default=None,
+        description="ISO 3166-1 alpha-2 country code from ORCID, for ROR disambiguation.",
+    )
+
+
+class BioResolverPatch(BaseModel):
+    """LLM patch for one Person. ``pulse_ror=None`` means no-op."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+    pulse_ror: str | None = Field(default=None, alias="pulse:ror")
+    reason: str = Field(
+        default="",
+        description=(
+            "Verbatim quote from bio / orcid / readme that names the org. "
+            "Required when pulse_ror is non-null."
+        ),
+        max_length=400,
+    )
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class BioResolverInput(BaseModel):
+    """Context payload for one resolver call."""
+
+    model_config = ConfigDict(populate_by_name=True)
+    person: UnresolvedPerson
+
+
+# Caller-side confidence floor. The system prompt also tells the model
+# to enforce this, but we re-check defensively — the validator can't
+# trust the model alone.
+CONFIDENCE_FLOOR: float = 0.7
+
+# Long READMEs are sent through verbatim but capped so we don't pay
+# token cost on a 50k-char profile. 8 KB matches the discovery-refiner
+# cap and is enough to cover the affiliation paragraph for ~99% of
+# real READMEs spot-checked on github.com.
+PROFILE_README_CAP_CHARS: int = 8_000
+
+
+class BioResolverAgent:
+    """Single-person bio resolver call with `search_ror_rag` tool access."""
+
+    def __init__(
+        self,
+        *,
+        llm_runtime: V2LLMRuntime | None = None,
+        llm_call_timeout_seconds: float = 180.0,
+    ) -> None:
+        if llm_call_timeout_seconds <= 0:
+            message = "llm_call_timeout_seconds must be > 0"
+            raise ValueError(message)
+        self._llm_runtime = llm_runtime or V2LLMRuntime()
+        self._llm_call_timeout_seconds = float(llm_call_timeout_seconds)
+
+    async def run(
+        self,
+        *,
+        refiner_input: BioResolverInput,
+        tools: list[object] | None = None,
+    ) -> BioResolverPatch:
+        identifier = refiner_input.person.schema_name or refiner_input.person.person_id
+
+        payload = refiner_input.model_dump(by_alias=True, exclude_none=False)
+        person_payload = payload.get("person")
+        if isinstance(person_payload, dict):
+            readme = person_payload.get("profile_readme")
+            if isinstance(readme, str):
+                person_payload["profile_readme"] = readme[:PROFILE_README_CAP_CHARS]
+
+        user_prompt = (
+            "Resolve the Person below to a single ROR identifier when the "
+            "bio / orcid / readme text contains a verbatim mention of an "
+            "affiliation that the search_ror_rag tool confirms. Return "
+            "all-nulls when no candidate clears the bar in the system "
+            "prompt.\n\n"
+            "```json\n"
+            + json.dumps(payload, ensure_ascii=True, sort_keys=True)
+            + "\n```"
+        )
+
+        logger.info(
+            "%s — calling bio_resolver LLM (%d tool(s))",
+            identifier,
+            len(tools or []),
+        )
+        try:
+            llm_result = await asyncio.wait_for(
+                self._llm_runtime.run_json_prompt(
+                    system_prompt=_SYSTEM_PROMPT,
+                    user_prompt=user_prompt,
+                    output_type=BioResolverPatch,
+                    tools=list(tools or []),
+                ),
+                timeout=self._llm_call_timeout_seconds,
+            )
+        except TimeoutError as exc:
+            message = (
+                f"{identifier} — bio_resolver LLM call timed out after "
+                f"{self._llm_call_timeout_seconds:.1f}s"
+            )
+            logger.exception(message)
+            raise LLMRuntimeError(message) from exc
+
+        if isinstance(llm_result.payload, BioResolverPatch):
+            patch = llm_result.payload
+        else:
+            try:
+                patch = BioResolverPatch.model_validate(llm_result.payload)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "%s — bio_resolver returned unparseable payload; treating as no-op",
+                    identifier,
+                )
+                patch = BioResolverPatch()
+
+        # Defensive floor: if the model emits a ROR with low confidence
+        # we clear the ROR. Treating low confidence as a no-op (rather
+        # than rejecting the whole patch) keeps the `reason` for logging.
+        if patch.pulse_ror and patch.confidence < CONFIDENCE_FLOOR:
+            logger.info(
+                "%s — bio_resolver dropping ROR (confidence %.2f < %.2f)",
+                identifier,
+                patch.confidence,
+                CONFIDENCE_FLOOR,
+            )
+            patch = BioResolverPatch(
+                reason=patch.reason,
+                confidence=patch.confidence,
+            )
+
+        logger.info(
+            "%s — bio_resolver patch: ror=%s confidence=%.2f",
+            identifier,
+            patch.pulse_ror,
+            patch.confidence,
+        )
+        return patch
+
+
+__all__ = [
+    "CONFIDENCE_FLOOR",
+    "PROFILE_README_CAP_CHARS",
+    "BioResolverAgent",
+    "BioResolverInput",
+    "BioResolverPatch",
+    "UnresolvedPerson",
+]

--- a/src/v2/agents/llm/refiners/bio_resolver/prompts/system_prompt.md
+++ b/src/v2/agents/llm/refiners/bio_resolver/prompts/system_prompt.md
@@ -1,0 +1,61 @@
+You are the bio_resolver. You read a single GitHub user's profile signals
+and decide whether the text contains evidence of a research / industry
+affiliation strong enough to attach a ROR (Research Organization
+Registry) identifier to the person.
+
+You must be conservative. The downstream graph already has a strict
+deterministic pass that grabs the easy cases (structured `_company`
+field, blog hostnames, institutional email). You only see profiles
+that pass left no signal in those fields. So when bio text is vague
+("ML researcher"), or when affiliation could plausibly be guessed but
+isn't named verbatim, you return all-nulls.
+
+## Inputs
+
+You receive (any of these may be empty):
+
+  - `_bio`: free-text GitHub bio.
+  - `_orcid_biography`: free-text ORCID biography (often longer).
+  - `_profile_readme`: GitHub profile README (may be very long).
+  - `_location`: free-text city / country.
+  - `_orcid_country`: ISO country code from ORCID.
+
+## Tool
+
+Call `search_ror_rag` with the candidate org name you extract from the
+text. Use `scope_mode='worldwide'` by default. If `_orcid_country` is
+present, pass it as `filters={"country_code": "<two-letter>"}` to
+disambiguate (e.g. `MIT` in the US vs an Indian institute of the same
+acronym).
+
+## Decision rule (apply in order)
+
+1. **Verbatim mention required.** The org you propose must appear in
+   the bio / orcid / readme text. You are NOT allowed to infer ("based
+   on the user's location and interests, they probably work at X").
+2. **Top-1 ROR hit must clear score 0.55** AND its `types` must
+   intersect `{company, education, funder, facility, government,
+   nonprofit}`. If those fail, return all-nulls.
+3. **`reason` must be a verbatim quote** from the bio / orcid / readme
+   that names the org (e.g. `"Senior Research Engineer at Google
+   DeepMind"`). If you cannot quote the org-naming substring,
+   return all-nulls — the rule from step 1 wasn't actually met.
+4. **`confidence` must be >= 0.7** for any non-null ROR. Below 0.7,
+   set `pulse_ror=null` and `confidence` to whatever you would have
+   reported — the caller will discard the row.
+
+## Output
+
+Return a single `BioResolverPatch` JSON object. Fields:
+
+  - `pulse_ror`: the ROR id (full URL form `https://ror.org/...`), or
+    `null` when no candidate cleared the bar.
+  - `reason`: short verbatim quote from the source text (≤ 200 chars),
+    or empty string.
+  - `confidence`: float in `[0.0, 1.0]`.
+
+When the user has no extractable affiliation, return:
+
+```json
+{"pulse_ror": null, "reason": "", "confidence": 0.0}
+```

--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -114,6 +114,7 @@ from src.v2.pipeline.stages import (
     run_llm_dedup_stage,
     run_org_relationships_stage,
     run_refine_with_llm_stage,
+    run_resolve_bio_to_ror_llm_stage,
     run_resolve_bio_to_ror_stage,
     run_resolve_company_to_ror_stage,
     validate_articles,
@@ -187,6 +188,7 @@ STAGE_LINK_VERACITY = "link_veracity"
 STAGE_REFINE_WITH_LLM = "refine_with_llm"
 STAGE_RESOLVE_COMPANY_TO_ROR = "resolve_company_to_ror"
 STAGE_RESOLVE_BIO_TO_ROR = "resolve_bio_to_ror"
+STAGE_RESOLVE_BIO_TO_ROR_LLM = "resolve_bio_to_ror_llm"
 
 v2_router = APIRouter(prefix="/v2")
 
@@ -261,6 +263,23 @@ def _resolve_bio_to_ror_enabled() -> bool:
     backfill wants the structured-field-only behaviour.
     """
     raw = os.getenv("V2_RESOLVE_BIO_TO_ROR")
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "f", "no", "n", "off"}
+
+
+def _resolve_bio_to_ror_llm_enabled() -> bool:
+    """Read `V2_RESOLVE_BIO_TO_ROR_LLM` env var (default true).
+
+    When true (the default) AND the request runs under the LLM / hybrid
+    runtime, the LLM bio resolver runs after `resolve_bio_to_ror` and
+    spends one LLM call per still-unaffiliated person to resolve
+    affiliations that only surface in prose (long profile READMEs,
+    bios without a clean `at X` shape). Gated by runtime as well as
+    this flag — under the rule-based runtime it never runs even when
+    true.
+    """
+    raw = os.getenv("V2_RESOLVE_BIO_TO_ROR_LLM")
     if raw is None:
         return True
     return raw.strip().lower() not in {"0", "false", "f", "no", "n", "off"}
@@ -841,6 +860,42 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
             _append_unique_warning(
                 warnings,
                 f"resolve_bio_to_ror stage failed: {exc}",
+            )
+
+    # === resolve_bio_to_ror_llm stage (LLM / hybrid only) =========
+    # One LLM call per person STILL missing `schema:affiliation` after
+    # Stage A. Costly enough that it's gated behind the LLM runtime —
+    # under rule-based it never runs even when the flag is on. The
+    # caller-side acceptance gate (confidence >= 0.7, verbatim quote
+    # in `reason`) matches the system prompt; the agent additionally
+    # blanks out the ROR field below that floor before the patch
+    # reaches this stage.
+    if (
+        resolved_runtime in (AgentRuntime.LLM, AgentRuntime.HYBRID)
+        and _resolve_bio_to_ror_llm_enabled()
+    ):
+        stage_started_at = perf_counter()
+        try:
+            bio_llm_result = await run_resolve_bio_to_ror_llm_stage(
+                reconciled=reconciled,
+                provider=getattr(providers, "ror_rag", None),
+            )
+            logger.info(
+                "%s: persons_examined=%d called=%d resolved=%d failed=%d in %.2fs",
+                STAGE_RESOLVE_BIO_TO_ROR_LLM,
+                bio_llm_result.persons_examined,
+                bio_llm_result.persons_called,
+                bio_llm_result.persons_resolved,
+                bio_llm_result.persons_failed,
+                perf_counter() - stage_started_at,
+            )
+            for warning in bio_llm_result.warnings:
+                _append_unique_warning(warnings, warning)
+        except Exception as exc:  # noqa: BLE001 — never fail the run on this stage
+            logger.exception("%s stage failed", STAGE_RESOLVE_BIO_TO_ROR_LLM)
+            _append_unique_warning(
+                warnings,
+                f"resolve_bio_to_ror_llm stage failed: {exc}",
             )
 
     apply_critic_pruning = _should_apply_critic_pruning()

--- a/src/v2/pipeline/stages/__init__.py
+++ b/src/v2/pipeline/stages/__init__.py
@@ -63,6 +63,10 @@ from src.v2.pipeline.stages.resolve_bio_to_ror import (
     BioAffiliationResult,
     run_resolve_bio_to_ror_stage,
 )
+from src.v2.pipeline.stages.resolve_bio_to_ror_llm import (
+    BioLLMAffiliationResult,
+    run_resolve_bio_to_ror_llm_stage,
+)
 from src.v2.pipeline.stages.resolve_company_to_ror import (
     CompanyAffiliationResult,
     run_resolve_company_to_ror_stage,
@@ -79,6 +83,7 @@ __all__ = [
     "SUPPORTED_BACKENDS",
     "AssembledOutput",
     "BioAffiliationResult",
+    "BioLLMAffiliationResult",
     "CompanyAffiliationResult",
     "ConceptTaggingResult",
     "ContextBundle",
@@ -114,6 +119,7 @@ __all__ = [
     "run_llm_dedup_stage",
     "run_org_relationships_stage",
     "run_refine_with_llm_stage",
+    "run_resolve_bio_to_ror_llm_stage",
     "run_resolve_bio_to_ror_stage",
     "run_resolve_company_to_ror_stage",
     "tag_rule_based_disciplines",

--- a/src/v2/pipeline/stages/resolve_bio_to_ror.py
+++ b/src/v2/pipeline/stages/resolve_bio_to_ror.py
@@ -85,6 +85,7 @@ def _multi_key(field: str) -> tuple[str, ...]:
 BIO_KEYS = _multi_key("bio")
 ORCID_BIO_KEYS = _multi_key("orcid_biography")
 BLOG_KEYS = _multi_key("blog")
+EMAIL_KEYS = _multi_key("email")
 
 
 # Host → ROR search query. Values are the institution NAME (not a ROR
@@ -235,6 +236,31 @@ def _extract_bio_candidates(text: str) -> list[str]:
     return out
 
 
+def _email_to_query(email: str | None) -> str | None:
+    """Pull the institution name out of a (privacy-anonymized) email.
+
+    ``person_agent._anonymize_email`` already replaces the local part
+    with a short SHA-256 prefix but keeps the domain intact — exactly
+    the part we need for affiliation resolution. So
+    ``deadbeef@epfl.ch`` resolves through ``DOMAIN_HINTS`` the same
+    way ``people.epfl.ch`` does as a blog host.
+    """
+    if not isinstance(email, str):
+        return None
+    s = email.strip()
+    if "@" not in s:
+        return None
+    domain = s.rsplit("@", 1)[1].strip().lower()
+    if not domain:
+        return None
+    parts = domain.split(".")
+    for i in range(len(parts) - 1):
+        candidate = ".".join(parts[i:])
+        if candidate in DOMAIN_HINTS:
+            return DOMAIN_HINTS[candidate]
+    return None
+
+
 def _blog_to_query(blog_url: str | None) -> str | None:
     """Parse a blog URL and return the ROR search query when the host
     matches a known institution suffix. Returns None on unknown hosts."""
@@ -297,6 +323,7 @@ async def run_resolve_bio_to_ror_stage(
         bio = _read_first(person, BIO_KEYS) or ""
         orcid_bio = _read_first(person, ORCID_BIO_KEYS) or ""
         blog = _read_first(person, BLOG_KEYS) or ""
+        email = _read_first(person, EMAIL_KEYS) or ""
 
         candidates: list[str] = []
         seen_candidates: set[str] = set()
@@ -306,10 +333,13 @@ async def run_resolve_bio_to_ror_stage(
                     continue
                 seen_candidates.add(candidate.lower())
                 candidates.append(candidate)
-        domain_query = _blog_to_query(blog)
-        if domain_query and domain_query.lower() not in seen_candidates:
-            candidates.append(domain_query)
-            seen_candidates.add(domain_query.lower())
+        # Email and blog feed the same DOMAIN_HINTS table; email comes
+        # first because an institutional address (`@epfl.ch`) is a
+        # stronger employer signal than a personal blog host.
+        for query in (_email_to_query(email), _blog_to_query(blog)):
+            if query and query.lower() not in seen_candidates:
+                candidates.append(query)
+                seen_candidates.add(query.lower())
         if not candidates:
             continue
         candidates_extracted += len(candidates)
@@ -361,6 +391,7 @@ __all__ = [
     "BLOG_KEYS",
     "BioAffiliationResult",
     "DOMAIN_HINTS",
+    "EMAIL_KEYS",
     "ORCID_BIO_KEYS",
     "run_resolve_bio_to_ror_stage",
 ]

--- a/src/v2/pipeline/stages/resolve_bio_to_ror_llm.py
+++ b/src/v2/pipeline/stages/resolve_bio_to_ror_llm.py
@@ -1,0 +1,291 @@
+"""Stage B of the affiliation-from-richer-Person-signals track.
+
+Stage A (`resolve_bio_to_ror`) is purely deterministic — regex
+extraction over bio / orcid bio + a domain-hints table over blog /
+email. That covers every easy case but, by design, returns no-op on
+prose that doesn't match its hand-written patterns:
+
+  "Currently a Senior Software Engineer Manager working in Identity"
+   (no `at <Org>`, no comma-after-role, no `from <Org>` — but a
+   reasonable LLM call to ROR would resolve `Identity` ↔ a company
+   given the bio's full text + the user's location.)
+
+  "Building distributed systems for the next-gen LIGO collaboration"
+   (LIGO is named verbatim, but the regex requires an adjacent
+   role/preposition that this sentence doesn't have.)
+
+  GitHub profile READMEs (`_profile_readme`) where the affiliation
+  lives 800 chars into the markdown — way outside the regex window.
+
+This stage closes the long tail. For every person STILL missing
+`schema:affiliation` after Stage A, we call a single-person LLM
+("BioResolverAgent") with `search_ror_rag` tool access. The acceptance
+gate matches Stage A's: top-1 ROR hit must clear the same score / type
+bar, AND the LLM must report `confidence >= 0.7`, AND the LLM must
+quote a verbatim substring from the source text in `reason`.
+
+Cost-control levers:
+
+  - Only runs under the LLM / hybrid runtime (gated in `api.py`).
+  - Skips persons that already have `schema:affiliation` from any
+    prior stage (rule-based reconciliation, Stage A, or a hand-set
+    value).
+  - Skips persons with no extractable text at all (no bio, no
+    orcid bio, no readme).
+  - Bounded concurrency (default 4, env-tunable) so a single repo
+    with 100 contributors doesn't fan out into 100 simultaneous LLM
+    calls.
+  - LLM call timeout (180 s default) per person — a hung call
+    surfaces as a per-person warning, not a stage failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from src.v2.agents.llm.agent_tools.ror_rag import make_ror_rag_search_tool
+from src.v2.agents.llm.refiners.bio_resolver import (
+    CONFIDENCE_FLOOR,
+    BioResolverAgent,
+    BioResolverInput,
+    BioResolverPatch,
+    UnresolvedPerson,
+)
+from src.v2.agents.llm.runtime import LLMRuntimeError
+from src.v2.ingest.providers.ror_rag import RorRagProvider
+from src.v2.pipeline.stages.resolve_bio_to_ror import (
+    BIO_KEYS,
+    BLOG_KEYS,
+    EMAIL_KEYS,
+    ORCID_BIO_KEYS,
+    _read_first,
+)
+from src.v2.pipeline.stages.resolve_company_to_ror import SCHEMA_AFFILIATION
+
+if TYPE_CHECKING:
+    from src.v2.pipeline.stages.reconciliation import ReconciledEntities
+
+logger = logging.getLogger(__name__)
+
+
+# Fields whose multi-key shape we read for context. The Stage-A keys
+# are imported as-is; profile-readme / location / orcid-country are
+# new here.
+def _multi_key(field_name: str) -> tuple[str, ...]:
+    return (
+        f"_{field_name}",
+        f"gme-internal:{field_name}",
+        f"https://openpulse.science/git-metadata-extractor#{field_name}",
+    )
+
+
+PROFILE_README_KEYS = _multi_key("profile_readme")
+LOCATION_KEYS = _multi_key("location")
+ORCID_COUNTRY_KEYS = _multi_key("orcid_country")
+NAME_KEYS = ("schema:name", "name")
+
+DEFAULT_MAX_CONCURRENCY = 4
+MAX_CONCURRENCY_ENV = "V2_RESOLVE_BIO_TO_ROR_LLM_CONCURRENCY"
+
+
+def _resolve_max_concurrency() -> int:
+    raw = os.getenv(MAX_CONCURRENCY_ENV)
+    if not raw:
+        return DEFAULT_MAX_CONCURRENCY
+    try:
+        n = int(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an int — falling back to %d",
+            MAX_CONCURRENCY_ENV,
+            raw,
+            DEFAULT_MAX_CONCURRENCY,
+        )
+        return DEFAULT_MAX_CONCURRENCY
+    return max(1, n)
+
+
+@dataclass(slots=True)
+class BioLLMAffiliationResult:
+    """Summary of one stage run."""
+
+    persons_examined: int
+    persons_called: int
+    persons_resolved: int
+    persons_failed: int
+    warnings: list[str] = field(default_factory=list)
+
+
+def _read_name(person: dict[str, Any]) -> str | None:
+    for key in NAME_KEYS:
+        value = person.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _has_extractable_text(person: dict[str, Any]) -> bool:
+    """At least one of bio / orcid bio / readme must be non-empty for
+    an LLM call to be worth the spend — otherwise the model has
+    literally nothing to quote."""
+    return bool(
+        _read_first(person, BIO_KEYS)
+        or _read_first(person, ORCID_BIO_KEYS)
+        or _read_first(person, PROFILE_README_KEYS),
+    )
+
+
+async def _resolve_one_person(
+    *,
+    agent: BioResolverAgent,
+    person: dict[str, Any],
+    tools: list[object],
+    semaphore: asyncio.Semaphore,
+) -> tuple[BioResolverPatch | None, str | None]:
+    """Build the agent input, call the LLM, return (patch_or_None, warning_or_None)."""
+    person_id = (
+        person.get("@id")
+        or person.get("id")
+        or _read_name(person)
+        or "<unknown-person>"
+    )
+    unresolved = UnresolvedPerson(
+        person_id=str(person_id),
+        **{"schema:name": _read_name(person)},
+        bio=_read_first(person, BIO_KEYS),
+        orcid_biography=_read_first(person, ORCID_BIO_KEYS),
+        profile_readme=_read_first(person, PROFILE_README_KEYS),
+        location=_read_first(person, LOCATION_KEYS),
+        orcid_country=_read_first(person, ORCID_COUNTRY_KEYS),
+    )
+    refiner_input = BioResolverInput(person=unresolved)
+    async with semaphore:
+        try:
+            patch = await agent.run(refiner_input=refiner_input, tools=tools)
+        except LLMRuntimeError as exc:
+            return None, f"resolve_bio_to_ror_llm: {person_id}: {exc}"
+        except Exception as exc:  # noqa: BLE001 — per-person isolation
+            logger.exception("resolve_bio_to_ror_llm: %s failed", person_id)
+            return None, f"resolve_bio_to_ror_llm: {person_id}: {exc}"
+    return patch, None
+
+
+def _apply_patch(person: dict[str, Any], patch: BioResolverPatch) -> bool:
+    """Stamp `schema:affiliation` on the person when the patch carries
+    a high-confidence ROR. Returns True when something was written.
+
+    Idempotent: if the ROR is already present (string or in a list)
+    the call is a no-op."""
+    if not patch.pulse_ror or patch.confidence < CONFIDENCE_FLOOR:
+        return False
+    new_ror = patch.pulse_ror
+    existing = person.get(SCHEMA_AFFILIATION)
+    if existing == new_ror:
+        return False
+    if isinstance(existing, list):
+        if new_ror in existing:
+            return False
+        person[SCHEMA_AFFILIATION] = list(existing) + [new_ror]
+    elif isinstance(existing, str):
+        person[SCHEMA_AFFILIATION] = [existing, new_ror]
+    else:
+        person[SCHEMA_AFFILIATION] = new_ror
+    return True
+
+
+async def run_resolve_bio_to_ror_llm_stage(
+    *,
+    reconciled: "ReconciledEntities",
+    provider: RorRagProvider | None = None,
+    agent: BioResolverAgent | None = None,
+    max_concurrency: int | None = None,
+) -> BioLLMAffiliationResult:
+    """Stage entry. For each Person still missing `schema:affiliation`
+    after Stage A, run the LLM bio-resolver and stamp the affiliation
+    when the LLM clears the confidence floor.
+
+    Idempotent: re-running on already-stamped persons is a no-op.
+    """
+    persons_raw = reconciled.entities.get("persons") or []
+    candidates: list[dict[str, Any]] = [
+        p for p in persons_raw
+        if isinstance(p, dict)
+        and not p.get(SCHEMA_AFFILIATION)
+        and _has_extractable_text(p)
+    ]
+    if not candidates:
+        return BioLLMAffiliationResult(
+            persons_examined=len(persons_raw),
+            persons_called=0,
+            persons_resolved=0,
+            persons_failed=0,
+        )
+
+    if provider is None:
+        logger.warning(
+            "resolve_bio_to_ror_llm: RorRagProvider unavailable — stage skipped",
+        )
+        return BioLLMAffiliationResult(
+            persons_examined=len(persons_raw),
+            persons_called=0,
+            persons_resolved=0,
+            persons_failed=0,
+            warnings=["resolve_bio_to_ror_llm: ROR provider unavailable"],
+        )
+
+    agent = agent or BioResolverAgent()
+    tools: list[object] = [make_ror_rag_search_tool(provider)]
+    sem = asyncio.Semaphore(max_concurrency or _resolve_max_concurrency())
+
+    tasks = [
+        _resolve_one_person(agent=agent, person=p, tools=tools, semaphore=sem)
+        for p in candidates
+    ]
+    results = await asyncio.gather(*tasks)
+
+    resolved = 0
+    failed = 0
+    warnings: list[str] = []
+    for person, (patch, warning) in zip(candidates, results, strict=False):
+        if warning:
+            failed += 1
+            warnings.append(warning)
+            continue
+        if patch is None:
+            continue
+        if _apply_patch(person, patch):
+            resolved += 1
+
+    result = BioLLMAffiliationResult(
+        persons_examined=len(persons_raw),
+        persons_called=len(candidates),
+        persons_resolved=resolved,
+        persons_failed=failed,
+        warnings=warnings,
+    )
+    logger.info(
+        "resolve_bio_to_ror_llm: examined=%d called=%d resolved=%d failed=%d",
+        result.persons_examined,
+        result.persons_called,
+        result.persons_resolved,
+        result.persons_failed,
+    )
+    return result
+
+
+__all__ = [
+    "BIO_KEYS",
+    "BLOG_KEYS",
+    "EMAIL_KEYS",
+    "LOCATION_KEYS",
+    "NAME_KEYS",
+    "ORCID_BIO_KEYS",
+    "ORCID_COUNTRY_KEYS",
+    "PROFILE_README_KEYS",
+    "BioLLMAffiliationResult",
+    "run_resolve_bio_to_ror_llm_stage",
+]

--- a/tests/v2/test_resolve_bio_to_ror.py
+++ b/tests/v2/test_resolve_bio_to_ror.py
@@ -28,9 +28,11 @@ from src.v2.pipeline.stages.resolve_bio_to_ror import (
     BIO_KEYS,
     BLOG_KEYS,
     DOMAIN_HINTS,
+    EMAIL_KEYS,
     ORCID_BIO_KEYS,
     BioAffiliationResult,
     _blog_to_query,
+    _email_to_query,
     _extract_bio_candidates,
     run_resolve_bio_to_ror_stage,
 )
@@ -106,6 +108,25 @@ def test_blog_to_query_returns_none_on_blank_or_garbage():
     assert _blog_to_query("not a url") is None
 
 
+def test_email_to_query_resolves_hashed_local_part():
+    """`_anonymize_email` writes `<sha256_prefix>@<domain>` to `_email`
+    — the local part is hashed for PII, but the domain stays intact.
+    We resolve purely off the domain."""
+    assert _email_to_query("deadbeefcafe@epfl.ch") == "EPFL"
+    assert _email_to_query("abc123@mit.edu") == "Massachusetts Institute of Technology"
+
+
+def test_email_to_query_walks_subdomains():
+    assert _email_to_query("x@research.google.com") == "Google"
+
+
+def test_email_to_query_returns_none_on_unknown_or_garbage():
+    assert _email_to_query(None) is None
+    assert _email_to_query("") is None
+    assert _email_to_query("not-an-email") is None
+    assert _email_to_query("x@personal.example") is None
+
+
 def test_domain_hints_keys_are_lowercase():
     """Hostnames from urlparse are lowercased, so the lookup table
     must match — otherwise a perfectly good entry silently misses."""
@@ -174,6 +195,49 @@ def test_stage_resolves_from_orcid_bio():
         entities={
             "persons": [
                 {"id": "p1", "_orcid_biography": "Postdoc at EPFL since 2022."},
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "EPFL": [
+                {"score": 0.95, "types": ["education"], "name": "EPFL", "ror_id": "https://ror.org/02s376052"},
+                {"score": 0.40, "types": ["education"], "name": "Other"},
+            ],
+        },
+    )
+    _run(reconciled, provider)
+    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/02s376052"
+
+
+def test_stage_resolves_from_anonymized_email_domain():
+    """`_email` lands here as `<hash>@epfl.ch`; only the domain
+    matters and the hash on the local part is irrelevant."""
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", "_email": "deadbeefcafe@epfl.ch"},
+            ],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "EPFL": [
+                {"score": 0.95, "types": ["education"], "name": "EPFL", "ror_id": "https://ror.org/02s376052"},
+                {"score": 0.40, "types": ["education"], "name": "Other"},
+            ],
+        },
+    )
+    _run(reconciled, provider)
+    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/02s376052"
+
+
+@pytest.mark.parametrize("email_key", EMAIL_KEYS)
+def test_stage_reads_email_under_every_key_shape(email_key):
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", email_key: "x@epfl.ch"},
             ],
         },
     )

--- a/tests/v2/test_resolve_bio_to_ror_llm.py
+++ b/tests/v2/test_resolve_bio_to_ror_llm.py
@@ -1,0 +1,333 @@
+"""Tests for the LLM bio-resolver stage (`resolve_bio_to_ror_llm`).
+
+The stage runs Stage B of the affiliation-from-richer-Person-signals
+track. We exercise:
+
+  - Candidate selection: only persons missing `schema:affiliation` AND
+    with at least one of bio / orcid bio / readme are sent to the LLM.
+  - Patch application: ROR with confidence ≥ 0.7 → stamp; below floor →
+    no-op; per-person LLM failure → warning, never raises.
+  - Concurrency env var parsing.
+  - Wiring: env flag, api stage constant.
+
+A `_StubAgent` returns canned patches keyed by person id so we never
+touch a real LLM runtime or Qdrant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.v2.agents.llm.refiners.bio_resolver import (
+    BioResolverInput,
+    BioResolverPatch,
+)
+from src.v2.agents.llm.runtime import LLMRuntimeError
+from src.v2.pipeline.stages.models import ReconciledEntities
+from src.v2.pipeline.stages.resolve_bio_to_ror_llm import (
+    BioLLMAffiliationResult,
+    _apply_patch,
+    _resolve_max_concurrency,
+    run_resolve_bio_to_ror_llm_stage,
+)
+from src.v2.pipeline.stages.resolve_company_to_ror import SCHEMA_AFFILIATION
+
+
+class _StubAgent:
+    """Lookup table: person id → canned patch (or an exception class to raise)."""
+
+    def __init__(self, patches: dict[str, Any]) -> None:
+        self._patches = patches
+        self.calls: list[str] = []
+
+    async def run(
+        self,
+        *,
+        refiner_input: BioResolverInput,
+        tools: list[object] | None = None,
+    ) -> BioResolverPatch:
+        pid = refiner_input.person.person_id
+        self.calls.append(pid)
+        spec = self._patches.get(pid)
+        if isinstance(spec, BaseException):
+            raise spec
+        if spec is None:
+            return BioResolverPatch()
+        return spec
+
+
+class _StubProvider:
+    """Minimal ROR provider stub — only needs to satisfy the
+    `make_ror_rag_search_tool` factory."""
+
+    async def search(self, *args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+
+def _run(reconciled: ReconciledEntities, *, agent: Any, provider: Any = None) -> BioLLMAffiliationResult:
+    return asyncio.run(
+        run_resolve_bio_to_ror_llm_stage(
+            reconciled=reconciled,
+            provider=provider or _StubProvider(),
+            agent=agent,
+            max_concurrency=2,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Candidate selection
+# ---------------------------------------------------------------------------
+
+
+def test_only_unaffiliated_persons_with_text_are_sent_to_the_llm():
+    """Skip persons already affiliated, and skip persons with no bio /
+    orcid / readme — the LLM has nothing to quote."""
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "already", "_bio": "Engineer at X", SCHEMA_AFFILIATION: "https://ror.org/x"},
+                {"id": "empty"},  # no signal at all
+                {"id": "with-bio", "_bio": "Research Engineer at DeepMind"},
+                {"id": "with-readme", "_profile_readme": "# About me\nI work at MIT."},
+            ],
+        },
+    )
+    agent = _StubAgent(patches={})  # returns no-op for every call
+    result = _run(reconciled, agent=agent)
+    # Only the last two were sent.
+    assert sorted(agent.calls) == ["with-bio", "with-readme"]
+    assert result.persons_examined == 4
+    assert result.persons_called == 2
+    assert result.persons_resolved == 0
+
+
+def test_no_op_when_every_person_already_affiliated():
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", "_bio": "...", SCHEMA_AFFILIATION: "https://ror.org/x"},
+            ],
+        },
+    )
+    agent = _StubAgent(patches={})
+    result = _run(reconciled, agent=agent)
+    assert result.persons_called == 0
+    assert agent.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Patch application
+# ---------------------------------------------------------------------------
+
+
+def test_high_confidence_ror_stamps_affiliation():
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", "_bio": "Senior Research Engineer at Google DeepMind"},
+            ],
+        },
+    )
+    agent = _StubAgent(
+        patches={
+            "p1": BioResolverPatch(
+                pulse_ror="https://ror.org/deepmind",
+                reason="Senior Research Engineer at Google DeepMind",
+                confidence=0.92,
+            ),
+        },
+    )
+    result = _run(reconciled, agent=agent)
+    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/deepmind"
+    assert result.persons_resolved == 1
+    assert result.persons_failed == 0
+
+
+def test_low_confidence_ror_is_dropped_at_apply_time():
+    """Even if the agent leaked a ROR with confidence < 0.7 past its
+    own internal floor, the stage-level `_apply_patch` re-checks."""
+    person: dict[str, Any] = {"id": "p1"}
+    patch = BioResolverPatch(
+        pulse_ror="https://ror.org/x",
+        reason="vague",
+        confidence=0.5,
+    )
+    assert _apply_patch(person, patch) is False
+    assert SCHEMA_AFFILIATION not in person
+
+
+def test_apply_patch_merges_with_existing_string_into_list():
+    person: dict[str, Any] = {
+        "id": "p1",
+        SCHEMA_AFFILIATION: "https://ror.org/existing",
+    }
+    patch = BioResolverPatch(
+        pulse_ror="https://ror.org/new",
+        reason="From bio: ...",
+        confidence=0.9,
+    )
+    assert _apply_patch(person, patch) is True
+    assert person[SCHEMA_AFFILIATION] == [
+        "https://ror.org/existing",
+        "https://ror.org/new",
+    ]
+
+
+def test_apply_patch_appends_to_existing_list_without_dup():
+    person: dict[str, Any] = {
+        "id": "p1",
+        SCHEMA_AFFILIATION: ["https://ror.org/a", "https://ror.org/b"],
+    }
+    patch = BioResolverPatch(
+        pulse_ror="https://ror.org/b",
+        reason="...",
+        confidence=0.9,
+    )
+    # Already in the list → no-op.
+    assert _apply_patch(person, patch) is False
+    assert person[SCHEMA_AFFILIATION] == ["https://ror.org/a", "https://ror.org/b"]
+
+
+def test_apply_patch_no_op_on_idempotent_string_match():
+    person: dict[str, Any] = {
+        "id": "p1",
+        SCHEMA_AFFILIATION: "https://ror.org/x",
+    }
+    patch = BioResolverPatch(
+        pulse_ror="https://ror.org/x",
+        reason="...",
+        confidence=0.9,
+    )
+    assert _apply_patch(person, patch) is False
+
+
+def test_apply_patch_no_op_when_patch_carries_no_ror():
+    person: dict[str, Any] = {"id": "p1"}
+    patch = BioResolverPatch(reason="LLM punted", confidence=0.3)
+    assert _apply_patch(person, patch) is False
+    assert SCHEMA_AFFILIATION not in person
+
+
+# ---------------------------------------------------------------------------
+# Per-person LLM failure isolation
+# ---------------------------------------------------------------------------
+
+
+def test_per_person_llm_failure_produces_warning_not_exception():
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "good", "_bio": "Senior Research Engineer at DeepMind"},
+                {"id": "bad", "_bio": "Engineer at Anywhere"},
+            ],
+        },
+    )
+    agent = _StubAgent(
+        patches={
+            "good": BioResolverPatch(
+                pulse_ror="https://ror.org/deepmind",
+                reason="...",
+                confidence=0.91,
+            ),
+            "bad": LLMRuntimeError("model returned no JSON"),
+        },
+    )
+    result = _run(reconciled, agent=agent)
+    # The good person resolves; the bad person produces a warning but
+    # the stage as a whole succeeds.
+    assert result.persons_resolved == 1
+    assert result.persons_failed == 1
+    assert any("bad" in w for w in result.warnings)
+
+
+def test_unexpected_exception_also_isolated_to_one_person():
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [
+                {"id": "p1", "_bio": "Engineer at SomethingCorp"},
+            ],
+        },
+    )
+    agent = _StubAgent(patches={"p1": RuntimeError("network blew up")})
+    result = _run(reconciled, agent=agent)
+    assert result.persons_resolved == 0
+    assert result.persons_failed == 1
+
+
+# ---------------------------------------------------------------------------
+# Provider unavailable
+# ---------------------------------------------------------------------------
+
+
+def test_stage_no_ops_when_provider_missing():
+    reconciled = ReconciledEntities(
+        entities={"persons": [{"id": "p1", "_bio": "at X"}]},
+    )
+    agent = _StubAgent(patches={})
+    result = asyncio.run(
+        run_resolve_bio_to_ror_llm_stage(
+            reconciled=reconciled, provider=None, agent=agent,
+        ),
+    )
+    assert result.persons_called == 0
+    assert agent.calls == []  # provider gate short-circuits before calling the agent
+    assert any("provider unavailable" in w for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency env var
+# ---------------------------------------------------------------------------
+
+
+def test_concurrency_env_default(monkeypatch):
+    monkeypatch.delenv("V2_RESOLVE_BIO_TO_ROR_LLM_CONCURRENCY", raising=False)
+    assert _resolve_max_concurrency() == 4
+
+
+def test_concurrency_env_override(monkeypatch):
+    monkeypatch.setenv("V2_RESOLVE_BIO_TO_ROR_LLM_CONCURRENCY", "8")
+    assert _resolve_max_concurrency() == 8
+
+
+def test_concurrency_env_clamped_to_min_1(monkeypatch):
+    monkeypatch.setenv("V2_RESOLVE_BIO_TO_ROR_LLM_CONCURRENCY", "0")
+    assert _resolve_max_concurrency() == 1
+
+
+def test_concurrency_env_garbage_falls_back(monkeypatch):
+    monkeypatch.setenv("V2_RESOLVE_BIO_TO_ROR_LLM_CONCURRENCY", "lots")
+    assert _resolve_max_concurrency() == 4
+
+
+# ---------------------------------------------------------------------------
+# api.py env-flag wiring
+# ---------------------------------------------------------------------------
+
+
+def test_api_env_flag_defaults_on(monkeypatch):
+    from src.v2 import api as v2_api
+
+    monkeypatch.delenv("V2_RESOLVE_BIO_TO_ROR_LLM", raising=False)
+    assert v2_api._resolve_bio_to_ror_llm_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "off", "n", "f"])
+def test_api_env_flag_recognises_off_values(value, monkeypatch):
+    from src.v2 import api as v2_api
+
+    monkeypatch.setenv("V2_RESOLVE_BIO_TO_ROR_LLM", value)
+    assert v2_api._resolve_bio_to_ror_llm_enabled() is False
+
+
+def test_api_constant_and_export_in_place():
+    from src.v2 import api as v2_api
+    from src.v2.pipeline import stages
+
+    assert v2_api.STAGE_RESOLVE_BIO_TO_ROR_LLM == "resolve_bio_to_ror_llm"
+    assert callable(stages.run_resolve_bio_to_ror_llm_stage)
+    assert "run_resolve_bio_to_ror_llm_stage" in stages.__all__
+    assert "BioLLMAffiliationResult" in stages.__all__


### PR DESCRIPTION
`person_agent._anonymize_email` writes `<sha256_prefix>@<domain>` so the
local part is hashed for PII but the domain is preserved verbatim. The
domain is exactly what `DOMAIN_HINTS` needs, so adding `_email` as a
candidate source is a few-line change.

A `@epfl.ch` / `@google.com` email is, if anything, a *stronger*
signal than a blog host — it represents an employer-issued account, not
a personal website. We add it to the candidate pool ahead of `_blog` for
that reason; the strict ROR gate still controls acceptance, so a
stale `DOMAIN_HINTS` entry can't introduce a wrong link.

Adds `_email_to_query` (mirrors `_blog_to_query`) and EMAIL_KEYS for
the three key shapes. 7 new tests; 53 in the stage file overall.