### PR TITLE
feat(repository): surface CITATION.cff / AUTHORS / CONTRIBUTING / pub…

### DIFF
--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -28,6 +28,60 @@ DATE_ONLY_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 STRICT_TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
 
+# Case-insensitive lookups against the repo-root aux file list. Keys are
+# lowercased filename matchers; values map to the `_*_url` internal
+# field that should be stamped when the matcher hits. Order within a
+# tuple is preference order — we use the first match. The provider
+# (`get_repository_aux_files`) is responsible for fetching these; the
+# agent only stamps a URL pointer so downstream stages (LLM refiners,
+# graph consumers) can quote the source.
+_REPO_AUX_FILE_LOOKUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("_citation_cff_url",  ("citation.cff",)),
+    ("_authors_url",       ("authors", "authors.md", "authors.rst", "authors.txt")),
+    # CONTRIBUTING is the standard spelling; CONTRIBUTION is rarer but
+    # ships in a handful of older research projects.
+    ("_contributing_url",  ("contributing.md", "contribution.md")),
+    ("_publiccode_url",    ("publiccode.yml", "publiccode.yaml")),
+)
+
+
+def _resolve_aux_file_urls(
+    aux_files: Any,
+    *,
+    full_name: str,
+) -> dict[str, str | None]:
+    """Return ``{field: url_or_None}`` for the supplementary repo-root
+    files we expose as internal fields. URL form is canonical
+    (`https://github.com/<owner>/<repo>/blob/HEAD/<filename>`), matching
+    the project-wide "everything is a URL" convention. None is emitted
+    when no case-insensitive match for that field's allowed filenames
+    is in ``aux_files``.
+    """
+    if not isinstance(aux_files, dict) or not full_name:
+        return {field: None for field, _ in _REPO_AUX_FILE_LOOKUPS}
+    # `aux_files` keys come back from GitHub with their original
+    # casing; build a once-only lookup so each field-level scan is O(1).
+    lower_to_original = {
+        str(name).lower(): name
+        for name in aux_files
+        if isinstance(name, str)
+    }
+    out: dict[str, str | None] = {}
+    for field, candidates in _REPO_AUX_FILE_LOOKUPS:
+        matched: str | None = None
+        for candidate in candidates:
+            original = lower_to_original.get(candidate)
+            if original is not None:
+                matched = original
+                break
+        out[field] = (
+            f"https://github.com/{full_name}/blob/HEAD/{matched}"
+            if matched
+            else None
+        )
+    return out
+
+
 def _to_list_of_strings(value: Any) -> list[str]:
     if isinstance(value, str) and value:
         return [value]
@@ -231,6 +285,7 @@ class RepositoryAgentV2:
         contributors: list[dict[str, Any]]
         languages: dict[str, Any]
 
+        aux_files: dict[str, str]
         if reuse_gathered_context and isinstance(repository_context, dict):
             metadata_candidate = repository_context.get("metadata")
             repository = metadata_candidate if isinstance(metadata_candidate, dict) else {}
@@ -244,16 +299,21 @@ class RepositoryAgentV2:
 
             languages_candidate = repository_context.get("languages")
             languages = languages_candidate if isinstance(languages_candidate, dict) else {}
+
+            aux_files_candidate = repository_context.get("aux_files")
+            aux_files = aux_files_candidate if isinstance(aux_files_candidate, dict) else {}
         else:
             repository = providers.github.get_repository(full_name)
             contributors = providers.github.get_contributors(full_name)
             languages = providers.github.get_languages(full_name)
