### PR TITLE
feat(jsonld): publiccode: namespace so _publiccode is uploadable as RDF

### DIFF
--- a/src/v2/pipeline/stages/jsonld_build.py
+++ b/src/v2/pipeline/stages/jsonld_build.py
@@ -20,6 +20,36 @@ HELPER_ONLY_FIELDS = {"shacl", "identifiers", "idSource", "_person_ref"}
 GME_INTERNAL_PREFIX = "gme-internal"
 GME_INTERNAL_NAMESPACE = "https://openpulse.science/git-metadata-extractor#"
 
+# Auxiliary namespace for parsed publiccode.yml metadata. Same strategy
+# as `gme-internal:` (separate vocabulary, surfaced only when
+# `include_internal_fields=True`, does NOT touch the Open Pulse
+# ontology) — but with its own prefix so downstream RDF consumers can
+# recognise publiccode triples as such. The base IRI points at the
+# publiccode standard's docs URL (no formal ontology IRI exists for
+# the spec, but the docs URL is stable and identifies the field defs).
+#
+# Repository entities whose `_publiccode` field is populated have its
+# top-level scalar/list fields hoisted to `publiccode:<field>`
+# predicates so SPARQL queries like `?repo publiccode:license ?l` work
+# without re-parsing JSON. Nested sub-trees (legal / maintenance /
+# localisation / description / dependsOn / intendedAudience) remain
+# accessible via the `gme-internal:publiccode` JSON blob so structured
+# consumers don't lose data.
+PUBLICCODE_PREFIX = "publiccode"
+PUBLICCODE_NAMESPACE = "https://yml.publiccode.tools/"
+
+# Top-level publiccode v0.4 fields that are scalars or lists of
+# scalars — safe to hoist to `publiccode:<field>` triples. Anything not
+# in this set stays as nested JSON under `gme-internal:publiccode`.
+_PUBLICCODE_FLAT_FIELDS: frozenset[str] = frozenset({
+    # Scalars
+    "publiccodeYmlVersion", "name", "url", "applicationSuite",
+    "landingURL", "softwareVersion", "releaseDate", "logo",
+    "monochromeLogo", "roadmap", "developmentStatus", "softwareType",
+    # List-of-strings
+    "isBasedOn", "platforms", "categories", "usedBy",
+})
+
 
 def _normalize_node_id(value: Any, *, index: int) -> str:
     if isinstance(value, str) and value:
@@ -112,6 +142,39 @@ def _internal_term(key: str) -> str:
     return f"{GME_INTERNAL_PREFIX}:{key.lstrip('_')}"
 
 
