### PR TITLE
fix(resolver stages): materialise Membership + Organization (not sche…

### DIFF
--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -828,10 +828,13 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
             )
             logger.info(
                 "%s: persons_examined=%d persons_resolved=%d "
+                "memberships=%d organizations=%d "
                 "queries=%d accepted=%d in %.2fs",
                 STAGE_RESOLVE_COMPANY_TO_ROR,
                 company_result.persons_examined,
                 company_result.persons_resolved,
+                company_result.memberships_created,
+                company_result.organizations_created,
                 company_result.queries_attempted,
                 company_result.queries_accepted,
                 perf_counter() - stage_started_at,
@@ -860,10 +863,13 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
             )
             logger.info(
                 "%s: persons_examined=%d persons_resolved=%d "
+                "memberships=%d organizations=%d "
                 "candidates=%d queries=%d accepted=%d in %.2fs",
                 STAGE_RESOLVE_BIO_TO_ROR,
                 bio_result.persons_examined,
                 bio_result.persons_resolved,
+                bio_result.memberships_created,
+                bio_result.organizations_created,
                 bio_result.candidates_extracted,
                 bio_result.queries_attempted,
                 bio_result.queries_accepted,
@@ -895,12 +901,15 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
                 provider=getattr(providers, "ror_rag", None),
             )
             logger.info(
-                "%s: persons_examined=%d called=%d resolved=%d failed=%d in %.2fs",
+                "%s: persons_examined=%d called=%d resolved=%d failed=%d "
+                "memberships=%d organizations=%d in %.2fs",
                 STAGE_RESOLVE_BIO_TO_ROR_LLM,
                 bio_llm_result.persons_examined,
                 bio_llm_result.persons_called,
                 bio_llm_result.persons_resolved,
                 bio_llm_result.persons_failed,
+                bio_llm_result.memberships_created,
+                bio_llm_result.organizations_created,
                 perf_counter() - stage_started_at,
             )
             for warning in bio_llm_result.warnings:

--- a/src/v2/pipeline/stages/resolve_bio_to_ror.py
+++ b/src/v2/pipeline/stages/resolve_bio_to_ror.py
@@ -60,9 +60,14 @@ from urllib.parse import urlparse
 
 from src.v2.ingest.providers.ror_rag import RorRagProvider, build_default_provider
 from src.v2.pipeline.stages.resolve_company_to_ror import (
-    SCHEMA_AFFILIATION,
+    _existing_membership_keys,
+    _existing_org_ids,
+    _materialise,
+    _person_canonical_id,
     _resolve_one,
 )
+
+STAGE_SOURCE_TAG = "resolve_bio_to_ror"
 
 if TYPE_CHECKING:
     from src.v2.pipeline.stages.reconciliation import ReconciledEntities
@@ -195,10 +200,32 @@ class BioAffiliationResult:
 
     persons_examined: int
     persons_resolved: int
+    memberships_created: int
+    organizations_created: int
     candidates_extracted: int
     queries_attempted: int
     queries_accepted: int
     rejection_reasons: dict[str, int]
+
+
+def _persons_with_memberships(reconciled: "ReconciledEntities") -> set[str]:
+    """Pre-compute the set of person ids that already have at least one
+    Membership entry in the graph. Used to honour the
+    `skip_if_already_affiliated` flag without re-checking on every
+    person."""
+    out: set[str] = set()
+    for m in reconciled.entities.get("memberships") or []:
+        if not isinstance(m, dict):
+            continue
+        composite: Any = None
+        identifiers = m.get("identifiers")
+        if isinstance(identifiers, dict):
+            composite = identifiers.get("pulse:composite")
+        if not isinstance(composite, str):
+            composite = m.get("id")
+        if isinstance(composite, str) and "__" in composite:
+            out.add(composite.split("__", 1)[0])
+    return out
 
 
 def _read_first(person: dict[str, Any], keys: tuple[str, ...]) -> str | None:
@@ -293,12 +320,15 @@ async def run_resolve_bio_to_ror_stage(
     provider: RorRagProvider | None = None,
     skip_if_already_affiliated: bool = True,
 ) -> BioAffiliationResult:
-    """Stage entry. Mutates each Person dict in ``reconciled.entities['persons']``
-    that has an extractable affiliation signal in bio / orcid bio / blog.
+    """Stage entry. For each Person whose bio / orcid bio / blog /
+    email carries an institution signal, push a matching Membership
+    (and Org stub, when new) onto ``reconciled.entities``.
 
