### PR TITLE
feat(repository): parse publiccode.yml into typed `_publiccode` field

### DIFF
--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -12,6 +12,7 @@ from src.v2.agents.models import (
     generate_uuid,
     validate_permissive,
 )
+from src.v2.parsers.publiccode import parse_publiccode
 
 CompiledContextStage = Callable[[dict[str, Any], ProviderSet], dict[str, Any] | Awaitable[dict[str, Any]]]
 StructuredOutputStage = Callable[
@@ -43,6 +44,21 @@ _REPO_AUX_FILE_LOOKUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("_contributing_url",  ("contributing.md", "contribution.md")),
     ("_publiccode_url",    ("publiccode.yml", "publiccode.yaml")),
 )
+
+
+def _resolve_publiccode_payload(aux_files: Any) -> dict[str, Any] | None:
+    """Locate publiccode.yml / publiccode.yaml (case-insensitive) in
+    the gathered ``aux_files`` and return the parsed payload, or None
+    when none is present / parseable."""
+    if not isinstance(aux_files, dict):
+        return None
+    for filename, content in aux_files.items():
+        if not isinstance(filename, str) or not isinstance(content, str):
+            continue
+        lower = filename.lower()
+        if lower in ("publiccode.yml", "publiccode.yaml"):
+            return parse_publiccode(content)
+    return None
 
 
 def _resolve_aux_file_urls(
@@ -437,6 +453,15 @@ class RepositoryAgentV2:
             **_resolve_aux_file_urls(
                 compiled_context.get("aux_files"),
                 full_name=full_name,
+            ),
+            # Parsed publiccode.yml payload (when present). Keys are the
+            # camelCase publiccode v0.4 field names — caller-side
+            # consumers don't have to re-parse YAML. Future work
+            # (separate PR): promote selected fields (license, repoOwner,
+            # softwareType, developmentStatus) to first-class
+            # ontology terms via a `publiccode:` JSON-LD prefix.
+            "_publiccode": _resolve_publiccode_payload(
+                compiled_context.get("aux_files"),
             ),
         }
 

--- a/src/v2/parsers/__init__.py
+++ b/src/v2/parsers/__init__.py
@@ -1,0 +1,9 @@
+"""Format-specific parsers for repository-root supplementary metadata
+files (publiccode.yml, …). Each module exposes a single ``parse_*``
+entry point that takes the raw file contents and returns a typed
+dict; failure modes are observable (returns ``None``) so the caller
+never raises on a malformed file."""
+
+from src.v2.parsers.publiccode import parse_publiccode
+
+__all__ = ["parse_publiccode"]