+            aux_files = {}
 
         return {
             "full_name": full_name,
             "repository": repository,
             "contributors": contributors,
             "languages": languages,
+            "aux_files": aux_files,
         }
 
     async def _default_structured_output(  # noqa: C901
@@ -365,6 +425,19 @@ class RepositoryAgentV2:
             "_license_url": (repository.get("license") or {}).get("url"),
             "_avatar_url": (repository.get("owner") or {}).get("avatar_url"),
             "_visibility": repository.get("visibility"),
+            # Pointers to supplementary metadata files at the repo root
+            # (CITATION.cff, AUTHORS, CONTRIBUTING.md, publiccode.yml).
+            # The provider already fetches the *contents* into the
+            # `aux_files` slice of compiled_context for the LLM
+            # refiners; we surface a URL pointer here so non-LLM
+            # consumers (graph queries, dashboards) can link out to
+            # the source-of-truth file even when they don't have the
+            # content in hand. Each value is None when no case-
+            # insensitive match for that field's filename is present.
+            **_resolve_aux_file_urls(
+                compiled_context.get("aux_files"),
+                full_name=full_name,
+            ),
         }
 
     async def _default_repository_classifier(

--- a/src/v2/ingest/providers/github_provider.py
+++ b/src/v2/ingest/providers/github_provider.py
@@ -1056,7 +1056,9 @@ class RealGitHubProvider(GitHubProvider):
         "go.mod", "package.swift", "project.toml", "pom.xml",
         "description",  # R package manifest (Author / Maintainer fields)
         # Research-software & public-sector metadata standards
-        ".zenodo.json", "codemeta.json", "publiccode.yml",
+        ".zenodo.json", "codemeta.json", "publiccode.yml", "publiccode.yaml",
+        # Some projects spell it "CONTRIBUTION.md" instead of CONTRIBUTING.md.
+        "contribution.md",
     })
 
     # Suffix-based matches for ecosystems that name files <project>.ext

--- a/src/v2/pipeline/stages/refine_with_llm.py
+++ b/src/v2/pipeline/stages/refine_with_llm.py
@@ -71,6 +71,21 @@ PERSON_PATCHABLE_FIELDS: frozenset[str] = frozenset({"schema:name"})
 MEMBERSHIP_PATCHABLE_FIELDS: frozenset[str] = frozenset({"org:role"})
 
 README_CONTEXT_MAX_CHARS = 1500
+# Aux file excerpts are short enough that we can ship more characters
+# than the README (the LLM cares about author names / institutional
+# affiliations / cited DOIs, which live in the first ~2-3 KB).
+AUX_FILE_CONTEXT_MAX_CHARS = 4_000
+# Case-insensitive filenames whose contents we forward to the LLM
+# refiners as additional context. Mirrors the agent-level URL pointers
+# in `repository_agent._REPO_AUX_FILE_LOOKUPS` (CITATION.cff / AUTHORS /
+# CONTRIBUTING.md / publiccode.yml). The key in the LLM context summary
+# is the slug; the value is the (capped) file content.
+_AUX_FILE_CONTEXT_LOOKUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("citation_cff",  ("citation.cff",)),
+    ("authors",       ("authors", "authors.md", "authors.rst", "authors.txt")),
+    ("contributing",  ("contributing.md", "contribution.md")),
+    ("publiccode",    ("publiccode.yml", "publiccode.yaml")),
+)
 DEFAULT_MAX_CONCURRENCY = 4
 
 # Discovery refiner thresholds. The LLM is told to only propose