-    The function is idempotent: re-running on already-stamped persons
-    leaves their `schema:affiliation` unchanged and (with
-    ``skip_if_already_affiliated=True``, the default) won't even re-query.
+    Idempotent: existing Memberships act as a de-dup set, so a
+    re-run on a graph that already contains this stage's output is a
+    no-op. With ``skip_if_already_affiliated=True`` (the default) the
+    stage won't even query ROR for persons that already have any
+    Membership — set to ``False`` to additively enrich.
     """
     provider = provider or build_default_provider()
     if provider is None:
@@ -306,18 +336,27 @@ async def run_resolve_bio_to_ror_stage(
             "resolve_bio_to_ror: RorRagProvider unavailable (check "
             "V2_ROR_RAG_ENABLED + INDEX_QDRANT_URL); stage skipped",
         )
-        return BioAffiliationResult(0, 0, 0, 0, 0, {"provider_unavailable": 1})
+        return BioAffiliationResult(0, 0, 0, 0, 0, 0, 0, {"provider_unavailable": 1})
 
     persons = reconciled.entities.get("persons") or []
-    cache: dict[str, str | None] = {}
+    cache: dict[str, Any] = {}
     reasons: dict[str, int] = {}
     candidates_extracted = 0
     resolved = 0
+    memberships_added = 0
+    organizations_added = 0
+
+    existing_org_ids = _existing_org_ids(reconciled)
+    existing_membership_keys = _existing_membership_keys(reconciled)
+    affiliated_persons = _persons_with_memberships(reconciled)
 
     for person in persons:
         if not isinstance(person, dict):
             continue
-        if skip_if_already_affiliated and person.get(SCHEMA_AFFILIATION):
+        person_id = _person_canonical_id(person)
+        if not person_id:
+            continue
+        if skip_if_already_affiliated and person_id in affiliated_persons:
             continue
 
         bio = _read_first(person, BIO_KEYS) or ""
@@ -344,31 +383,40 @@ async def run_resolve_bio_to_ror_stage(
             continue
         candidates_extracted += len(candidates)
 
-        candidate_rors: list[str] = []
+        candidate_hits: list[dict[str, Any]] = []
         for candidate in candidates:
-            ror_id, reason = await _resolve_one(provider, cache, candidate)
-            if ror_id:
-                if ror_id not in candidate_rors:
-                    candidate_rors.append(ror_id)
+            hit, reason = await _resolve_one(provider, cache, candidate)
+            if hit is not None:
+                ror_id = hit.get("ror_id")
+                if isinstance(ror_id, str) and ror_id and not any(
+                    h.get("ror_id") == ror_id for h in candidate_hits
+                ):
+                    candidate_hits.append(hit)
             else:
                 reasons[reason] = reasons.get(reason, 0) + 1
 
-        if not candidate_rors:
+        if not candidate_hits:
             continue
 
-        existing = person.get(SCHEMA_AFFILIATION)
-        if isinstance(existing, str):
-            merged = [existing] + [r for r in candidate_rors if r != existing]
-        elif isinstance(existing, list):
-            merged = list(existing) + [r for r in candidate_rors if r not in existing]
-        else:
-            merged = candidate_rors
-        person[SCHEMA_AFFILIATION] = merged[0] if len(merged) == 1 else merged
-        resolved += 1
+        m_added, o_added = _materialise(
+            reconciled=reconciled,
+            person_id=person_id,
+            hits=candidate_hits,
+            source=STAGE_SOURCE_TAG,
+            existing_org_ids=existing_org_ids,
+            existing_membership_keys=existing_membership_keys,
+        )
+        if m_added > 0:
+            resolved += 1
+            memberships_added += m_added
+            organizations_added += o_added
+            affiliated_persons.add(person_id)
 
     result = BioAffiliationResult(
         persons_examined=len(persons),
         persons_resolved=resolved,
+        memberships_created=memberships_added,
+        organizations_created=organizations_added,
         candidates_extracted=candidates_extracted,
         queries_attempted=len(cache),
         queries_accepted=sum(1 for v in cache.values() if v is not None),
@@ -376,9 +424,12 @@ async def run_resolve_bio_to_ror_stage(
     )
     logger.info(
         "resolve_bio_to_ror: persons_examined=%d persons_resolved=%d "
+        "memberships_created=%d organizations_created=%d "
         "candidates=%d queries=%d accepted=%d",
         result.persons_examined,
         result.persons_resolved,
+        result.memberships_created,
+        result.organizations_created,
         result.candidates_extracted,
         result.queries_attempted,
         result.queries_accepted,

--- a/src/v2/pipeline/stages/resolve_bio_to_ror_llm.py
+++ b/src/v2/pipeline/stages/resolve_bio_to_ror_llm.py
@@ -62,9 +62,18 @@ from src.v2.pipeline.stages.resolve_bio_to_ror import (
     BLOG_KEYS,
     EMAIL_KEYS,
     ORCID_BIO_KEYS,
+    _persons_with_memberships,
     _read_first,
 )
-from src.v2.pipeline.stages.resolve_company_to_ror import SCHEMA_AFFILIATION
+from src.v2.pipeline.stages.resolve_company_to_ror import (
+    _build_membership,
+    _build_org_stub,
+    _existing_membership_keys,
+    _existing_org_ids,
+    _person_canonical_id,
+)
+
+STAGE_SOURCE_TAG = "resolve_bio_to_ror_llm"
 
 if TYPE_CHECKING:
     from src.v2.pipeline.stages.reconciliation import ReconciledEntities
@@ -117,6 +126,8 @@ class BioLLMAffiliationResult:
     persons_called: int
     persons_resolved: int
     persons_failed: int
+    memberships_created: int = 0
+    organizations_created: int = 0
     warnings: list[str] = field(default_factory=list)
 
 
@@ -174,27 +185,57 @@ async def _resolve_one_person(
     return patch, None
 
 
-def _apply_patch(person: dict[str, Any], patch: BioResolverPatch) -> bool:
-    """Stamp `schema:affiliation` on the person when the patch carries
-    a high-confidence ROR. Returns True when something was written.
+def _apply_patch(
+    *,
+    person: dict[str, Any],
+    patch: BioResolverPatch,
+    reconciled: "ReconciledEntities",
+    existing_org_ids: set[str],
+    existing_membership_keys: set[str],
+) -> tuple[int, int]:
+    """Materialise the LLM patch as Membership + Org entities (when
+    the confidence floor is cleared and the ROR isn't already linked
+    to this person). Returns ``(memberships_added, organizations_added)``.
 
-    Idempotent: if the ROR is already present (string or in a list)
-    the call is a no-op."""
+    The agent already enforces the floor and a verbatim quote on the
+    `reason` field; the stage-side floor here is defensive — same as
+    the company-stage's strict acceptance gate.
+    """
     if not patch.pulse_ror or patch.confidence < CONFIDENCE_FLOOR:
-        return False
-    new_ror = patch.pulse_ror
-    existing = person.get(SCHEMA_AFFILIATION)
-    if existing == new_ror:
-        return False
-    if isinstance(existing, list):
-        if new_ror in existing:
-            return False
-        person[SCHEMA_AFFILIATION] = list(existing) + [new_ror]
-    elif isinstance(existing, str):
-        person[SCHEMA_AFFILIATION] = [existing, new_ror]
-    else:
-        person[SCHEMA_AFFILIATION] = new_ror
-    return True
+        return 0, 0
+    person_id = _person_canonical_id(person)
+    if not person_id:
+        return 0, 0
+    composite = f"{person_id}__{patch.pulse_ror}"
+    if composite in existing_membership_keys:
+        return 0, 0
+
+    orgs = reconciled.entities.setdefault("organizations", [])
+    memberships = reconciled.entities.setdefault("memberships", [])
+    o_added = 0
+    if patch.pulse_ror not in existing_org_ids:
+        # We don't have a ROR `name` from the LLM patch — `reason`
+        # carries a verbatim bio quote that may or may not be the
+        # canonical name. Use the ROR URL itself so the Org stub is
+        # well-formed; downstream refiners can backfill `schema:name`.
+        stub = _build_org_stub(
+            {"ror_id": patch.pulse_ror, "name": patch.pulse_ror},
+            source=STAGE_SOURCE_TAG,
+        )
+        if stub is not None:
+            orgs.append(stub)
+            existing_org_ids.add(patch.pulse_ror)
+            o_added = 1
+
+    memberships.append(
+        _build_membership(
+            person_id=person_id,
+            org_id=patch.pulse_ror,
+            source=STAGE_SOURCE_TAG,
+        ),
+    )
+    existing_membership_keys.add(composite)
+    return 1, o_added
 
 
 async def run_resolve_bio_to_ror_llm_stage(
@@ -204,17 +245,17 @@ async def run_resolve_bio_to_ror_llm_stage(
     agent: BioResolverAgent | None = None,
     max_concurrency: int | None = None,
 ) -> BioLLMAffiliationResult:
-    """Stage entry. For each Person still missing `schema:affiliation`
-    after Stage A, run the LLM bio-resolver and stamp the affiliation
-    when the LLM clears the confidence floor.
-
-    Idempotent: re-running on already-stamped persons is a no-op.
+    """Stage entry. For each Person without a Membership after Stage A
+    that still has bio / orcid bio / readme text, call the LLM
+    bio-resolver and (on a high-confidence patch) materialise a
+    Membership + Organization entity. Idempotent across re-runs.
     """
     persons_raw = reconciled.entities.get("persons") or []
+    affiliated_persons = _persons_with_memberships(reconciled)
     candidates: list[dict[str, Any]] = [
         p for p in persons_raw
         if isinstance(p, dict)
-        and not p.get(SCHEMA_AFFILIATION)
+        and (_person_canonical_id(p) or "") not in affiliated_persons
         and _has_extractable_text(p)
     ]
     if not candidates:
@@ -247,8 +288,13 @@ async def run_resolve_bio_to_ror_llm_stage(
     ]
     results = await asyncio.gather(*tasks)
 