--- a/src/v2/parsers/publiccode.py
+++ b/src/v2/parsers/publiccode.py
@@ -1,0 +1,344 @@
+"""Parser for ``publiccode.yml`` / ``publiccode.yaml``.
+
+The Public Code spec (``https://yml.publiccode.tools/``) is the
+Italian-government-driven standard for declaring metadata about
+open-source public-sector software. v0.4 is the current core schema
+(``publiccodeYmlVersion: '0.4.0'``). The format carries strong
+attribution / classification signal that the GME pipeline otherwise
+has to derive from README parsing:
+
+  - canonical project URL + landing page,
+  - declared license + copyright owner + repo owner,
+  - development status enum + softwareType enum,
+  - maintainer contacts (name + email + affiliation),
+  - intended-audience country list,
+  - structured per-language descriptions (shortDescription,
+    longDescription, features),
+  - locale support matrix.
+
+This parser is intentionally lenient: it tolerates extra keys (the
+``it:`` country extension and other namespaces ship with arbitrary
+sub-trees), drops fields that aren't a sensible type, and never
+raises on a malformed file. Callers get either a fully populated dict
+or ``None``.
+
+Spec references:
+  - https://yml.publiccode.tools/schema.core.html
+  - https://yml.publiccode.tools/schema.country-it.html
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+# Top-level fields that are always plain scalars / lists per the v0.4
+# spec. Anything that lands here in a non-scalar shape is dropped (we
+# pass through but flag a logger warning).
+_TOP_LEVEL_SCALAR_FIELDS: tuple[str, ...] = (
+    "publiccodeYmlVersion",
+    "name",
+    "url",
+    "applicationSuite",
+    "landingURL",
+    "softwareVersion",
+    "releaseDate",
+    "logo",
+    "monochromeLogo",
+    "roadmap",
+    "developmentStatus",
+    "softwareType",
+)
+_TOP_LEVEL_LIST_OR_STR_FIELDS: tuple[str, ...] = (
+    # `isBasedOn` is `string OR list[string]` in the spec; we coerce
+    # the singular into a list for caller-side simplicity.
+    "isBasedOn",
+)
+_TOP_LEVEL_LIST_FIELDS: tuple[str, ...] = (
+    "platforms",
+    "categories",
+    "usedBy",
+)
+
+
+def _coerce_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        s = value.strip()
+        return s or None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return str(value)
+    # PyYAML decodes `2024-05-01` as `datetime.date` and timestamped
+    # forms as `datetime.datetime`. We stringify because everything
+    # downstream (JSON-LD output, validation) expects the YAML scalar
+    # form, not the Python type.
+    import datetime
+    if isinstance(value, (datetime.date, datetime.datetime)):
+        return value.isoformat()
+    return None
+
+
+def _coerce_str_list(value: Any) -> list[str] | None:
+    if isinstance(value, str):
+        s = value.strip()
+        return [s] if s else None
+    if isinstance(value, list):
+        out = [s.strip() for s in value if isinstance(s, str) and s.strip()]
+        return out or None
+    return None
+
+
+def _coerce_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _parse_intended_audience(value: Any) -> dict[str, Any] | None:
+    """``intendedAudience: { countries, unsupportedCountries, scope }``"""
+    if not isinstance(value, dict):
+        return None
+    out: dict[str, Any] = {}
+    for key in ("countries", "unsupportedCountries", "scope"):
+        coerced = _coerce_str_list(value.get(key))
+        if coerced:
+            out[key] = coerced
+    return out or None
+
+
+def _parse_legal(value: Any) -> dict[str, Any] | None:
+    """``legal: { license, mainCopyrightOwner, repoOwner, authorsFile }``"""
+    if not isinstance(value, dict):
+        return None
+    out: dict[str, Any] = {}
+    for key in ("license", "mainCopyrightOwner", "repoOwner", "authorsFile"):
+        coerced = _coerce_str(value.get(key))
+        if coerced:
+            out[key] = coerced
+    return out or None
+
+
+def _parse_maintenance(value: Any) -> dict[str, Any] | None:
+    """``maintenance: { type, contractors, contacts }``
+
+    ``type`` is one of: internal | community | contract | none.
+    ``contacts`` is a list of ``{ name, email, affiliation, phone }``
+    dicts; we keep the records intact (caller may want any of them).
+    """
+    if not isinstance(value, dict):
+        return None
+    out: dict[str, Any] = {}
+    type_ = _coerce_str(value.get("type"))
+    if type_:
+        out["type"] = type_
+    contractors = value.get("contractors")
+    if isinstance(contractors, list):
+        clean_contractors = []
+        for item in contractors:
+            if not isinstance(item, dict):
+                continue
+            entry = {
+                k: _coerce_str(item.get(k))
+                for k in ("name", "until", "email", "website", "affiliation")
+                if _coerce_str(item.get(k))
+            }
+            if entry:
+                clean_contractors.append(entry)
+        if clean_contractors:
+            out["contractors"] = clean_contractors
+    contacts = value.get("contacts")
+    if isinstance(contacts, list):
+        clean_contacts = []
+        for item in contacts:
+            if not isinstance(item, dict):
+                continue
+            entry = {
+                k: _coerce_str(item.get(k))
+                for k in ("name", "email", "affiliation", "phone")
+                if _coerce_str(item.get(k))
+            }
+            if entry:
+                clean_contacts.append(entry)
+        if clean_contacts:
+            out["contacts"] = clean_contacts
+    return out or None
+
+
+def _parse_localisation(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    out: dict[str, Any] = {}
+    ready = _coerce_bool(value.get("localisationReady"))
+    if ready is not None:
+        out["localisationReady"] = ready
+    langs = _coerce_str_list(value.get("availableLanguages"))
+    if langs:
+        out["availableLanguages"] = langs
+    return out or None
+
+
+def _parse_depends_on(value: Any) -> dict[str, Any] | None:
+    """``dependsOn: { open: [...], proprietary: [...], hardware: [...] }``
+
+    Each sub-list holds objects of shape
+    ``{ name, versionMin, versionMax, optional }``.
+    """
+    if not isinstance(value, dict):
+        return None
+    out: dict[str, Any] = {}
+    for bucket in ("open", "proprietary", "hardware"):
+        items = value.get(bucket)
+        if not isinstance(items, list):
+            continue
+        clean_items = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            entry: dict[str, Any] = {}
+            for k in ("name", "versionMin", "versionMax", "version"):
+                coerced = _coerce_str(item.get(k))
+                if coerced:
+                    entry[k] = coerced
+            optional = _coerce_bool(item.get("optional"))
+            if optional is not None:
+                entry["optional"] = optional
+            if entry:
+                clean_items.append(entry)
+        if clean_items:
+            out[bucket] = clean_items
+    return out or None
+
+
+def _parse_description(value: Any) -> dict[str, Any] | None:
+    """``description: { <lang>: { ... shortDescription, longDescription,
+    features, screenshots, videos, awards, genericName, documentation,
+    apiDocumentation, localisedName } }``
+
+    Returns the per-language map verbatim (after cleaning). Caller is
+    free to pick its preferred language (`en`/`it`/…).
+    """
+    if not isinstance(value, dict):
+        return None
+    out: dict[str, dict[str, Any]] = {}
+    for lang, entry in value.items():
+        if not isinstance(lang, str) or not isinstance(entry, dict):
+            continue
+        clean: dict[str, Any] = {}
+        for k in (
+            "localisedName",
+            "genericName",
+            "shortDescription",
+            "longDescription",
+            "documentation",
+            "apiDocumentation",
+        ):
+            coerced = _coerce_str(entry.get(k))
+            if coerced:
+                clean[k] = coerced
+        for k in ("features", "screenshots", "videos", "awards"):
+            coerced_list = _coerce_str_list(entry.get(k))
+            if coerced_list:
+                clean[k] = coerced_list
+        if clean:
+            out[lang.strip()] = clean
+    return out or None
+
+
+def parse_publiccode(content: str | None) -> dict[str, Any] | None:
+    """Parse a ``publiccode.yml`` (or ``.yaml``) document.
+
+    Returns a dict whose top-level keys are the publiccode field names
+    (camelCase, per the spec) for fields that were present and well-
+    typed in the input. Always lossy by design: malformed sub-trees
+    are silently dropped rather than surfaced as parse errors.
+
+    Returns ``None`` when:
+      - ``content`` is None / empty,
+      - the YAML payload doesn't load to a mapping,
+      - the YAML is malformed.
+
+    Country extensions (``it:`` etc.) and any other top-level keys not
+    recognised by the v0.4 core schema are passed through verbatim as
+    long as their value is a dict — callers who want to inspect e.g.
+    ``it.riuso.codiceIPA`` can do so without losing fidelity.
+    """
+    if not isinstance(content, str) or not content.strip():
+        return None
+    try:
+        loaded = yaml.safe_load(content)
+    except yaml.YAMLError:
+        logger.warning("publiccode.yml: YAML parse error; skipping")
+        return None
+    if not isinstance(loaded, dict):
+        return None
+
+    out: dict[str, Any] = {}
+
+    for field in _TOP_LEVEL_SCALAR_FIELDS:
+        coerced = _coerce_str(loaded.get(field))
+        if coerced:
+            out[field] = coerced
+
+    for field in _TOP_LEVEL_LIST_OR_STR_FIELDS:
+        coerced_list = _coerce_str_list(loaded.get(field))
+        if coerced_list:
+            out[field] = coerced_list
+
+    for field in _TOP_LEVEL_LIST_FIELDS:
+        coerced_list = _coerce_str_list(loaded.get(field))
+        if coerced_list:
+            out[field] = coerced_list
+
+    audience = _parse_intended_audience(loaded.get("intendedAudience"))
+    if audience:
+        out["intendedAudience"] = audience
+
+    description = _parse_description(loaded.get("description"))
+    if description:
+        out["description"] = description
+
+    legal = _parse_legal(loaded.get("legal"))
+    if legal:
+        out["legal"] = legal
+
+    maintenance = _parse_maintenance(loaded.get("maintenance"))
+    if maintenance:
+        out["maintenance"] = maintenance
+
+    localisation = _parse_localisation(loaded.get("localisation"))
+    if localisation:
+        out["localisation"] = localisation
+
+    depends_on = _parse_depends_on(loaded.get("dependsOn"))
+    if depends_on:
+        out["dependsOn"] = depends_on
+
+    # Pass through any country-extension blocks (it:, fr:, etc.) and
+    # other dict-valued top-level fields verbatim. Helps preserve
+    # forward compatibility — when v0.5 lands with a new top-level
+    # block we don't need to recompile to surface it.
+    recognised = (
+        set(_TOP_LEVEL_SCALAR_FIELDS)
+        | set(_TOP_LEVEL_LIST_OR_STR_FIELDS)
+        | set(_TOP_LEVEL_LIST_FIELDS)
+        | {
+            "intendedAudience", "description", "legal",
+            "maintenance", "localisation", "dependsOn",
+        }
+    )
+    for key, value in loaded.items():
+        if not isinstance(key, str) or key in recognised:
+            continue
+        if isinstance(value, dict):
+            out[key] = value
+
+    return out or None
+
+
+__all__ = ["parse_publiccode"]

--- a/src/v2/pipeline/stages/refine_with_llm.py
+++ b/src/v2/pipeline/stages/refine_with_llm.py
@@ -59,6 +59,7 @@ from src.v2.agents.llm.refiners.org_resolver import (
 from src.v2.agents.llm.runtime import LLMRuntimeError
 from src.v2.api_models.enums import OrganizationTypeV2
 from src.v2.ingest.providers.epfl_graph_rag import EpflGraphRagProvider
+from src.v2.parsers.publiccode import parse_publiccode
 from src.v2.pipeline.stages.models import ReconciledEntities
 
 logger = logging.getLogger(__name__)
@@ -191,6 +192,21 @@ def _build_repo_context_summary(
                     break  # first match wins per slug
         if aux_excerpts:
             summary["aux_files"] = aux_excerpts
+
+        # When a publiccode.yml is present, also surface the *parsed*
+        # payload so the LLM gets typed fields (license, softwareType,
+        # repoOwner, contacts) instead of having to reparse YAML. The
+        # raw excerpt above remains so the LLM can verify a quote
+        # verbatim if it needs to.
+        publiccode_filename = lower_to_original.get(
+            "publiccode.yml",
+        ) or lower_to_original.get("publiccode.yaml")
+        if publiccode_filename:
+            content = aux_files.get(publiccode_filename)
+            if isinstance(content, str):
+                parsed = parse_publiccode(content)
+                if parsed:
+                    summary["publiccode"] = parsed
 
     return summary
 

--- a/tests/v2/fixtures/publiccode_foodsoft_1e3adaef.yml
+++ b/tests/v2/fixtures/publiccode_foodsoft_1e3adaef.yml
@@ -1,0 +1,58 @@
+# This repository adheres to the publiccode.yml standard by including this 
+# metadata file that makes public software easily discoverable.
+# More info at https://github.com/italia/publiccode.yml
+
+publiccodeYmlVersion: '0.2'
+name: Foodsoft
+url: 'https://github.com/foodcoops/foodsoft.git'
+landingURL: 'https://foodcoops.net'
+releaseDate: '2025-03-20'
+softwareVersion: v4.9.1
+developmentStatus: stable
+platforms:
+  - web
+softwareType: standalone/web
+categories:
+  - e-commerce
+  - business-process-management
+  - project-collaboration
+  - warehouse-management
+maintenance:
+  type: community
+legal:
+  license: AGPL-3.0-or-later
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - de
+    - en
+    - es
+    - fr
+    - nl
+    - tr
+description:
+  en:
+    genericName: Webshop
+    shortDescription: >-
+      Foodsoft is a web-based tool for organizing food coops and aiding small
+      producers in managing orders and distributing local products efficiently
+    longDescription: >
+      Foodsoft is a web-based software designed to help food cooperatives manage
+      their operations more effectively. It provides tools for small regional
+      producers to distribute their products directly to consumers. With
+      Foodsoft, cooperatives can handle orders, keep track of inventory, and
+      communicate with their members easily. The platform allows producers to
+      list their products, making it simple for consumers to find and purchase
+      fresh, local food. By connecting producers and consumers, Foodsoft
+      supports local businesses and encourages the use of locally sourced
+      ingredients.
+    features:
+      - Order management system
+      - Inventory tracking
+      - Member communication tools
+      - Product listing for producers
+      - Payment processing integration
+      - Delivery scheduling options
+      - Membership management
+      - Access control for different user roles
+      - Community engagement features

--- a/tests/v2/test_parsers_publiccode.py
+++ b/tests/v2/test_parsers_publiccode.py
@@ -1,0 +1,363 @@
+"""Tests for `src.v2.parsers.publiccode.parse_publiccode`.
+
+We cover every section the v0.4 core schema declares plus a handful
+of failure modes (malformed YAML, wrong top-level type, missing
+optional sub-trees). Country extensions (``it:`` etc.) are also
+passed through.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+from src.v2.parsers.publiccode import parse_publiccode
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_returns_none_on_none_or_blank():
+    assert parse_publiccode(None) is None
+    assert parse_publiccode("") is None
+    assert parse_publiccode("   \n   ") is None
+
+
+def test_returns_none_on_malformed_yaml():
+    assert parse_publiccode("foo: : bar") is None
+
+
+def test_returns_none_when_top_level_is_not_a_mapping():
+    """A YAML list at the root is well-formed YAML but not a
+    publiccode document."""
+    assert parse_publiccode("- a\n- b\n") is None
+
+
+def test_returns_none_when_nothing_recognised():
+    """Document loads but carries no recognised v0.4 fields → None
+    (caller treats this as 'effectively empty')."""
+    assert parse_publiccode("foo: bar\n") is None
+
+
+# ---------------------------------------------------------------------------
+# Top-level scalar + list fields
+# ---------------------------------------------------------------------------
+
+
+def test_parses_minimal_required_fields():
+    """The fields most likely to be filled in by real public-sector
+    repos: yml version, name, repo URL, license. Coerced to strings
+    even when YAML loads them as numbers (releaseDate as a date is
+    YAML-native but we want str)."""
+    doc = textwrap.dedent("""
+        publiccodeYmlVersion: '0.4.0'
+        name: My Service
+        url: https://github.com/agency/my-service
+        softwareVersion: 1.2.3
+        releaseDate: 2024-05-01
+        developmentStatus: stable
+        softwareType: standalone/web
+    """)
+    out = parse_publiccode(doc)
+    assert out is not None
+    assert out["publiccodeYmlVersion"] == "0.4.0"
+    assert out["name"] == "My Service"
+    assert out["url"] == "https://github.com/agency/my-service"
+    assert out["softwareVersion"] == "1.2.3"
+    assert out["releaseDate"] == "2024-05-01"
+    assert out["developmentStatus"] == "stable"
+    assert out["softwareType"] == "standalone/web"
+
+
+def test_parses_list_fields():
+    doc = textwrap.dedent("""
+        publiccodeYmlVersion: '0.4.0'
+        platforms:
+          - web
+          - linux
+        categories:
+          - office
+          - document-management
+        usedBy:
+          - City of Bologna
+          - City of Florence
+    """)
+    out = parse_publiccode(doc)
+    assert out["platforms"] == ["web", "linux"]
+    assert out["categories"] == ["office", "document-management"]
+    assert out["usedBy"] == ["City of Bologna", "City of Florence"]
+
+
+def test_is_based_on_coerces_singular_string_to_list():
+    """Spec says ``isBasedOn`` is string OR list-of-strings; we
+    normalise to list so callers don't have to branch."""
+    out = parse_publiccode(
+        "publiccodeYmlVersion: '0.4.0'\nisBasedOn: https://example.com/upstream\n",
+    )
+    assert out["isBasedOn"] == ["https://example.com/upstream"]
+
+
+# ---------------------------------------------------------------------------
+# Structured sub-trees
+# ---------------------------------------------------------------------------
+
+
+def test_parses_intended_audience():
+    doc = textwrap.dedent("""
+        publiccodeYmlVersion: '0.4.0'
+        intendedAudience:
+          countries:
+            - it
+            - fr
+          unsupportedCountries:
+            - cn
+          scope:
+            - government
+            - education
+    """)
+    out = parse_publiccode(doc)
+    assert out["intendedAudience"] == {
+        "countries": ["it", "fr"],
+        "unsupportedCountries": ["cn"],
+        "scope": ["government", "education"],
+    }
+
+
+def test_parses_legal():
+    doc = textwrap.dedent("""
+        publiccodeYmlVersion: '0.4.0'
+        legal:
+          license: AGPL-3.0-or-later
+          mainCopyrightOwner: City of Bologna
+          repoOwner: City of Bologna
+          authorsFile: AUTHORS.md
+    """)
+    out = parse_publiccode(doc)
+    assert out["legal"] == {
+        "license": "AGPL-3.0-or-later",
+        "mainCopyrightOwner": "City of Bologna",
+        "repoOwner": "City of Bologna",
+        "authorsFile": "AUTHORS.md",
+    }
+
+
+def test_parses_maintenance_with_contractors_and_contacts():
+    doc = textwrap.dedent("""
+        publiccodeYmlVersion: '0.4.0'
+        maintenance:
+          type: contract
+          contractors:
+            - name: ACME Corp
+              until: 2025-12-31
+              website: https://acme.example
+          contacts:
+            - name: Jane Smith
+              email: jane@example.org
+              affiliation: City of Bologna
+              phone: '+39 051 1234567'
+    """)
+    out = parse_publiccode(doc)
+    maintenance = out["maintenance"]
+    assert maintenance["type"] == "contract"
+    assert maintenance["contractors"] == [
+        {"name": "ACME Corp", "until": "2025-12-31", "website": "https://acme.example"},
+    ]
+    assert maintenance["contacts"] == [
+        {
+            "name": "Jane Smith",
+            "email": "jane@example.org",
+            "affiliation": "City of Bologna",
+            "phone": "+39 051 1234567",
+        },
+    ]
+
+
+def test_parses_localisation_with_boolean_and_languages():
+    doc = textwrap.dedent("""
+        publiccodeYmlVersion: '0.4.0'
+        localisation:
+          localisationReady: true
+          availableLanguages:
+            - en
+            - it
+            - fr
+    """)
+    out = parse_publiccode(doc)
+    assert out["localisation"] == {
+        "localisationReady": True,
+        "availableLanguages": ["en", "it", "fr"],
+    }
+
+
+def test_parses_depends_on_buckets():
+    doc = textwrap.dedent("""
+        publiccodeYmlVersion: '0.4.0'
+        dependsOn:
+          open:
+            - name: PostgreSQL
+              versionMin: '13'
+              optional: false
+          proprietary:
+            - name: Oracle Database
+              version: '19c'
+              optional: true
+          hardware:
+            - name: NVIDIA T4
+              optional: true
+    """)
+    out = parse_publiccode(doc)
+    assert out["dependsOn"]["open"] == [
+        {"name": "PostgreSQL", "versionMin": "13", "optional": False},
+    ]
+    assert out["dependsOn"]["proprietary"] == [
+        {"name": "Oracle Database", "version": "19c", "optional": True},
+    ]
+    assert out["dependsOn"]["hardware"] == [
+        {"name": "NVIDIA T4", "optional": True},
+    ]
+
+
+def test_parses_description_with_multiple_languages():
+    """Description is per-language; we keep the map intact so
+    consumers can pick (English-preferring callers can do
+    ``out['description'].get('en') or next(iter(out['description'].values()))``)."""
+    doc = textwrap.dedent("""
+        publiccodeYmlVersion: '0.4.0'
+        description:
+          en:
+            localisedName: My Service
+            genericName: Records Manager
+            shortDescription: A document management system.
+            longDescription: |
+              Long description here.
+              Multiple paragraphs.
+            documentation: https://docs.example/en
+            apiDocumentation: https://api.example/en
+            features:
+              - search
+              - audit-trail
+            screenshots:
+              - https://example.com/s1.png
+            awards:
+              - Best of OpenGov 2023
+          it:
+            shortDescription: Un sistema di gestione documentale.
+            longDescription: Versione italiana.
+    """)
+    out = parse_publiccode(doc)
+    description = out["description"]
+    assert set(description.keys()) == {"en", "it"}
+    en = description["en"]
+    assert en["localisedName"] == "My Service"
+    assert en["genericName"] == "Records Manager"
+    assert en["shortDescription"] == "A document management system."
+    assert en["longDescription"].startswith("Long description")
+    assert en["documentation"] == "https://docs.example/en"
+    assert en["features"] == ["search", "audit-trail"]
+    assert en["awards"] == ["Best of OpenGov 2023"]
+    assert description["it"]["shortDescription"].startswith("Un sistema")
+
+
+# ---------------------------------------------------------------------------
+# Forward-compat: country extensions and unknown top-level keys
+# ---------------------------------------------------------------------------
+
+
+def test_passes_country_extension_block_through_verbatim():
+    """The `it:` country extension declares Italy-specific fields
+    (riuso, codiceIPA). We don't model those individually but the
+    payload is dict-shaped, so we pass it through so callers can
+    inspect what they need."""
+    doc = textwrap.dedent("""
+        publiccodeYmlVersion: '0.4.0'
+        name: foo
+        it:
+          countryExtensionVersion: '1.0'
+          riuso:
+            codiceIPA: city_of_bologna
+          piattaforme:
+            spid: true
+    """)
+    out = parse_publiccode(doc)
+    assert out["it"]["countryExtensionVersion"] == "1.0"
+    assert out["it"]["riuso"] == {"codiceIPA": "city_of_bologna"}
+    assert out["it"]["piattaforme"] == {"spid": True}
+
+
+def test_does_not_pass_non_dict_unknown_keys_through():
+    """An unknown top-level key whose value isn't a dict (e.g. someone
+    declared a random scalar) is ignored — only structured forward-
+    extension blocks are forwarded."""
+    out = parse_publiccode(
+        "publiccodeYmlVersion: '0.4.0'\nname: foo\nrandomScalar: hello\n",
+    )
+    assert "randomScalar" not in out
+
+
+# ---------------------------------------------------------------------------
+# Robustness against malformed sub-trees
+# ---------------------------------------------------------------------------
+
+
+def test_parses_real_world_foodsoft_publiccode():
+    """Regression-pin against a real publiccode.yml in the wild
+    (https://github.com/foodcoops/foodsoft @ 1e3adaef). The doc
+    declares `publiccodeYmlVersion: 0.2` (older than v0.4), exercising
+    forward compatibility — every field present in v0.2 is also in
+    v0.4 and parses cleanly."""
+    from pathlib import Path
+
+    fixture = (
+        Path(__file__).parent
+        / "fixtures"
+        / "publiccode_foodsoft_1e3adaef.yml"
+    )
+    out = parse_publiccode(fixture.read_text(encoding="utf-8"))
+    assert out is not None
+    # Top-level scalars.
+    assert out["publiccodeYmlVersion"] == "0.2"
+    assert out["name"] == "Foodsoft"
+    assert out["url"] == "https://github.com/foodcoops/foodsoft.git"
+    assert out["landingURL"] == "https://foodcoops.net"
+    assert out["releaseDate"] == "2025-03-20"
+    assert out["softwareVersion"] == "v4.9.1"
+    assert out["developmentStatus"] == "stable"
+    assert out["softwareType"] == "standalone/web"
+    # Lists.
+    assert out["platforms"] == ["web"]
+    assert out["categories"] == [
+        "e-commerce",
+        "business-process-management",
+        "project-collaboration",
+        "warehouse-management",
+    ]
+    # Structured sub-trees.
+    assert out["maintenance"] == {"type": "community"}
+    assert out["legal"] == {"license": "AGPL-3.0-or-later"}
+    assert out["localisation"] == {
+        "localisationReady": True,
+        "availableLanguages": ["de", "en", "es", "fr", "nl", "tr"],
+    }
+    en = out["description"]["en"]
+    assert en["genericName"] == "Webshop"
+    assert "food coops" in en["shortDescription"]
+    assert "cooperatives" in en["longDescription"]
+    assert "Order management system" in en["features"]
+    assert len(en["features"]) == 9
+
+
+def test_skips_malformed_subtrees_without_failing_whole_parse():
+    """A wrong-shape `legal` block shouldn't make the whole parse return
+    None — we still get the other fields."""
+    doc = textwrap.dedent("""
+        publiccodeYmlVersion: '0.4.0'
+        name: foo
+        legal: "this should be a dict but is a string"
+        platforms:
+          - web
+    """)
+    out = parse_publiccode(doc)
+    assert out["name"] == "foo"
+    assert out["platforms"] == ["web"]
+    assert "legal" not in out  # silently dropped

