### PR TITLE
docs(env.example): document the bio-resolver pipeline flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,37 @@ OPENROUTER_API_KEY=your-openrouter-key-here
 # `true` for `agent_runtime=llm` and ignored for `rule_based`.
 # V2_HYBRID_REFINER_ENABLED=true
 
+# Affiliation-from-Person-signals pipeline. Three independent stages run in
+# the same pipeline slot (right after reconciliation, before the LLM critic)
+# and stamp `schema:affiliation` on Person entities the rule-based path left
+# unanchored. All default `true`; set to `false`/`0`/`no`/`off` to skip a
+# stage entirely (e.g. catalog backfills that should preserve the raw
+# `_company` strings unchanged).
+#
+#   `resolve_company_to_ror` reads the structured `_company` field, sends it
+# through the same ROR RAG with strict acceptance (score >= 0.55, type in
+# {company,education,funder,facility,government,nonprofit}, gap >= 0.02 or
+# exact-name override). Cheap — one vector search per unique company string.
+# V2_RESOLVE_COMPANY_TO_ROR=true
+#
+#   `resolve_bio_to_ror` (deterministic backstop) — when `_company` is empty,
+# extracts org candidates from `_bio` / `_orcid_biography` via regex
+# (`at <Org>`, `@handle`, `, <Org>` after a role, `from <Org>`) AND from
+# `_blog` / `_email` host via a small DOMAIN_HINTS table (EPFL, ETH Zurich,
+# MIT, DeepMind, …). Reuses the same acceptance gate as the company stage.
+# Email is matched by domain only — the local part is hashed in `_email`.
+# V2_RESOLVE_BIO_TO_ROR=true
+#
+#   `resolve_bio_to_ror_llm` (LLM long-tail) — for each Person still missing
+# `schema:affiliation` after the two stages above AND with at least one of
+# bio / orcid bio / profile readme, run a single-Person `bio_resolver` LLM
+# agent with `search_ror_rag` tool access. Confidence floor 0.7 + verbatim
+# quote required. Only runs under `agent_runtime=llm` or `hybrid` — a
+# no-op under `rule_based` even when the flag is true. Concurrency is
+# bounded (default 4) so a 100-contributor repo doesn't fan out 100x.
+# V2_RESOLVE_BIO_TO_ROR_LLM=true
+# V2_RESOLVE_BIO_TO_ROR_LLM_CONCURRENCY=4
+
 # Owned-repo fan-out for user/organization roots. When `false` (default), a
 # user/org extraction keeps its repositories as references in `pulse:owns`
 # instead of running the full per-repo pipeline on each — fast, and avoids


### PR DESCRIPTION
Three pipeline stages landed in #76 / #77 / #78 with no entry in .env.example: `V2_RESOLVE_COMPANY_TO_ROR`, `V2_RESOLVE_BIO_TO_ROR`, `V2_RESOLVE_BIO_TO_ROR_LLM` (plus the LLM concurrency knob). All default `true`; operators had no way to discover them short of grep'ing the source. Defaults unchanged — this is documentation only.

Section explains the three-stage ladder (structured `_company` → regex/domain backstop → LLM long-tail), the per-stage acceptance gate, the email-hashing detail, and the LLM-runtime gating so operators don't expect Stage B to run under rule_based.