@@ -152,6 +167,30 @@ def _build_repo_context_summary(
     readme = repository_context.get("readme_content")
     if isinstance(readme, str) and readme:
         summary["readme_excerpt"] = readme[:README_CONTEXT_MAX_CHARS]
+
+    # Forward excerpts of supplementary attribution / governance /
+    # public-sector metadata files so the LLM refiners can quote
+    # author names and DOIs straight out of CITATION.cff and AUTHORS
+    # instead of having to re-derive them from the README.
+    aux_files = repository_context.get("aux_files")
+    if isinstance(aux_files, dict) and aux_files:
+        lower_to_original = {
+            str(name).lower(): name
+            for name in aux_files
+            if isinstance(name, str)
+        }
+        aux_excerpts: dict[str, str] = {}
+        for slug, candidates in _AUX_FILE_CONTEXT_LOOKUPS:
+            for candidate in candidates:
+                original = lower_to_original.get(candidate)
+                if original is None:
+                    continue
+                content = aux_files.get(original)
+                if isinstance(content, str) and content.strip():
+                    aux_excerpts[slug] = content[:AUX_FILE_CONTEXT_MAX_CHARS]
+                    break  # first match wins per slug
+        if aux_excerpts:
+            summary["aux_files"] = aux_excerpts
 
     return summary
 

--- a/tests/v2/test_refine_with_llm_aux_files.py
+++ b/tests/v2/test_refine_with_llm_aux_files.py
@@ -1,0 +1,116 @@
+"""Test the aux-file forwarding in `_build_repo_context_summary`.
+
+The function is a pure summariser over the `gathered_context` slice the
+LLM refiners receive. We pin the contract:
+
+  - When CITATION.cff / AUTHORS / CONTRIBUTING.md / publiccode.yml are
+    present in `aux_files`, their (capped) content is forwarded to the
+    LLM via the `aux_files` key in the summary.
+  - Case-insensitive matching against the on-disk filename.
+  - Alternate spellings (publiccode.yaml, CONTRIBUTION.md) are also
+    recognised — they match the same slug.
+  - Empty / missing slice → no `aux_files` key emitted (caller checks).
+  - Long file contents are capped at `AUX_FILE_CONTEXT_MAX_CHARS`.
+"""
+
+from __future__ import annotations
+
+from src.v2.pipeline.stages.refine_with_llm import (
+    AUX_FILE_CONTEXT_MAX_CHARS,
+    _build_repo_context_summary,
+)
+
+
+def _wrap_context(aux_files: dict[str, str] | None) -> dict[str, dict[str, object]]:
+    return {
+        "repository": {
+            "metadata": {"name": "Hello-World", "full_name": "octocat/Hello-World"},
+            "readme_content": "",
+            "aux_files": aux_files,
+        },
+    }
+
+
+def test_summary_forwards_all_four_aux_files_when_present():
+    summary = _build_repo_context_summary(
+        gathered_context=_wrap_context({
+            "CITATION.cff": "cff-version: 1.2.0\nauthors:\n - given-names: Octo",
+            "AUTHORS.md": "- Octo Cat\n- Alice",
+            "CONTRIBUTING.md": "Open a PR.",
+            "publiccode.yml": "publiccodeYmlVersion: '0.4'",
+        }),
+    )
+    aux = summary["aux_files"]
+    assert set(aux.keys()) == {"citation_cff", "authors", "contributing", "publiccode"}
+    assert aux["citation_cff"].startswith("cff-version:")
+    assert aux["authors"].startswith("- Octo")
+    assert aux["contributing"] == "Open a PR."
+    assert aux["publiccode"].startswith("publiccodeYmlVersion:")
+
+
+def test_summary_case_insensitive_match():
+    """Real GitHub responses preserve the file's casing. The lookup
+    should still match `Citation.CFF` and `Authors.RST` etc."""
+    summary = _build_repo_context_summary(
+        gathered_context=_wrap_context({
+            "Citation.CFF": "cff-version: 1.2.0",
+            "Authors.RST": "Octo Cat",
+        }),
+    )
+    aux = summary["aux_files"]
+    assert "citation_cff" in aux
+    assert "authors" in aux
+
+
+def test_summary_recognises_alternate_publiccode_extension():
+    summary = _build_repo_context_summary(
+        gathered_context=_wrap_context({"publiccode.yaml": "publiccodeYmlVersion: '0.4'"}),
+    )
+    assert summary["aux_files"]["publiccode"].startswith("publiccodeYmlVersion:")
+
+
+def test_summary_recognises_alternate_contribution_spelling():
+    summary = _build_repo_context_summary(
+        gathered_context=_wrap_context({"CONTRIBUTION.md": "be nice"}),
+    )
+    assert summary["aux_files"]["contributing"] == "be nice"
+
+
+def test_summary_omits_aux_files_key_when_no_relevant_files():
+    """Just a README and nothing else — the `aux_files` key shouldn't
+    pollute the summary."""
+    summary = _build_repo_context_summary(
+        gathered_context=_wrap_context({"README.md": "Hello"}),
+    )
+    assert "aux_files" not in summary
+
+
+def test_summary_handles_missing_aux_files_slice():
+    """`aux_files` may be absent or None — the summariser must not raise."""
+    summary = _build_repo_context_summary(
+        gathered_context={"repository": {"metadata": {}, "readme_content": ""}},
+    )
+    assert "aux_files" not in summary
+
+
+def test_summary_caps_long_aux_file_contents():
+    big = "x" * (AUX_FILE_CONTEXT_MAX_CHARS + 1_000)
+    summary = _build_repo_context_summary(
+        gathered_context=_wrap_context({"CITATION.cff": big}),
+    )
+    assert len(summary["aux_files"]["citation_cff"]) == AUX_FILE_CONTEXT_MAX_CHARS
+
+
+def test_summary_picks_first_match_per_slug():
+    """When both `authors` and `authors.md` are present, the first
+    match in the candidate order wins — deterministic regardless of
+    Python dict insertion order."""
+    summary = _build_repo_context_summary(
+        gathered_context=_wrap_context({
+            "authors.md": "the md version",
+            "AUTHORS": "the plain version",
+        }),
+    )
+    # `authors` (no extension) comes first in the candidate tuple, so
+    # it wins regardless of which file the dict iterates first.
+    assert summary["aux_files"]["authors"] == "the plain version"

--- a/tests/v2/test_repository_agent.py
+++ b/tests/v2/test_repository_agent.py
@@ -158,3 +158,120 @@ def test_repository_agent_filters_organization_contributors_from_authors() -> No
     derivation = result.stats.get("derivation")
     assert isinstance(derivation, dict)
     assert derivation["contributor_logins"] == ["alice"]
+
+
+def test_repository_agent_emits_aux_file_urls_for_present_files() -> None:
+    """When the context-gather slice carries a CITATION.cff / AUTHORS /
+    CONTRIBUTING.md / publiccode.yml, the agent should stamp a URL
+    pointer for each. The matcher is case-insensitive (real GitHub
+    responses preserve the on-disk casing)."""
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "octocat/Hello-World",
+                "repository_context": {
+                    "full_name": "octocat/Hello-World",
+                    "metadata": {
+                        "name": "Hello-World",
+                        "full_name": "octocat/Hello-World",
+                        "owner": {"login": "octocat", "type": "User"},
+                        "created_at": "2020-01-01T00:00:00Z",
+                        "license": {"spdx_id": "MIT"},
+                        "fork": False,
+                        "source": {"full_name": None},
+                    },
+                    "contributors": [{"login": "octocat"}],
+                    "languages": {"Python": 1},
+                    "aux_files": {
+                        # GitHub preserves the on-disk casing.
+                        "CITATION.cff": "cff-version: 1.2.0\nauthors:\n - given-names: Octo\n   family-names: Cat",
+                        "AUTHORS.md": "- Octo Cat",
+                        "CONTRIBUTING.md": "Open a PR.",
+                        "publiccode.yaml": "publiccodeYmlVersion: '0.4'",
+                    },
+                },
+            },
+            providers,
+        ),
+    )
+
+    raw = result.raw_output
+    assert raw["_citation_cff_url"] == "https://github.com/octocat/Hello-World/blob/HEAD/CITATION.cff"
+    assert raw["_authors_url"] == "https://github.com/octocat/Hello-World/blob/HEAD/AUTHORS.md"
+    assert raw["_contributing_url"] == "https://github.com/octocat/Hello-World/blob/HEAD/CONTRIBUTING.md"
+    assert raw["_publiccode_url"] == "https://github.com/octocat/Hello-World/blob/HEAD/publiccode.yaml"
+
+
+def test_repository_agent_emits_none_for_absent_aux_files() -> None:
+    """A repo with no CITATION.cff / AUTHORS / CONTRIBUTING / publiccode
+    must explicitly carry `None` for those internal fields so downstream
+    consumers can distinguish "absent" from "not checked"."""
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "octocat/Hello-World",
+                "repository_context": {
+                    "full_name": "octocat/Hello-World",
+                    "metadata": {
+                        "name": "Hello-World",
+                        "full_name": "octocat/Hello-World",
+                        "owner": {"login": "octocat", "type": "User"},
+                        "created_at": "2020-01-01T00:00:00Z",
+                        "license": {"spdx_id": "MIT"},
+                        "fork": False,
+                        "source": {"full_name": None},
+                    },
+                    "contributors": [{"login": "octocat"}],
+                    "languages": {"Python": 1},
+                    "aux_files": {"README.md": "Hello"},  # nothing relevant
+                },
+            },
+            providers,
+        ),
+    )
+
+    raw = result.raw_output
+    assert raw["_citation_cff_url"] is None
+    assert raw["_authors_url"] is None
+    assert raw["_contributing_url"] is None
+    assert raw["_publiccode_url"] is None
+
+
+def test_repository_agent_accepts_alternate_contribution_spelling() -> None:
+    """Some projects ship `CONTRIBUTION.md` (singular) — match that too."""
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "octocat/Hello-World",
+                "repository_context": {
+                    "full_name": "octocat/Hello-World",
+                    "metadata": {
+                        "name": "Hello-World",
+                        "full_name": "octocat/Hello-World",
+                        "owner": {"login": "octocat", "type": "User"},
+                        "created_at": "2020-01-01T00:00:00Z",
+                        "license": {"spdx_id": "MIT"},
+                        "fork": False,
+                        "source": {"full_name": None},
+                    },
+                    "contributors": [{"login": "octocat"}],
+                    "languages": {"Python": 1},
+                    "aux_files": {"CONTRIBUTION.md": "see docs"},
+                },
+            },
+            providers,
+        ),
+    )
+
+    assert result.raw_output["_contributing_url"] == (
+        "https://github.com/octocat/Hello-World/blob/HEAD/CONTRIBUTION.md"
+    )