--- a/tests/v2/test_refine_with_llm_aux_files.py
+++ b/tests/v2/test_refine_with_llm_aux_files.py
@@ -101,6 +101,46 @@ def test_summary_caps_long_aux_file_contents():
     assert len(summary["aux_files"]["citation_cff"]) == AUX_FILE_CONTEXT_MAX_CHARS
 
 
+def test_summary_includes_parsed_publiccode_payload():
+    """The LLM context summary should carry the *parsed* publiccode
+    payload alongside the raw excerpt — the LLM gets typed fields
+    (license, softwareType, contacts) without having to reparse YAML."""
+    pc = (
+        "publiccodeYmlVersion: '0.4.0'\n"
+        "name: foo\n"
+        "softwareType: standalone/web\n"
+        "legal:\n  license: AGPL-3.0-or-later\n"
+    )
+    summary = _build_repo_context_summary(
+        gathered_context=_wrap_context({"publiccode.yml": pc}),
+    )
+    assert summary["publiccode"]["name"] == "foo"
+    assert summary["publiccode"]["softwareType"] == "standalone/web"
+    assert summary["publiccode"]["legal"] == {"license": "AGPL-3.0-or-later"}
+    # The raw excerpt is still there for verbatim quoting.
+    assert "publiccode" in summary["aux_files"]
+
+
+def test_summary_publiccode_payload_handled_for_yaml_extension():
+    pc = "publiccodeYmlVersion: '0.4.0'\nname: bar\n"
+    summary = _build_repo_context_summary(
+        gathered_context=_wrap_context({"publiccode.yaml": pc}),
+    )
+    assert summary["publiccode"]["name"] == "bar"
+
+
+def test_summary_omits_publiccode_key_when_payload_unparseable():
+    """A malformed publiccode.yml leaves the raw excerpt in
+    `aux_files` (caller may still want to show it) but does not pin a
+    bogus `publiccode` key on the summary."""
+    summary = _build_repo_context_summary(
+        gathered_context=_wrap_context({"publiccode.yml": "foo: : not yaml"}),
+    )
+    assert "publiccode" not in summary
+    # Raw excerpt still present.
+    assert "publiccode" in summary["aux_files"]
+
+
 def test_summary_picks_first_match_per_slug():
     """When both `authors` and `authors.md` are present, the first
     match in the candidate order wins — deterministic regardless of

--- a/tests/v2/test_repository_agent.py
+++ b/tests/v2/test_repository_agent.py
@@ -243,6 +243,108 @@ def test_repository_agent_emits_none_for_absent_aux_files() -> None:
     assert raw["_publiccode_url"] is None
 
 
+def test_repository_agent_parses_publiccode_into_internal_field() -> None:
+    """When a publiccode.yml is present in the aux_files, the agent
+    must surface the parsed payload under `_publiccode` so downstream
+    consumers (LLM refiners, graph dashboards) get typed access to
+    license / repoOwner / softwareType / contacts without reparsing."""
+    import textwrap
+    pcyml = textwrap.dedent("""
+        publiccodeYmlVersion: '0.4.0'
+        name: Hello World Service
+        url: https://github.com/octocat/Hello-World
+        softwareVersion: 1.0.0
+        developmentStatus: stable
+        softwareType: standalone/web
+        platforms:
+          - web
+        categories:
+          - office
+        legal:
+          license: MIT
+          mainCopyrightOwner: Octo Cat
+          repoOwner: Octo Cat
+        maintenance:
+          type: internal
+          contacts:
+            - name: Octo Cat
+              email: octo@example.com
+              affiliation: GitHub
+        description:
+          en:
+            shortDescription: Say hello to the world.
+    """)
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "octocat/Hello-World",
+                "repository_context": {
+                    "full_name": "octocat/Hello-World",
+                    "metadata": {
+                        "name": "Hello-World",
+                        "full_name": "octocat/Hello-World",
+                        "owner": {"login": "octocat", "type": "User"},
+                        "created_at": "2020-01-01T00:00:00Z",
+                        "license": {"spdx_id": "MIT"},
+                        "fork": False,
+                        "source": {"full_name": None},
+                    },
+                    "contributors": [{"login": "octocat"}],
+                    "languages": {"Python": 1},
+                    "aux_files": {"publiccode.yml": pcyml},
+                },
+            },
+            providers,
+        ),
+    )
+
+    pc = result.raw_output["_publiccode"]
+    assert pc is not None
+    assert pc["publiccodeYmlVersion"] == "0.4.0"
+    assert pc["name"] == "Hello World Service"
+    assert pc["softwareType"] == "standalone/web"
+    assert pc["legal"] == {
+        "license": "MIT", "mainCopyrightOwner": "Octo Cat", "repoOwner": "Octo Cat",
+    }
+    assert pc["maintenance"]["contacts"][0]["email"] == "octo@example.com"
+    assert pc["description"]["en"]["shortDescription"] == "Say hello to the world."
+
+
+def test_repository_agent_publiccode_is_none_when_absent() -> None:
+    """No publiccode.yml in the aux files → `_publiccode` is None."""
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "octocat/Hello-World",
+                "repository_context": {
+                    "full_name": "octocat/Hello-World",
+                    "metadata": {
+                        "name": "Hello-World",
+                        "full_name": "octocat/Hello-World",
+                        "owner": {"login": "octocat", "type": "User"},
+                        "created_at": "2020-01-01T00:00:00Z",
+                        "license": {"spdx_id": "MIT"},
+                        "fork": False,
+                        "source": {"full_name": None},
+                    },
+                    "contributors": [{"login": "octocat"}],
+                    "languages": {"Python": 1},
+                    "aux_files": {"README.md": "Hello"},
+                },
+            },
+            providers,
+        ),
+    )
+
+    assert result.raw_output["_publiccode"] is None
+
+
 def test_repository_agent_accepts_alternate_contribution_spelling() -> None:
     """Some projects ship `CONTRIBUTION.md` (singular) — match that too."""
     agent = RepositoryAgentV2()


### PR DESCRIPTION
The Public Code spec (https://yml.publiccode.tools/) is the Italian-government-driven standard for declaring metadata about open-source public-sector software. It carries strong attribution + classification signal that the GME pipeline previously had to derive from README parsing:

  - canonical project URL + landing page,
  - declared license + copyright owner + repo owner,
  - development status enum + softwareType enum,
  - maintainer contacts (name + email + affiliation),
  - intended-audience country list,
  - structured per-language descriptions (shortDescription, longDescription, features),
  - locale support matrix.

New module `src/v2/parsers/publiccode.py` parses the document against the v0.4 core schema (also handles v0.2 / v0.3 docs cleanly — every field used in older versions is in the v0.4 core too). Country extensions (`it:` etc.) pass through verbatim as nested dicts for forward-compatibility.

The parser is intentionally lenient:
  - Malformed YAML → returns None (caller never raises).
  - Non-mapping root → None.
  - Bad sub-tree types → silently dropped (other fields still surface).

Wired into:
  - `repository_agent`: new `_publiccode` field carries the parsed dict (or None when no publiccode.yml is present) so graph queries and dashboards have typed access without reparsing.
  - `refine_with_llm._build_repo_context_summary`: LLM context gets both the raw `aux_files.publiccode` excerpt (for verbatim quoting) AND a typed `publiccode` payload (for direct field reads).

Real-world fixture pinned: foodcoops/foodsoft @ 1e3adaef (`publiccodeYmlVersion: '0.2'`, 14 top-level fields populated, 6 locales, 9 listed features) — exercises forward compatibility and serves as a regression guard.

Future work (separate PR per user spec): promote selected publiccode fields (license, repoOwner, softwareType, developmentStatus) to first-class ontology terms via a `publiccode:` JSON-LD prefix.

Tests: 17 parser tests (every section + failure modes + real-world fixture) + 2 repo-agent integration tests + 3 LLM-context tests. Full v2 regression: 906 passed / 1 skipped.