### PR TITLE
fix(index stores): wrap CTAS-swap in a transaction so DROP+RENAME is …

### DIFF
--- a/src/index/huggingface/storage/duckdb_store.py
+++ b/src/index/huggingface/storage/duckdb_store.py
@@ -185,15 +185,31 @@ class DuckDBStore:
             *, table: str, columns: list[tuple[str, str]], select: str,
             primary_key: tuple[str, ...] | None = None,
         ) -> None:
+            # The DROP-old / RENAME-new sequence is only atomic when
+            # wrapped in a transaction. Without BEGIN/COMMIT, a crash
+            # between the two statements leaves the database in a state
+            # where the original table has been deleted but the
+            # replacement is still under its temp name — the migration
+            # has to be hand-recovered from the WAL. The transient
+            # working table (CREATE + INSERT) doesn't need the
+            # transaction, but a single span keeps the rollback
+            # surface simple: any failure restores the pre-migration
+            # state in full.
             new_table = f"{table}__iri_migrate"
             conn.execute(f"DROP TABLE IF EXISTS {new_table}")
             col_defs = ", ".join(f"{name} {dtype}" for name, dtype in columns)
             if primary_key:
                 col_defs += f", PRIMARY KEY ({', '.join(primary_key)})"
-            conn.execute(f"CREATE TABLE {new_table} ({col_defs})")
-            conn.execute(f"INSERT INTO {new_table} {select}")
-            conn.execute(f"DROP TABLE {table}")
-            conn.execute(f"ALTER TABLE {new_table} RENAME TO {table}")
+            conn.execute("BEGIN TRANSACTION")
+            try:
+                conn.execute(f"CREATE TABLE {new_table} ({col_defs})")
+                conn.execute(f"INSERT INTO {new_table} {select}")
+                conn.execute(f"DROP TABLE {table}")
+                conn.execute(f"ALTER TABLE {new_table} RENAME TO {table}")
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
 
         # --- orgs.slug (PK) → IRI -------------------------------------
         if _table_has_bare("orgs", "slug"):

--- a/src/index/zenodo/storage/duckdb_store.py
+++ b/src/index/zenodo/storage/duckdb_store.py
@@ -260,16 +260,28 @@ class ZenodoStore:
             *, table: str, columns: list[tuple[str, str]],
             select: str, primary_key: tuple[str, ...] | None = None,
         ) -> None:
-            """Rewrite `table` via CREATE TABLE _new + INSERT + DROP + RENAME."""
+            """Rewrite `table` via CREATE TABLE _new + INSERT + DROP + RENAME.
+
+            All four statements run inside a single transaction so a
+            crash between DROP and RENAME doesn't leave the original
+            table deleted with the replacement still under its temp
+            name. Rollback restores the pre-migration state in full.
+            """
             new_table = f"{table}__iri_migrate"
             conn.execute(f"DROP TABLE IF EXISTS {new_table}")
             col_defs = ", ".join(f"{name} {dtype}" for name, dtype in columns)
             if primary_key:
                 col_defs += f", PRIMARY KEY ({', '.join(primary_key)})"
