### PR TITLE
feat(organization_agent): surface six unused GitHub-org REST fields

### DIFF
--- a/src/v2/agents/rule_based/organization_agent.py
+++ b/src/v2/agents/rule_based/organization_agent.py
@@ -462,6 +462,21 @@ class OrganizationAgentV2:
             "_github_created_at":  github_org.get("created_at"),
             "_github_updated_at":  github_org.get("updated_at"),
             "_github_account_type": github_org.get("type"),
+            # GitHub trust + activity signals we previously dropped on the
+            # floor. `is_verified` is GitHub's domain-ownership verification
+            # flag — when true, GitHub has confirmed the org owns the
+            # domain(s) listed on its profile, and the downstream
+            # `org_resolver` can short-circuit (the org is real, the
+            # ROR lookup is the only remaining question). `archived_at`
+            # is the org-level archival timestamp (distinct from per-repo
+            # `_archived`); pruning rollups against this is much cheaper
+            # than scanning all repos.
+            "_is_verified":            github_org.get("is_verified"),
+            "_archived_at":            github_org.get("archived_at"),
+            "_public_gists":           github_org.get("public_gists"),
+            "_following_count":        github_org.get("following"),
+            "_has_organization_projects": github_org.get("has_organization_projects"),
+            "_has_repository_projects":   github_org.get("has_repository_projects"),
             # ROR profile extras.
             "_ror_country":        ror_record.get("country") if isinstance(ror_record, dict) else None,
             "_ror_types":          ror_record.get("types") if isinstance(ror_record, dict) else None,

--- a/tests/v2/fixtures/providers/github/org_payload.json
+++ b/tests/v2/fixtures/providers/github/org_payload.json
@@ -18,8 +18,11 @@
   "email": "support@github.com",
   "is_verified": true,
   "has_organization_projects": true,
+  "has_repository_projects": true,
   "public_repos": 500,
+  "public_gists": 12,
   "followers": 200000,
   "following": 0,
+  "archived_at": null,
   "type": "Organization"
 }

--- a/tests/v2/test_organization_agent.py
+++ b/tests/v2/test_organization_agent.py
@@ -190,3 +190,29 @@ def test_organization_agent_repository_mode_owns_only_source_repo() -> None:
     )
 
     assert result.data["pulse:owns"] == ["owner-org/source-repo"]
+
+
+def test_organization_agent_surfaces_github_trust_and_activity_signals() -> None:
+    """The org agent should pass through `is_verified` (GitHub's
+    domain-ownership verification flag), `archived_at`, `public_gists`,
+    `following`, and the two `_projects` booleans into the internal
+    `_`-prefixed fields. The fixture sets `is_verified=true` so the
+    downstream `org_resolver` can short-circuit on a verified org."""
+    agent = OrganizationAgentV2()
+    providers = ProviderSet(
+        github=MockGitHubProvider(),
+        ror=MockRORProvider(),
+        infoscience=MockInfoscienceProvider(),
+    )
+
+    result = asyncio.run(
+        agent.run({"org_name": "github"}, providers),
+    )
+
+    raw = result.raw_output
+    assert raw["_is_verified"] is True
+    assert raw["_archived_at"] is None
+    assert raw["_public_gists"] == 12
+    assert raw["_following_count"] == 0
+    assert raw["_has_organization_projects"] is True
+    assert raw["_has_repository_projects"] is True


### PR DESCRIPTION
The `/orgs/{org}` REST endpoint already returns these in the same response we make for the existing internal fields — they were just being dropped. Promoting them costs zero extra requests and gives the downstream stages signal they previously had to guess at.

  - `_is_verified` — GitHub's domain-ownership verification flag. When true, GitHub confirmed the org owns the domain on its profile. The strongest "this org is the real institution" signal we can cheaply capture; the LLM `org_resolver` can short-circuit on verified orgs in a follow-up.
  - `_archived_at` — org-level archival timestamp. Distinct from the per-repo `_archived` flag the repo agent already exposes; useful for pruning rollups against dead author-orgs without rescanning every repo.
  - `_public_gists`, `_following_count` — engagement signals we already track for repos but skipped for orgs.
  - `_has_organization_projects`, `_has_repository_projects` — minor workflow-model signals (off-by-default for many orgs, useful for classification on the long tail).

Fixture already carried `is_verified`/`has_organization_projects`/ `following`; added `has_repository_projects`/`public_gists`/`archived_at` to round out the shape.