### PR DESCRIPTION
…liccode

Two complementary additions:

1. Repo agent emits URL pointers on Repository entities

   New internal fields stamped on every Repository when the corresponding file lives at the repo root (case-insensitive match against the `aux_files` slice gathered by context_gather):

     - `_citation_cff_url`  → CITATION.cff
     - `_authors_url`       → AUTHORS / AUTHORS.md / AUTHORS.rst / AUTHORS.txt
     - `_contributing_url`  → CONTRIBUTING.md (also CONTRIBUTION.md — used in a
                              handful of older research projects)
     - `_publiccode_url`    → publiccode.yml / publiccode.yaml

   Values are full GitHub URL form (`https://github.com/<owner>/<repo>/
   blob/HEAD/<filename>`) per the project-wide IRI convention. Each
   field is None when the file is absent — explicit absence is useful
   for graph consumers that need to distinguish "checked, not present"
   from "not checked."

   Provider already fetched citation/authors/contributing/publiccode
   content as part of `get_repository_aux_files`; this commit:
     a. extends `_AUX_FILE_PATTERNS` with the missing variants
        (publiccode.yaml, contribution.md);
     b. teaches the agent's `_context_compiler` to forward `aux_files`
        through the reuse path (previously dropped on the floor);
     c. stamps the four `_*_url` fields on the agent output.

2. LLM refiner context includes excerpts of the same four files

   `refine_with_llm._build_repo_context_summary` already gives the refiners the README excerpt; this commit adds an `aux_files` slot carrying capped contents (4 KB each) of CITATION.cff / AUTHORS / CONTRIBUTING / publiccode. The refiners can now quote author names and DOIs straight out of CITATION.cff instead of guessing from the README.

Tests:
  - 3 new tests on the repo agent (present / absent / alternate spelling)
  - 8 new tests on the LLM context summariser (4 slugs, case-insensitive, cap enforcement, deterministic ordering, missing-slice safety)