-            conn.execute(f"CREATE TABLE {new_table} ({col_defs})")
-            conn.execute(f"INSERT INTO {new_table} {select}")
-            conn.execute(f"DROP TABLE {table}")
-            conn.execute(f"ALTER TABLE {new_table} RENAME TO {table}")
+            conn.execute("BEGIN TRANSACTION")
+            try:
+                conn.execute(f"CREATE TABLE {new_table} ({col_defs})")
+                conn.execute(f"INSERT INTO {new_table} {select}")
+                conn.execute(f"DROP TABLE {table}")
+                conn.execute(f"ALTER TABLE {new_table} RENAME TO {table}")
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
 
         if _has_bare("record_creators", "record_id"):
             _ctas_swap(

--- a/tests/index/zenodo/test_iri.py
+++ b/tests/index/zenodo/test_iri.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import duckdb
 import pytest
@@ -166,6 +167,87 @@ def test_bootstrap_migrates_dois_to_url_form(tmp_path: Path):
     assert rows["https://zenodo.org/records/A"][1] == "https://doi.org/10.5281/zenodo.X"
     assert rows["https://zenodo.org/records/B"][1] is None
     store.close()
+
+
+def test_ctas_swap_failure_after_drop_rolls_back_original_table(tmp_path: Path):
+    """Regression for the atomicity hole in `_ctas_swap`.
+
+    The original failure mode was: DROP TABLE <orig> succeeded, then
+    the process crashed before ALTER TABLE <new> RENAME TO <orig>
+    could run. That left the database with the original table gone
+    and the replacement still under its `__iri_migrate` shadow name —
+    unrecoverable without hand-editing the WAL.
+
+    The transaction wrap closes this by holding both statements (plus
+    the preceding CREATE / INSERT) under one BEGIN/COMMIT. To exhibit
+    the failure mode that *needs* the wrap (a failure AFTER the DROP),
+    we have to inject the crash there — DuckDB on its own won't naturally
+    fail at the RENAME stage. The test monkey-patches the connection's
+    `execute` so the ALTER RENAME raises, then asserts that the original
+    table is fully restored after bootstrap unwinds.
+    """
+    db_path = tmp_path / "zenodo.duckdb"
+    conn = duckdb.connect(str(db_path))
+    schema = (
+        Path(__file__).resolve().parents[3]
+        / "src" / "index" / "zenodo" / "storage" / "schema.sql"
+    ).read_text(encoding="utf-8")
+    conn.execute(schema)
+    # Plant a bare-id row so `_table_has_bare` returns True and the
+    # migration actually runs against this table.
+    conn.execute(
+        "INSERT INTO record_creators (record_id, creator_key, position) VALUES "
+        "  ('foo', 'alice', 0),"
+        "  ('bar', 'bob',   1)",
+    )
+    pre_rows = sorted(
+        conn.execute(
+            "SELECT record_id, creator_key, position FROM record_creators ORDER BY position",
+        ).fetchall(),
+    )
+    assert len(pre_rows) == 2
+    conn.close()
+
+    store = ZenodoStore(db_path)
+    real_connect = store.connect
+
+    class _CrashingConn:
+        """Pass through every call except the RENAME, which raises.
+        Mimics a process death between DROP and RENAME."""
+
+        def __init__(self, inner: Any) -> None:  # noqa: ANN401
+            self._inner = inner
+
+        def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            if "ALTER TABLE" in sql and "RENAME TO record_creators" in sql:
+                msg = "simulated crash between DROP and RENAME"
+                raise RuntimeError(msg)
+            return self._inner.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name: str) -> Any:  # noqa: ANN401
+            return getattr(self._inner, name)
+
+    inner = real_connect()
+    store.connect = lambda: _CrashingConn(inner)  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        store.bootstrap()
+
+    # The bootstrap aborted mid-migration, but the transaction wrap
+    # should have rolled back: original `record_creators` survives,
+    # rows intact, no orphan shadow table.
+    surviving = sorted(
+        inner.execute(
+            "SELECT record_id, creator_key, position FROM record_creators ORDER BY position",
+        ).fetchall(),
+    )
+    assert surviving == pre_rows
+    orphan = inner.execute(
+        "SELECT table_name FROM duckdb_tables() "
+        "WHERE table_name = 'record_creators__iri_migrate'",
+    ).fetchone()
+    assert orphan is None, "rollback should have removed the shadow table too"
+    inner.close()
 
 
 def test_doi_migration_is_idempotent(tmp_path: Path):


### PR DESCRIPTION
…atomic

The IRI-migration helpers in `src/index/{huggingface,zenodo}/storage/ duckdb_store.py` rewrite each table via:

  CREATE TABLE foo__iri_migrate ...;
  INSERT INTO foo__iri_migrate SELECT ... FROM foo;
  DROP TABLE foo;
  ALTER TABLE foo__iri_migrate RENAME TO foo;

Between the DROP and the RENAME there's a window where a crash leaves the database with the original table gone and the replacement still under its `__iri_migrate` shadow name — unrecoverable without hand-editing the WAL. We saw the migration code reviewed for this months ago and the fix was flagged but not landed.

This wraps all four statements in BEGIN TRANSACTION / COMMIT (with ROLLBACK on exception). DuckDB supports DDL rollback under explicit transactions, so the whole swap either lands or unwinds — original table + rows restored, shadow table cleaned up.

New regression test (`test_ctas_swap_failure_after_drop_rolls_back_ original_table`) exhibits exactly this race by monkey-patching the connection to raise on `ALTER TABLE ... RENAME TO record_creators`, asserts the original table survives unchanged and the shadow table is gone. Without the wrap the test fails because the DROP commits before the RENAME runs.

No behaviour change on the happy path — migrations still produce the same end state.