+    existing_org_ids = _existing_org_ids(reconciled)
+    existing_membership_keys = _existing_membership_keys(reconciled)
+
     resolved = 0
     failed = 0
+    memberships_added = 0
+    organizations_added = 0
     warnings: list[str] = []
     for person, (patch, warning) in zip(candidates, results, strict=False):
         if warning:
@@ -257,22 +303,36 @@ async def run_resolve_bio_to_ror_llm_stage(
             continue
         if patch is None:
             continue
-        if _apply_patch(person, patch):
+        m_added, o_added = _apply_patch(
+            person=person,
+            patch=patch,
+            reconciled=reconciled,
+            existing_org_ids=existing_org_ids,
+            existing_membership_keys=existing_membership_keys,
+        )
+        if m_added > 0:
             resolved += 1
+            memberships_added += m_added
+            organizations_added += o_added
 
     result = BioLLMAffiliationResult(
         persons_examined=len(persons_raw),
         persons_called=len(candidates),
         persons_resolved=resolved,
         persons_failed=failed,
+        memberships_created=memberships_added,
+        organizations_created=organizations_added,
         warnings=warnings,
     )
     logger.info(
-        "resolve_bio_to_ror_llm: examined=%d called=%d resolved=%d failed=%d",
+        "resolve_bio_to_ror_llm: examined=%d called=%d resolved=%d failed=%d "
+        "memberships=%d organizations=%d",
         result.persons_examined,
         result.persons_called,
         result.persons_resolved,
         result.persons_failed,
+        result.memberships_created,
+        result.organizations_created,
     )
     return result
 

--- a/src/v2/pipeline/stages/resolve_company_to_ror.py
+++ b/src/v2/pipeline/stages/resolve_company_to_ror.py
@@ -1,14 +1,18 @@
-"""Stage: resolve gme-internal:company strings into ROR identifiers and
-stamp ``schema:affiliation`` directly on the Person entity.
+"""Stage: resolve ``_company`` strings to ROR ids and materialise the
+result as proper ``org:Membership`` + ``org:Organization`` entities on
+``reconciled.entities``. The Person itself is left alone — affiliation
+without evidence is modelled as a Membership pointing to an Org, per
+the v2 ontology. The stage does NOT emit a bare ``schema:affiliation``
+triple on Person (that property isn't in the Open Pulse ontology).
 
 Why this stage exists
 ---------------------
 ``reconciliation.py`` correctly requires *either* role/dates *or* an
 ORCID-on-Person + ROR-on-Org authority anchor before it materialises a
-``Membership`` (this prevents the "Statistics Botswana"-class false
-positives). The downstream ``refine_with_llm`` rescue pass can rescue
-some dropped memberships, but only when the README/CITATION text
-verbatim names the person + org.
+``Membership`` from raw agent output (this prevents the "Statistics
+Botswana"-class false positives that bit us in v1). The downstream
+``refine_with_llm`` rescue pass can rescue some dropped memberships,
+but only when the README/CITATION text verbatim names the person + org.
 
 That leaves a huge class of legitimate, evidence-free affiliations on
 the floor: any GitHub user who writes ``company: Google`` (or any
@@ -16,14 +20,12 @@ variant — ``@google``, ``Google Inc.``, ``Google Brain``) and does not
 also publish an ORCID iD ends up with **no** institutional link in the
 graph, even though ROR confidently resolves the string.
 
-This stage closes that gap by emitting ``schema:affiliation`` triples
-(not Memberships — Memberships still require evidence per the existing
-rule) when the GME's own ``search_ror`` skill returns a single high-
-confidence research-org candidate. The output is intentionally
-*weaker* than a Membership: ``schema:affiliation`` carries no role and
-no dates, so downstream consumers that need provenance (validation,
-critic pruning) can ignore it; consumers that only need org rollups
-(dashboards, CHAOSS metrics) get the link they actually wanted.
+This stage closes that gap by materialising Memberships when the GME's
+own ``search_ror`` skill returns a single high-confidence research-org
+candidate. The Memberships carry no ``org:role`` and no dates — that's
+honest (we have no evidence), and downstream consumers that need
+provenance can read ``_source`` (internal-only, stripped at output by
+default).
 
 Decision rule
 -------------
@@ -42,16 +44,23 @@ Reject every query whose canonical form is in ``NON_ORG_KEYS``
 The cross-encoder reranker is **off by default**. For single-word
 company queries it hurts: the reranker over-weights semantic
 similarity and promotes Calico / GamesThatWork over the literal
-match. Multi-word queries with ``--rerank`` would help — left as a
-future knob.
+match.
 
-Integration
------------
-The stage is meant to be invoked from ``api.py`` right after
-``reconcile_entities`` and before the LLM critic / refiner. The
-implementation is purely synchronous (vector search is fast: ~50 ms
-per query on the GPU embedder), so it does not need the orchestrator
-task machinery.
+Output shape
+------------
+For each accepted resolution the stage pushes:
+
+  * one minimal Organization entity to ``reconciled.entities['organizations']``
+    (id = ROR URL, type = ``org:Organization``, idSource = ``pulse:ror``,
+    schema:name = ROR's display name) when the ROR URL isn't already
+    represented in the graph;
+  * one Membership entity to ``reconciled.entities['memberships']``
+    (id = ``{personId}__{rorURL}``, type = ``org:Membership``,
+    org:organization = ROR URL, org:role / time:hasBeginning /
+    time:hasEnd = None) when the same composite isn't already present.
+
+Both writes are idempotent — re-running the stage on a graph that
+already contains its earlier output is a no-op.
 """
 from __future__ import annotations
 
@@ -61,6 +70,7 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from src.v2.agents.models import generate_uuid
 from src.v2.ingest.providers.ror_rag import RorRagProvider, build_default_provider
 
 if TYPE_CHECKING:
@@ -82,8 +92,13 @@ NON_ORG_KEYS: frozenset[str] = frozenset({
     "various", "multiple", "https",
 })
 
-# Schema IRIs (kept inline to avoid a pipeline-wide constants module).
-SCHEMA_AFFILIATION = "http://schema.org/affiliation"
+# Source tag stamped on `_source` for every Membership/Org this stage
+# generates, so downstream consumers (the critic, refine_with_llm,
+# the SHACL gate's logs) can distinguish resolver output from
+# text-extracted entities. Internal-only — `_drop_internal_keys` strips
+# it before strict validation + JSON-LD output by default.
+STAGE_SOURCE_TAG = "resolve_company_to_ror"
+
 # The Person dict carries the company under different keys depending on
 # where in the pipeline we run. In-pipeline (between reconciliation and
 # the LLM critic) it's the rule-based agent's `_company`. The
@@ -122,6 +137,8 @@ class CompanyAffiliationResult:
 
     persons_examined: int
     persons_resolved: int
+    memberships_created: int
+    organizations_created: int
     queries_attempted: int
     queries_accepted: int
     rejection_reasons: dict[str, int]
@@ -176,19 +193,23 @@ def _accept(hits: list[dict[str, Any]], query: str) -> tuple[dict | None, str]:
 
 async def _resolve_one(
     provider: RorRagProvider,
-    cache: dict[str, str | None],
+    cache: dict[str, dict[str, Any] | None],
     raw_company: str,
-) -> tuple[str | None, str]:
+) -> tuple[dict[str, Any] | None, str]:
     """Resolve one raw company string. Caches by cleaned query so
-    ``Google`` / ``@google`` / ``Google `` share a single search."""
+    ``Google`` / ``@google`` / ``Google `` share a single search.
+
+    Returns the winning ROR hit dict (with ``ror_id``, ``name``,
+    ``types``) so callers can mint a matching Org stub without a
+    second round trip. ``None`` when nothing clears the acceptance
+    gate."""
     q = _clean_query(raw_company)
     if not q or q.lower() in NON_ORG_KEYS:
         return None, "non-org key"
     if q in cache:
-        ror = cache[q]
-        return ror, "cache hit" if ror else "cached negative"
+        hit = cache[q]
+        return hit, "cache hit" if hit else "cached negative"
     hits = await provider.search(query=q, scope_mode="worldwide", top_k=5, rerank=False)
-    # Normalise hit dicts (provider may yield pydantic objects)
     norm: list[dict[str, Any]] = []
     for h in hits or []:
         if isinstance(h, dict):
@@ -198,9 +219,129 @@ async def _resolve_one(
         else:
             norm.append(dict(h.__dict__))
     winner, reason = _accept(norm, q)
-    ror_id = winner.get("ror_id") if winner else None
-    cache[q] = ror_id
-    return ror_id, reason
+    cache[q] = winner
+    return winner, reason
+
+
+# ---------------------------------------------------------------------------
+# Membership / Organization materialisation
+# ---------------------------------------------------------------------------
+
+
+def _build_org_stub(hit: dict[str, Any], *, source: str) -> dict[str, Any] | None:
+    """Build a minimal Organization entity from a ROR hit. Returns
+    ``None`` if the hit lacks a `ror_id`. Schema-conformant to
+    ``pulse:OrganizationShape`` (id, type, shacl, identifiers, idSource,
+    schema:name)."""
+    ror_id = hit.get("ror_id")
+    if not isinstance(ror_id, str) or not ror_id:
+        return None
+    name = _strip_country(str(hit.get("name") or "")) or ror_id
+    return {
+        "id": ror_id,
+        "type": "org:Organization",
+        "shacl": "pulse:OrganizationShape",
+        "identifiers": {
+            "pulse:ror": ror_id,
+            "uuid": generate_uuid(),
+        },
+        "idSource": "pulse:ror",
+        "schema:name": name,
+        # Internal provenance — stripped at output by `_drop_internal_keys`
+        # unless `?include_internal_fields=true`. Not in the ontology;
+        # purely for tooling/debugging.
+        "_source": source,
+    }
+
+
+def _build_membership(
+    *, person_id: str, org_id: str, source: str,
+) -> dict[str, Any]:
+    """Build a Membership entity linking person→org. No role, no dates
+    (we have no evidence). Schema-conformant to ``pulse:MembershipShape``."""
+    composite_id = f"{person_id}__{org_id}"
+    return {
+        "id": composite_id,
+        "type": "org:Membership",
+        "shacl": "pulse:MembershipShape",
+        "identifiers": {
+            "pulse:composite": composite_id,
+            "uuid": generate_uuid(),
+        },
+        "idSource": "pulse:composite",
+        "org:organization": org_id,
+        "org:role": None,
+        "time:hasBeginning": None,
+        "time:hasEnd": None,
+        "_source": source,
+    }
+
+
+def _existing_org_ids(reconciled: "ReconciledEntities") -> set[str]:
+    out: set[str] = set()
+    for org in reconciled.entities.get("organizations") or []:
+        if isinstance(org, dict):
+            org_id = org.get("id")
+            if isinstance(org_id, str):
+                out.add(org_id)
+    return out
+
+
+def _existing_membership_keys(reconciled: "ReconciledEntities") -> set[str]:
+    out: set[str] = set()
+    for m in reconciled.entities.get("memberships") or []:
+        if isinstance(m, dict):
+            mid = m.get("id")
+            if isinstance(mid, str):
+                out.add(mid)
+    return out
+
+
+def _materialise(
+    *,
+    reconciled: "ReconciledEntities",
+    person_id: str,
+    hits: list[dict[str, Any]],
+    source: str,
+    existing_org_ids: set[str],
+    existing_membership_keys: set[str],
+) -> tuple[int, int]:
+    """Push Org stubs + Memberships for each accepted ROR hit. Returns
+    ``(memberships_added, organizations_added)``. Mutates ``reconciled``
+    in place; updates the existing-id sets so within a single stage
+    invocation later persons don't re-add the same org."""
+    orgs = reconciled.entities.setdefault("organizations", [])
+    memberships = reconciled.entities.setdefault("memberships", [])
+    m_added = 0
+    o_added = 0
+    for hit in hits:
+        ror_id = hit.get("ror_id")
+        if not isinstance(ror_id, str) or not ror_id:
+            continue
+        if ror_id not in existing_org_ids:
+            stub = _build_org_stub(hit, source=source)
+            if stub is not None:
+                orgs.append(stub)
+                existing_org_ids.add(ror_id)
+                o_added += 1
+        composite = f"{person_id}__{ror_id}"
+        if composite not in existing_membership_keys:
+            memberships.append(
+                _build_membership(person_id=person_id, org_id=ror_id, source=source),
+            )
+            existing_membership_keys.add(composite)
+            m_added += 1
+    return m_added, o_added
+
+
+def _person_canonical_id(person: dict[str, Any]) -> str | None:
+    """The membership composite needs a stable person id. Prefer the
+    pipeline's `id` field, fall back to `@id`."""
+    for key in ("id", "@id"):
+        value = person.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
 
 
 async def run_resolve_company_to_ror_stage(
@@ -208,13 +349,13 @@ async def run_resolve_company_to_ror_stage(
     reconciled: "ReconciledEntities",
     provider: RorRagProvider | None = None,
 ) -> CompanyAffiliationResult:
-    """Stage entry. Mutates each Person dict in ``reconciled.entities['persons']``
-    by appending a ``schema:affiliation`` (str or list[str]) when a high-
-    confidence ROR match is found.
+    """Stage entry. Materialises one Membership + (when new) one
+    Organization per accepted ROR hit, idempotently.
 
-    The function is idempotent — re-running on already-stamped persons
-    will not duplicate existing affiliations and will not overwrite a
-    pre-existing value that points at a different ROR.
+    Re-running the stage on a graph that already contains its earlier
+    output is a no-op — both the org set and the membership composite
+    set are pre-computed from `reconciled.entities` so duplicates can't
+    creep in across re-runs.
     """
     provider = provider or build_default_provider()
     if provider is None:
@@ -222,15 +363,23 @@ async def run_resolve_company_to_ror_stage(
             "resolve_company_to_ror: RorRagProvider unavailable (check "
             "V2_ROR_RAG_ENABLED + INDEX_QDRANT_URL); stage skipped",
         )
-        return CompanyAffiliationResult(0, 0, 0, 0, {"provider_unavailable": 1})
+        return CompanyAffiliationResult(0, 0, 0, 0, 0, 0, {"provider_unavailable": 1})
 
     persons = reconciled.entities.get("persons") or []
-    cache: dict[str, str | None] = {}
+    cache: dict[str, dict[str, Any] | None] = {}
     reasons: dict[str, int] = {}
     resolved = 0
+    memberships_added = 0
+    organizations_added = 0
+
+    existing_org_ids = _existing_org_ids(reconciled)
+    existing_membership_keys = _existing_membership_keys(reconciled)
 
     for person in persons:
         if not isinstance(person, dict):
+            continue
+        person_id = _person_canonical_id(person)
+        if not person_id:
             continue
         raw_companies = _read_company(person)
         if not raw_companies:
@@ -242,46 +391,52 @@ async def run_resolve_company_to_ror_stage(
         else:
             continue
 
-        # Each raw company string may carry joint affiliations.
-        candidate_rors: list[str] = []
+        candidate_hits: list[dict[str, Any]] = []
         for raw in raw_list:
             for part in _split_joint(raw):
-                ror_id, reason = await _resolve_one(provider, cache, part)
-                if ror_id:
-                    if ror_id not in candidate_rors:
-                        candidate_rors.append(ror_id)
+                hit, reason = await _resolve_one(provider, cache, part)
+                if hit is not None:
+                    ror_id = hit.get("ror_id")
+                    if isinstance(ror_id, str) and ror_id and not any(
+                        h.get("ror_id") == ror_id for h in candidate_hits
+                    ):
+                        candidate_hits.append(hit)
                 else:
                     reasons[reason] = reasons.get(reason, 0) + 1
 
-        if not candidate_rors:
+        if not candidate_hits:
             continue
 
-        # Merge with any pre-existing affiliation triple, dedupe.
-        existing = person.get(SCHEMA_AFFILIATION)
-        if isinstance(existing, str):
-            merged = [existing] + [r for r in candidate_rors if r != existing]
-        elif isinstance(existing, list):
-            merged = list(existing) + [r for r in candidate_rors if r not in existing]
-        else:
-            merged = candidate_rors
-        # Single-element values stay as strings (schema.org convention);
-        # multi-element values become lists. JSON-LD output assembly
-        # already handles both shapes.
-        person[SCHEMA_AFFILIATION] = merged[0] if len(merged) == 1 else merged
-        resolved += 1
+        m_added, o_added = _materialise(
+            reconciled=reconciled,
+            person_id=person_id,
+            hits=candidate_hits,
+            source=STAGE_SOURCE_TAG,
+            existing_org_ids=existing_org_ids,
+            existing_membership_keys=existing_membership_keys,
+        )
+        if m_added > 0:
+            resolved += 1
+            memberships_added += m_added
+            organizations_added += o_added
 
     result = CompanyAffiliationResult(
         persons_examined=len(persons),
         persons_resolved=resolved,
+        memberships_created=memberships_added,
+        organizations_created=organizations_added,
         queries_attempted=len(cache),
         queries_accepted=sum(1 for v in cache.values() if v is not None),
         rejection_reasons=reasons,
     )
     logger.info(
         "resolve_company_to_ror: persons_examined=%d persons_resolved=%d "
+        "memberships_created=%d organizations_created=%d "
         "queries=%d accepted=%d",
         result.persons_examined,
         result.persons_resolved,
+        result.memberships_created,
+        result.organizations_created,
         result.queries_attempted,
         result.queries_accepted,
     )

--- a/tests/v2/test_resolve_bio_to_ror.py
+++ b/tests/v2/test_resolve_bio_to_ror.py
@@ -36,7 +36,23 @@ from src.v2.pipeline.stages.resolve_bio_to_ror import (
     _extract_bio_candidates,
     run_resolve_bio_to_ror_stage,
 )
-from src.v2.pipeline.stages.resolve_company_to_ror import SCHEMA_AFFILIATION
+def _memberships(reconciled: ReconciledEntities) -> list[dict[str, Any]]:
+    return reconciled.entities.get("memberships") or []
+
+
+def _organizations(reconciled: ReconciledEntities) -> list[dict[str, Any]]:
+    return reconciled.entities.get("organizations") or []
+
+
+def _membership_org_ids(reconciled: ReconciledEntities, *, person_id: str) -> list[str]:
+    out: list[str] = []
+    for m in _memberships(reconciled):
+        composite = m.get("id", "")
+        if composite.startswith(f"{person_id}__"):
+            org_ref = m.get("org:organization")
+            if isinstance(org_ref, str):
+                out.append(org_ref)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -185,8 +201,9 @@ def test_stage_resolves_from_bio_at_phrase():
         },
     )
     result = _run(reconciled, provider)
-    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/deepmind"
+    assert _membership_org_ids(reconciled, person_id="p1") == ["https://ror.org/deepmind"]
     assert result.persons_resolved == 1
+    assert result.memberships_created == 1
     assert result.queries_accepted == 1
 
 
@@ -207,7 +224,7 @@ def test_stage_resolves_from_orcid_bio():
         },
     )
     _run(reconciled, provider)
-    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/02s376052"
+    assert _membership_org_ids(reconciled, person_id="p1") == ["https://ror.org/02s376052"]
 
 
 def test_stage_resolves_from_anonymized_email_domain():
@@ -229,7 +246,7 @@ def test_stage_resolves_from_anonymized_email_domain():
         },
     )
     _run(reconciled, provider)
-    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/02s376052"
+    assert _membership_org_ids(reconciled, person_id="p1") == ["https://ror.org/02s376052"]
 
 
 @pytest.mark.parametrize("email_key", EMAIL_KEYS)
@@ -250,7 +267,7 @@ def test_stage_reads_email_under_every_key_shape(email_key):
         },
     )
     _run(reconciled, provider)
-    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/02s376052"
+    assert _membership_org_ids(reconciled, person_id="p1") == ["https://ror.org/02s376052"]
 
 
 def test_stage_resolves_from_blog_domain():
@@ -271,7 +288,7 @@ def test_stage_resolves_from_blog_domain():
         },
     )
     _run(reconciled, provider)
-    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/02s376052"
+    assert _membership_org_ids(reconciled, person_id="p1") == ["https://ror.org/02s376052"]
 
 
 def test_stage_no_op_when_no_signals():
@@ -284,39 +301,62 @@ def test_stage_no_op_when_no_signals():
     assert result.persons_resolved == 0
 
 
-def test_stage_skips_already_affiliated_by_default():
-    """The stage is a backstop — when company-stage already stamped
-    an affiliation, the bio stage stays out of the way."""
-    reconciled = ReconciledEntities(
-        entities={
-            "persons": [
-                {
-                    "id": "p1",
-                    "_bio": "Now at Google DeepMind",
-                    SCHEMA_AFFILIATION: "https://ror.org/companyx",
-                },
-            ],
+def _seed_membership(reconciled: ReconciledEntities, *, person_id: str, ror: str) -> None:
+    """Plant an existing Membership in the graph as if the company
+    stage had already resolved this person to ``ror``."""
+    composite = f"{person_id}__{ror}"
+    reconciled.entities.setdefault("memberships", []).append(
+        {
+            "id": composite,
+            "type": "org:Membership",
+            "shacl": "pulse:MembershipShape",
+            "identifiers": {"pulse:composite": composite, "uuid": "x"},
+            "idSource": "pulse:composite",
+            "org:organization": ror,
+            "org:role": None,
+            "time:hasBeginning": None,
+            "time:hasEnd": None,
+            "_source": "test_seed",
         },
     )
+    reconciled.entities.setdefault("organizations", []).append(
+        {
+            "id": ror,
+            "type": "org:Organization",
+            "shacl": "pulse:OrganizationShape",
+            "identifiers": {"pulse:ror": ror, "uuid": "y"},
+            "idSource": "pulse:ror",
+            "schema:name": "seed",
+        },
+    )
+
+
+def test_stage_skips_already_affiliated_by_default():
+    """The stage is a backstop — when an earlier stage already
+    materialised a Membership for this person, the bio stage stays
+    out of the way."""
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [{"id": "p1", "_bio": "Now at Google DeepMind"}],
+        },
+    )
+    _seed_membership(reconciled, person_id="p1", ror="https://ror.org/companyx")
     provider = _StubProvider(hits={})
     _run(reconciled, provider)
-    # Untouched: still just the company-stage value, no queries issued.
-    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/companyx"
+    # Only the seeded Membership; no new one added.
+    assert _membership_org_ids(reconciled, person_id="p1") == [
+        "https://ror.org/companyx",
+    ]
     assert provider.queries == []
 
 
 def test_stage_enriches_when_skip_disabled():
     reconciled = ReconciledEntities(
         entities={
-            "persons": [
-                {
-                    "id": "p1",
-                    "_bio": "Now at Google DeepMind",
-                    SCHEMA_AFFILIATION: "https://ror.org/companyx",
-                },
-            ],
+            "persons": [{"id": "p1", "_bio": "Now at Google DeepMind"}],
         },
     )
+    _seed_membership(reconciled, person_id="p1", ror="https://ror.org/companyx")
     provider = _StubProvider(
         hits={
             "Google DeepMind": [
@@ -326,10 +366,10 @@ def test_stage_enriches_when_skip_disabled():
         },
     )
     _run(reconciled, provider, skip_if_already_affiliated=False)
-    affiliations = reconciled.entities["persons"][0][SCHEMA_AFFILIATION]
-    assert isinstance(affiliations, list)
-    assert "https://ror.org/companyx" in affiliations
-    assert "https://ror.org/deepmind" in affiliations
+    # Both Memberships now present — additive enrichment.
+    org_ids = sorted(_membership_org_ids(reconciled, person_id="p1"))
+    assert "https://ror.org/companyx" in org_ids
+    assert "https://ror.org/deepmind" in org_ids
 
 
 @pytest.mark.parametrize("bio_key", BIO_KEYS)
@@ -350,7 +390,7 @@ def test_stage_reads_bio_under_every_key_shape(bio_key):
         },
     )
     _run(reconciled, provider)
-    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/deepmind"
+    assert _membership_org_ids(reconciled, person_id="p1") == ["https://ror.org/deepmind"]
 
 
 @pytest.mark.parametrize("blog_key", BLOG_KEYS)
@@ -371,7 +411,7 @@ def test_stage_reads_blog_under_every_key_shape(blog_key):
         },
     )
     _run(reconciled, provider)
-    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/02s376052"
+    assert _membership_org_ids(reconciled, person_id="p1") == ["https://ror.org/02s376052"]
 
 
 @pytest.mark.parametrize("orcid_key", ORCID_BIO_KEYS)
@@ -392,7 +432,7 @@ def test_stage_reads_orcid_bio_under_every_key_shape(orcid_key):
         },
     )
     _run(reconciled, provider)
-    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/05a28rw58"
+    assert _membership_org_ids(reconciled, person_id="p1") == ["https://ror.org/05a28rw58"]
 
 
 def test_stage_dedups_candidates_across_sources():
@@ -438,7 +478,7 @@ def test_stage_rejects_low_confidence_bio_candidate():
         },
     )
     result = _run(reconciled, provider)
-    assert SCHEMA_AFFILIATION not in reconciled.entities["persons"][0]
+    assert _memberships(reconciled) == []
     assert result.persons_resolved == 0
 
 
@@ -460,14 +500,14 @@ def test_stage_is_idempotent_on_re_run_unaffiliated():
             ],
         },
     )
-    # First run skips no one (no prior affiliation). Second run hits
+    # First run skips no one (no prior Membership). Second run hits
     # the skip_if_already_affiliated guard and short-circuits.
     _run(reconciled, provider)
-    first = reconciled.entities["persons"][0][SCHEMA_AFFILIATION]
+    first_orgs = sorted(_membership_org_ids(reconciled, person_id="p1"))
     queries_after_first = len(provider.queries)
     _run(reconciled, provider)
-    second = reconciled.entities["persons"][0][SCHEMA_AFFILIATION]
-    assert first == second
+    second_orgs = sorted(_membership_org_ids(reconciled, person_id="p1"))
+    assert first_orgs == second_orgs
     assert len(provider.queries) == queries_after_first  # skip path → no new query
 
 

--- a/tests/v2/test_resolve_bio_to_ror_llm.py
+++ b/tests/v2/test_resolve_bio_to_ror_llm.py
@@ -33,7 +33,37 @@ from src.v2.pipeline.stages.resolve_bio_to_ror_llm import (
     _resolve_max_concurrency,
     run_resolve_bio_to_ror_llm_stage,
 )
-from src.v2.pipeline.stages.resolve_company_to_ror import SCHEMA_AFFILIATION
+def _memberships(reconciled: ReconciledEntities) -> list[dict[str, Any]]:
+    return reconciled.entities.get("memberships") or []
+
+
+def _membership_org_ids(reconciled: ReconciledEntities, *, person_id: str) -> list[str]:
+    return [
+        m["org:organization"]
+        for m in _memberships(reconciled)
+        if isinstance(m, dict)
+        and isinstance(m.get("id"), str)
+        and m["id"].startswith(f"{person_id}__")
+    ]
+
+
+def _seed_membership(
+    reconciled: ReconciledEntities, *, person_id: str, ror: str,
+) -> None:
+    composite = f"{person_id}__{ror}"
+    reconciled.entities.setdefault("memberships", []).append(
+        {
+            "id": composite,
+            "type": "org:Membership",
+            "shacl": "pulse:MembershipShape",
+            "identifiers": {"pulse:composite": composite, "uuid": "u"},
+            "idSource": "pulse:composite",
+            "org:organization": ror,
+            "org:role": None,
+            "time:hasBeginning": None,
+            "time:hasEnd": None,
+        },
+    )
 
 
 class _StubAgent:
@@ -84,18 +114,19 @@ def _run(reconciled: ReconciledEntities, *, agent: Any, provider: Any = None) ->
 
 
 def test_only_unaffiliated_persons_with_text_are_sent_to_the_llm():
-    """Skip persons already affiliated, and skip persons with no bio /
-    orcid / readme — the LLM has nothing to quote."""
+    """Skip persons that already have a Membership, and skip persons
+    with no bio / orcid / readme — the LLM has nothing to quote."""
     reconciled = ReconciledEntities(
         entities={
             "persons": [
-                {"id": "already", "_bio": "Engineer at X", SCHEMA_AFFILIATION: "https://ror.org/x"},
+                {"id": "already", "_bio": "Engineer at X"},
                 {"id": "empty"},  # no signal at all
                 {"id": "with-bio", "_bio": "Research Engineer at DeepMind"},
                 {"id": "with-readme", "_profile_readme": "# About me\nI work at MIT."},
             ],
         },
     )
+    _seed_membership(reconciled, person_id="already", ror="https://ror.org/x")
     agent = _StubAgent(patches={})  # returns no-op for every call
     result = _run(reconciled, agent=agent)
     # Only the last two were sent.
@@ -108,11 +139,10 @@ def test_only_unaffiliated_persons_with_text_are_sent_to_the_llm():
 def test_no_op_when_every_person_already_affiliated():
     reconciled = ReconciledEntities(
         entities={
-            "persons": [
-                {"id": "p1", "_bio": "...", SCHEMA_AFFILIATION: "https://ror.org/x"},
-            ],
+            "persons": [{"id": "p1", "_bio": "..."}],
         },
     )
+    _seed_membership(reconciled, person_id="p1", ror="https://ror.org/x")
     agent = _StubAgent(patches={})
     result = _run(reconciled, agent=agent)
     assert result.persons_called == 0
@@ -124,7 +154,7 @@ def test_no_op_when_every_person_already_affiliated():
 # ---------------------------------------------------------------------------
 
 
-def test_high_confidence_ror_stamps_affiliation():
+def test_high_confidence_ror_creates_membership_and_organization():
     reconciled = ReconciledEntities(
         entities={
             "persons": [
@@ -142,74 +172,103 @@ def test_high_confidence_ror_stamps_affiliation():
         },
     )
     result = _run(reconciled, agent=agent)
-    assert reconciled.entities["persons"][0][SCHEMA_AFFILIATION] == "https://ror.org/deepmind"
+    assert _membership_org_ids(reconciled, person_id="p1") == [
+        "https://ror.org/deepmind",
+    ]
+    org_ids = {o["id"] for o in reconciled.entities.get("organizations", [])}
+    assert "https://ror.org/deepmind" in org_ids
     assert result.persons_resolved == 1
+    assert result.memberships_created == 1
+    assert result.organizations_created == 1
     assert result.persons_failed == 0
 
 
+def _apply_kwargs(
+    *, reconciled: ReconciledEntities, existing_org_ids: set, existing_keys: set,
+) -> dict[str, Any]:
+    return {
+        "reconciled": reconciled,
+        "existing_org_ids": existing_org_ids,
+        "existing_membership_keys": existing_keys,
+    }
+
+
 def test_low_confidence_ror_is_dropped_at_apply_time():
-    """Even if the agent leaked a ROR with confidence < 0.7 past its
-    own internal floor, the stage-level `_apply_patch` re-checks."""
-    person: dict[str, Any] = {"id": "p1"}
+    """The stage-side `_apply_patch` re-checks the confidence floor
+    defensively — a low-confidence patch produces zero Memberships."""
+    reconciled = ReconciledEntities(entities={"persons": [{"id": "p1"}]})
+    person = reconciled.entities["persons"][0]
     patch = BioResolverPatch(
         pulse_ror="https://ror.org/x",
         reason="vague",
         confidence=0.5,
     )
-    assert _apply_patch(person, patch) is False
-    assert SCHEMA_AFFILIATION not in person
+    m_added, o_added = _apply_patch(
+        person=person, patch=patch,
+        **_apply_kwargs(reconciled=reconciled, existing_org_ids=set(), existing_keys=set()),
+    )
+    assert (m_added, o_added) == (0, 0)
+    assert _memberships(reconciled) == []
 
 
-def test_apply_patch_merges_with_existing_string_into_list():
-    person: dict[str, Any] = {
-        "id": "p1",
-        SCHEMA_AFFILIATION: "https://ror.org/existing",
-    }
+def test_apply_patch_adds_a_second_membership_when_person_has_one_already():
+    """An existing Membership to ROR /existing doesn't prevent a new
+    Membership to ROR /new from being created — they're distinct
+    composites."""
+    reconciled = ReconciledEntities(entities={"persons": [{"id": "p1"}]})
+    _seed_membership(reconciled, person_id="p1", ror="https://ror.org/existing")
     patch = BioResolverPatch(
         pulse_ror="https://ror.org/new",
         reason="From bio: ...",
         confidence=0.9,
     )
-    assert _apply_patch(person, patch) is True
-    assert person[SCHEMA_AFFILIATION] == [
+    m_added, o_added = _apply_patch(
+        person=reconciled.entities["persons"][0],
+        patch=patch,
+        **_apply_kwargs(
+            reconciled=reconciled,
+            existing_org_ids={"https://ror.org/existing"},
+            existing_keys={"p1__https://ror.org/existing"},
+        ),
+    )
+    assert m_added == 1
+    assert sorted(_membership_org_ids(reconciled, person_id="p1")) == [
         "https://ror.org/existing",
         "https://ror.org/new",
     ]
 
 
-def test_apply_patch_appends_to_existing_list_without_dup():
-    person: dict[str, Any] = {
-        "id": "p1",
-        SCHEMA_AFFILIATION: ["https://ror.org/a", "https://ror.org/b"],
-    }
-    patch = BioResolverPatch(
-        pulse_ror="https://ror.org/b",
-        reason="...",
-        confidence=0.9,
-    )
-    # Already in the list → no-op.
-    assert _apply_patch(person, patch) is False
-    assert person[SCHEMA_AFFILIATION] == ["https://ror.org/a", "https://ror.org/b"]
-
-
-def test_apply_patch_no_op_on_idempotent_string_match():
-    person: dict[str, Any] = {
-        "id": "p1",
-        SCHEMA_AFFILIATION: "https://ror.org/x",
-    }
+def test_apply_patch_idempotent_when_membership_already_present():
+    reconciled = ReconciledEntities(entities={"persons": [{"id": "p1"}]})
+    _seed_membership(reconciled, person_id="p1", ror="https://ror.org/x")
     patch = BioResolverPatch(
         pulse_ror="https://ror.org/x",
         reason="...",
         confidence=0.9,
     )
-    assert _apply_patch(person, patch) is False
+    m_added, _ = _apply_patch(
+        person=reconciled.entities["persons"][0],
+        patch=patch,
+        **_apply_kwargs(
+            reconciled=reconciled,
+            existing_org_ids={"https://ror.org/x"},
+            existing_keys={"p1__https://ror.org/x"},
+        ),
+    )
+    assert m_added == 0
+    assert len(_memberships(reconciled)) == 1
 
 
 def test_apply_patch_no_op_when_patch_carries_no_ror():
-    person: dict[str, Any] = {"id": "p1"}
+    reconciled = ReconciledEntities(entities={"persons": [{"id": "p1"}]})
     patch = BioResolverPatch(reason="LLM punted", confidence=0.3)
-    assert _apply_patch(person, patch) is False
-    assert SCHEMA_AFFILIATION not in person
+    m_added, _ = _apply_patch(
+        person=reconciled.entities["persons"][0],
+        patch=patch,
+        **_apply_kwargs(reconciled=reconciled, existing_org_ids=set(), existing_keys=set()),
+    )
+    assert m_added == 0
+    assert _memberships(reconciled) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v2/test_resolve_company_to_ror.py
+++ b/tests/v2/test_resolve_company_to_ror.py
@@ -23,7 +23,6 @@ import pytest
 from src.v2.pipeline.stages.models import ReconciledEntities
 from src.v2.pipeline.stages.resolve_company_to_ror import (
     GME_INTERNAL_COMPANY,
-    SCHEMA_AFFILIATION,
     CompanyAffiliationResult,
     _accept,
     _clean_query,
@@ -31,6 +30,26 @@ from src.v2.pipeline.stages.resolve_company_to_ror import (
     _strip_country,
     run_resolve_company_to_ror_stage,
 )
+
+
+def _memberships(reconciled: ReconciledEntities) -> list[dict[str, Any]]:
+    return reconciled.entities.get("memberships") or []
+
+
+def _organizations(reconciled: ReconciledEntities) -> list[dict[str, Any]]:
+    return reconciled.entities.get("organizations") or []
+
+
+def _membership_org_ids(reconciled: ReconciledEntities, *, person_id: str) -> list[str]:
+    """Return the ROR org ids attached to ``person_id`` via Memberships."""
+    out: list[str] = []
+    for m in _memberships(reconciled):
+        composite = m.get("id", "")
+        if composite.startswith(f"{person_id}__"):
+            org_ref = m.get("org:organization")
+            if isinstance(org_ref, str):
+                out.append(org_ref)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -169,9 +188,20 @@ def test_stage_reads_company_under_every_key_shape(key):
         },
     )
     result = _run(reconciled, provider)
+    # The Person dict is left alone — no `schema:affiliation` written.
     person = reconciled.entities["persons"][0]
-    assert person[SCHEMA_AFFILIATION] == "https://ror.org/google"
+    assert "schema:affiliation" not in person
+    assert "http://schema.org/affiliation" not in person
+    # Affiliation is modelled as a Membership pointing to the resolved Org.
+    assert _membership_org_ids(reconciled, person_id="p1") == [
+        "https://ror.org/google",
+    ]
+    # The resolver also mints a minimal Organization stub for the ROR.
+    org_ids = {o["id"] for o in _organizations(reconciled)}
+    assert "https://ror.org/google" in org_ids
     assert result.persons_resolved == 1
+    assert result.memberships_created == 1
+    assert result.organizations_created == 1
     assert result.queries_accepted == 1
 
 
@@ -191,8 +221,11 @@ def test_stage_skips_low_confidence():
         },
     )
     result = _run(reconciled, provider)
-    assert SCHEMA_AFFILIATION not in reconciled.entities["persons"][0]
+    # Below-threshold hit produces zero Memberships / Orgs.
+    assert _memberships(reconciled) == []
+    assert _organizations(reconciled) == []
     assert result.persons_resolved == 0
+    assert result.memberships_created == 0
     assert any("< 0.55" in reason for reason in result.rejection_reasons)
 
 
@@ -232,17 +265,20 @@ def test_stage_resolves_joint_affiliations_into_a_list():
         },
     )
     _run(reconciled, provider)
-    affiliations = reconciled.entities["persons"][0][SCHEMA_AFFILIATION]
-    assert isinstance(affiliations, list)
-    assert sorted(affiliations) == [
+    # Joint affiliations produce one Membership per resolved org, all
+    # linked to the same person.
+    assert sorted(_membership_org_ids(reconciled, person_id="p1")) == [
         "https://ror.org/02s376052",
         "https://ror.org/05a28rw58",
     ]
+    org_ids = {o["id"] for o in _organizations(reconciled)}
+    assert "https://ror.org/02s376052" in org_ids
+    assert "https://ror.org/05a28rw58" in org_ids
 
 
 def test_stage_is_idempotent_on_re_run():
-    """Re-running on a person that already carries the affiliation
-    leaves the value unchanged."""
+    """Re-running on a person whose Membership already exists is a
+    no-op: no duplicate Memberships or Organization stubs."""
     reconciled = ReconciledEntities(
         entities={
             "persons": [
@@ -258,12 +294,16 @@ def test_stage_is_idempotent_on_re_run():
         },
     )
     _run(reconciled, provider)
-    affiliation_first = reconciled.entities["persons"][0][SCHEMA_AFFILIATION]
+    memberships_first = list(_memberships(reconciled))
+    orgs_first = list(_organizations(reconciled))
     _run(reconciled, provider)
-    affiliation_second = reconciled.entities["persons"][0][SCHEMA_AFFILIATION]
-    assert affiliation_first == affiliation_second
-    # Cache means the second run issues no new queries either.
-    assert provider.queries == ["Google", "Google"]  # one per run, cached within run
+    memberships_second = list(_memberships(reconciled))
+    orgs_second = list(_organizations(reconciled))
+    # Same composite id ⇒ no second Membership; same ROR ⇒ no second Org.
+    assert [m["id"] for m in memberships_second] == [m["id"] for m in memberships_first]
+    assert [o["id"] for o in orgs_second] == [o["id"] for o in orgs_first]
+    assert len(memberships_second) == 1
+    assert len(orgs_second) == 1
 
 
 def test_stage_returns_zero_when_provider_missing():


### PR DESCRIPTION
…ma:affiliation)

Supersedes the in-flight `fix/affiliation-key-mismatch` PR. The schema:affiliation approach worked but violated the project principle that anything outside the Open Pulse ontology should live in the `gme-internal:` namespace. `schema:affiliation` is a schema.org property the v2 ontology deliberately doesn't model on Person — affiliation-with-evidence is `org:Membership`.

This commit fixes the original "0 affiliation triples land in the SPARQL store" bug by aligning with the ontology instead of around it:

  - Resolver stages stop writing to `person[SCHEMA_AFFILIATION]` (the full-IRI key that rdflib was silently dropping anyway).
  - Each accepted ROR hit now produces a proper `org:Membership` entity (id = `{personId}__{rorURL}`, org:organization = ROR URL, role / dates = null) pushed to `reconciled.entities['memberships']`, plus a minimal `org:Organization` stub (id = ROR URL, schema:name from ROR's display name, idSource = pulse:ror) pushed to `reconciled.entities['organizations']` when not already present.
  - Idempotent across re-runs: existing org IDs and membership composites are pre-computed once per invocation and used as a de-dup set.
  - Provenance via `_source = "resolve_company_to_ror" | "resolve_bio_to_ror" | "resolve_bio_to_ror_llm"`, stripped at output by `_drop_internal_keys` unless `include_internal_fields`.

Cross-stage skip-already-affiliated honours the new shape: the bio / bio-LLM stages now check `reconciled.entities['memberships']` instead of `person[SCHEMA_AFFILIATION]`. Pre-computed once per run.

Audit of similar key-mismatch risks elsewhere in the code: clean. `SCHEMA_AFFILIATION` was the only place writing a full-IRI key into a dict subsequently emitted as JSON-LD. Every other `person['…'] = …` site uses prefixed short forms or non-IRI keys.

Verified end-to-end on github.com/caviri (`_company = '@SwissDataScienceCenter'`):

  Membership:   urn:pulse:caviri__https://ror.org/02hdt9m26
                org:organization → https://ror.org/02hdt9m26
  Organization: https://ror.org/02hdt9m26
                schema:name "Swiss Data Science Center"
                idSource pulse:ror

rdflib parse yields the expected IRI-node triple chain. No schema or @context changes — every entity matches an existing ontology shape.

Tests: existing resolver test files refactored to assert on `reconciled.entities['memberships']` and `['organizations']` instead of `person['schema:affiliation']`. 106/106 resolver tests green; full v2 regression: 938 passed / 1 skipped.