+def _publiccode_term(field: str) -> str:
+    """`license` -> `publiccode:license`."""
+    return f"{PUBLICCODE_PREFIX}:{field}"
+
+
+def _hoist_publiccode_scalars(
+    publiccode: Any,
+) -> dict[str, Any]:
+    """Pull the scalar/list top-level fields from a parsed publiccode
+    payload into a flat ``{publiccode:<field>: value}`` dict for direct
+    emission as RDF predicates. Returns ``{}`` when the payload is
+    None / wrong-shape / missing every flat field.
+
+    Nested sub-trees (legal, maintenance, …) are intentionally NOT
+    hoisted here — they need their own predicate mapping per leaf,
+    which gets ambiguous fast (description has per-language sub-trees,
+    contractors/contacts are lists of dicts). They remain reachable
+    via `gme-internal:publiccode`."""
+    if not isinstance(publiccode, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for field in _PUBLICCODE_FLAT_FIELDS:
+        value = publiccode.get(field)
+        if value is None:
+            continue
+        if isinstance(value, str) and not value:
+            continue
+        if isinstance(value, list) and not value:
+            continue
+        out[_publiccode_term(field)] = value
+    return out
+
+
 def _rewrite_internal_keys(entity: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of ``entity`` with top-level `_`-prefixed keys
     renamed to their `gme-internal:` terms, so they expand to real IRI
@@ -192,6 +255,21 @@ def build_jsonld_output(
                 current_property=out_key,
             )
 
+        # Hoist scalar/list top-level publiccode fields to `publiccode:`
+        # predicates so SPARQL queries can hit them directly. The
+        # `gme-internal:publiccode` JSON blob above still carries the
+        # full nested payload for consumers that need the sub-trees.
+        if include_internal_fields:
+            for pc_term, pc_value in _hoist_publiccode_scalars(
+                entity.get("_publiccode"),
+            ).items():
+                node[pc_term] = _normalize_jsonld_value(
+                    pc_value,
+                    id_map=id_map,
+                    iri_typed_terms=iri_typed_terms,
+                    current_property=pc_term,
+                )
+
         # Strip `pulse:ror` when redundant with the node's own `@id`. The
         # `org:Organization` SHACL shape is `sh:closed` and does not
         # declare `pulse:ror`; emitting the field on a ROR-id'd node
@@ -209,8 +287,10 @@ def build_jsonld_output(
     graph.sort(key=lambda item: str(item.get("@id", "")))
     context = deepcopy(jsonld_context)
     if include_internal_fields:
-        # Register the prefix so `gme-internal:*` terms expand to IRIs.
+        # Register the prefixes so `gme-internal:*` and `publiccode:*`
+        # terms expand to IRIs (and the payload loads into RDF stores).
         context[GME_INTERNAL_PREFIX] = GME_INTERNAL_NAMESPACE
+        context[PUBLICCODE_PREFIX] = PUBLICCODE_NAMESPACE
     payload: dict[str, Any] = {
         "@context": context,
         "@graph": graph,

--- a/tests/v2/test_jsonld_build.py
+++ b/tests/v2/test_jsonld_build.py
@@ -209,3 +209,143 @@ def test_internal_fields_renamed_to_gme_internal_terms_when_flag_on() -> None:
         URIRef("https://openpulse.science/git-metadata-extractor#homepage"),
         Literal("https://example.org"),
     ) in graph
+
+
+def _assembled_with_publiccode() -> AssembledOutput:
+    return AssembledOutput(
+        root_entity={
+            "id": "owner/repo",
+            "type": "schema:SoftwareSourceCode",
+            "schema:name": "owner/repo",
+            "_publiccode": {
+                "publiccodeYmlVersion": "0.4.0",
+                "name": "Foodsoft",
+                "url": "https://github.com/foodcoops/foodsoft.git",
+                "softwareType": "standalone/web",
+                "developmentStatus": "stable",
+                "platforms": ["web"],
+                "categories": ["e-commerce", "warehouse-management"],
+                "legal": {"license": "AGPL-3.0-or-later"},
+                "maintenance": {"type": "community"},
+            },
+        },
+        related_entities=[],
+        excluded_entities=[],
+    )
+
+
+def test_publiccode_scalars_hoisted_to_publiccode_namespace_when_flag_on() -> None:
+    """Top-level scalar/list publiccode fields should appear under
+    `publiccode:<field>` predicates so SPARQL can query them directly,
+    while the structured sub-trees (legal, maintenance) stay inside the
+    `gme-internal:publiccode` JSON blob for consumers that want them."""
+    payload = build_jsonld_output(
+        assembled=_assembled_with_publiccode(),
+        jsonld_context=_context(),
+        include_internal_fields=True,
+    )
+    assert payload["@context"]["publiccode"] == "https://yml.publiccode.tools/"
+    node = payload["@graph"][0]
+    assert node["publiccode:name"] == "Foodsoft"
+    assert node["publiccode:url"] == "https://github.com/foodcoops/foodsoft.git"
+    assert node["publiccode:softwareType"] == "standalone/web"
+    assert node["publiccode:developmentStatus"] == "stable"
+    assert node["publiccode:platforms"] == ["web"]
+    assert node["publiccode:categories"] == ["e-commerce", "warehouse-management"]
+    # Structured sub-trees stay nested under gme-internal:publiccode —
+    # they're not safe to flatten generically.
+    pc_blob = node["gme-internal:publiccode"]
+    assert pc_blob["legal"] == {"license": "AGPL-3.0-or-later"}
+    assert pc_blob["maintenance"] == {"type": "community"}
+
+
+def test_publiccode_dropped_entirely_when_flag_off() -> None:
+    """`include_internal_fields=False` strips the publiccode predicates
+    along with everything else `_`-prefixed, keeping the public output
+    SHACL-conformant."""
+    payload = build_jsonld_output(
+        assembled=_assembled_with_publiccode(),
+        jsonld_context=_context(),
+        include_internal_fields=False,
+    )
+    assert "publiccode" not in payload["@context"]
+    node = payload["@graph"][0]
+    assert not [k for k in node if str(k).startswith("publiccode:")]
+    assert not [k for k in node if str(k).startswith("gme-internal:")]
+
+
+def test_publiccode_predicates_expand_to_rdf_triples() -> None:
+    """Sanity-check that rdflib expands the `publiccode:` prefix into
+    real IRI predicates, so the payload is uploadable as RDF without
+    any extra context plumbing."""
+    payload = build_jsonld_output(
+        assembled=_assembled_with_publiccode(),
+        jsonld_context=_context(),
+        include_internal_fields=True,
+    )
+    graph = Graph()
+    graph.parse(data=json.dumps(payload), format="json-ld")
+    repo_subject = URIRef(f"{ENTITY_URI_PREFIX}owner/repo")
+    # Scalar predicate.
+    assert (
+        repo_subject,
+        URIRef("https://yml.publiccode.tools/softwareType"),
+        Literal("standalone/web"),
+    ) in graph
+    # List-of-strings: each value becomes its own triple.
+    categories = set(
+        graph.objects(
+            repo_subject,
+            URIRef("https://yml.publiccode.tools/categories"),
+        ),
+    )
+    assert categories == {Literal("e-commerce"), Literal("warehouse-management")}
+
+
+def test_publiccode_no_hoist_when_publiccode_field_missing() -> None:
+    """An entity without `_publiccode` should produce no `publiccode:`
+    predicates — the hoist is conditional on the parsed payload being
+    present."""
+    assembled = AssembledOutput(
+        root_entity={
+            "id": "owner/repo",
+            "type": "schema:SoftwareSourceCode",
+            "schema:name": "owner/repo",
+            "_homepage": "https://example.org",
+        },
+        related_entities=[],
+        excluded_entities=[],
+    )
+    payload = build_jsonld_output(
+        assembled=assembled,
+        jsonld_context=_context(),
+        include_internal_fields=True,
+    )
+    # The `publiccode:` prefix is still registered in the context — that's
+    # fine, an unused prefix is cheap and keeps the @context stable across
+    # responses — but no triples carry the prefix.
+    node = payload["@graph"][0]
+    assert not [k for k in node if str(k).startswith("publiccode:")]
+
+
+def test_publiccode_empty_payload_emits_no_predicates() -> None:
+    """`_publiccode = None` or `_publiccode = {}` produce zero
+    `publiccode:` predicates even when the flag is on."""
+    for empty in (None, {}):
+        assembled = AssembledOutput(
+            root_entity={
+                "id": "owner/repo",
+                "type": "schema:SoftwareSourceCode",
+                "schema:name": "owner/repo",
+                "_publiccode": empty,
+            },
+            related_entities=[],
+            excluded_entities=[],
+        )
+        payload = build_jsonld_output(
+            assembled=assembled,
+            jsonld_context=_context(),
+            include_internal_fields=True,
+        )
+        node = payload["@graph"][0]
+        assert not [k for k in node if str(k).startswith("publiccode:")]


### PR DESCRIPTION
Mirrors the `gme-internal:` strategy already used for the other internal `_`-prefixed fields:

  - separate vocabulary (does NOT touch the Open Pulse ontology),
  - off by default; surfaced only when `include_internal_fields=true`,
  - registered in @context so JSON-LD expansion produces real IRI predicates and the payload loads into any RDF triplestore.

What this adds:

  - `publiccode:` prefix → `https://yml.publiccode.tools/` (the spec's stable docs URL — no formal ontology IRI exists but the docs URL identifies each field definition and is stable across spec versions).
  - On every Repository whose `_publiccode` parsed payload is present, its top-level scalar/list fields are hoisted to `publiccode:<field>` predicates (e.g. `publiccode:name`, `publiccode:url`, `publiccode:license` once we add it, `publiccode:softwareType`, `publiccode:platforms`, …). SPARQL queries can now hit them directly:

      SELECT ?repo ?license
      WHERE { ?repo publiccode:softwareType "standalone/web" ;
                    publiccode:url ?u . }

  - Structured sub-trees (legal / maintenance / localisation / description / dependsOn / intendedAudience) intentionally stay inside `gme-internal:publiccode` as a JSON sub-tree. They need per-leaf predicate mappings to expand cleanly (description has per-language sub-trees, contractors/contacts are lists of dicts) and that's a bigger commit; structured consumers keep full fidelity via the JSON blob.

Tests: 5 new (hoist on, hoist off, RDF round-trip, missing-payload no-op, empty-payload no-op) plus updated assertion that `include_internal_fields=False` strips publiccode predicates too.