### PR TITLE
fix(resolver stages): schema:affiliation key must use short form for …

### DIFF
--- a/dev/ontology-v2-json-response/a-001/json-schema/agent/pulse_PersonShape.schema.json
+++ b/dev/ontology-v2-json-response/a-001/json-schema/agent/pulse_PersonShape.schema.json
@@ -58,6 +58,13 @@
       "type": ["string", "null"],
       "description": "Profile URL. Example: 'https://people.epfl.ch/carlos.vivar'"
     },
+    "schema:affiliation": {
+      "oneOf": [
+        {"type": "string"},
+        {"type": "array", "items": {"type": "string"}}
+      ],
+      "description": "ROR identifier(s) of the institution(s) the person is affiliated with. Written as a single URL string when one match, or a list when multiple. Stamped by the resolve_company_to_ror / resolve_bio_to_ror / resolve_bio_to_ror_llm stages — agents should NOT emit this directly (use org:hasMembership when evidence is available). Example: 'https://ror.org/02s376052' or ['https://ror.org/02s376052', 'https://ror.org/05a28rw58']."
+    },
     "pulse:githubUsername": {
       "type": ["string", "null"],
       "description": "GitHub username. Example: 'caviri'"

--- a/dev/ontology-v2-json-response/a-001/json-schema/strict/pulse_PersonShape.schema.json
+++ b/dev/ontology-v2-json-response/a-001/json-schema/strict/pulse_PersonShape.schema.json
@@ -57,6 +57,12 @@
       "type": ["string", "null"],
       "format": "uri"
     },
+    "schema:affiliation": {
+      "oneOf": [
+        {"type": "string", "format": "uri"},
+        {"type": "array", "items": {"type": "string", "format": "uri"}}
+      ]
+    },
     "pulse:githubUsername": {
       "type": ["string", "null"]
     },

--- a/src/v2/pipeline/stages/resolve_company_to_ror.py
+++ b/src/v2/pipeline/stages/resolve_company_to_ror.py
@@ -83,7 +83,17 @@ NON_ORG_KEYS: frozenset[str] = frozenset({
 })
 
 # Schema IRIs (kept inline to avoid a pipeline-wide constants module).
-SCHEMA_AFFILIATION = "http://schema.org/affiliation"
+# Use the JSON-LD short form so the key matches the prefixed shape the
+# rest of the Person dict uses (`schema:name`, `schema:url`, …) AND
+# the @context's `schema:` prefix mapping. Writing the full IRI here
+# put the key outside every @context term mapping, so rdflib silently
+# dropped it on `Graph().parse(..., format="json-ld")` and zero
+# `schema:affiliation` triples landed in the SPARQL store despite the
+# stage logs reporting `persons_resolved>0`. The matching @context
+# entry in `src/v2/schema/json/context/v2.0.jsonld` declares
+# `@type: @id` + `@container: @set` so the ROR string value expands to
+# an IRI node rather than a literal.
+SCHEMA_AFFILIATION = "schema:affiliation"
 # The Person dict carries the company under different keys depending on
 # where in the pipeline we run. In-pipeline (between reconciliation and
 # the LLM critic) it's the rule-based agent's `_company`. The

--- a/src/v2/schema/json/agent/person.schema.json
+++ b/src/v2/schema/json/agent/person.schema.json
@@ -61,6 +61,13 @@
       "type": ["string", "null"],
       "description": "Profile URL for personal webpage. Example: 'https://caviri.github.io'"
     },
+    "schema:affiliation": {
+      "oneOf": [
+        {"type": "string"},
+        {"type": "array", "items": {"type": "string"}}
+      ],
+      "description": "ROR identifier(s) of the institution(s) the person is affiliated with. Written as a single URL string when one match, or a list when multiple. Stamped by the resolve_company_to_ror / resolve_bio_to_ror / resolve_bio_to_ror_llm stages — agents should NOT emit this directly (use org:hasMembership when evidence is available). Example: 'https://ror.org/02s376052' or ['https://ror.org/02s376052', 'https://ror.org/05a28rw58']."
+    },
     "pulse:githubUsername": {
       "type": ["string", "null"],
       "description": "GitHub username. Example: 'caviri'"

--- a/src/v2/schema/json/context/v2.0.jsonld
+++ b/src/v2/schema/json/context/v2.0.jsonld
@@ -30,6 +30,10 @@
     "schema:citation": {
       "@type": "@id"
     },
+    "schema:affiliation": {
+      "@type": "@id",
+      "@container": "@set"
+    },
     "org:organization": {
       "@type": "@id"
     },

--- a/src/v2/schema/json/strict/person.schema.json
+++ b/src/v2/schema/json/strict/person.schema.json
@@ -57,6 +57,12 @@
       "type": ["string", "null"],
       "format": "uri"
     },
+    "schema:affiliation": {
+      "oneOf": [
+        {"type": "string", "format": "uri"},
+        {"type": "array", "items": {"type": "string", "format": "uri"}}
+      ]
+    },
     "pulse:githubUsername": {
       "type": ["string", "null"]
     },

--- a/tests/v2/test_jsonld_build.py
+++ b/tests/v2/test_jsonld_build.py
@@ -209,3 +209,63 @@ def test_internal_fields_renamed_to_gme_internal_terms_when_flag_on() -> None:
         URIRef("https://openpulse.science/git-metadata-extractor#homepage"),
         Literal("https://example.org"),
     ) in graph
+
+
+def test_schema_affiliation_round_trips_to_rdf_as_iri_node() -> None:
+    """Regression for the bug where the bio-resolver stages wrote the
+    full IRI `http://schema.org/affiliation` as a JSON key, putting it
+    outside every @context term mapping so rdflib silently dropped it
+    on `Graph().parse(..., format='json-ld')`. After fixing the stages
+    to emit the prefixed short form `schema:affiliation` AND adding
+    the matching @context entry with `@type: @id`, the JSON-LD
+    round-trips to a real IRI-node triple in the RDF graph.
+    """
+    assembled = AssembledOutput(
+        root_entity={
+            "id": "owner/repo",
+            "type": "schema:SoftwareSourceCode",
+            "schema:name": "owner/repo",
+        },
+        related_entities=[
+            {
+                "id": "alice",
+                "type": "schema:Person",
+                "schema:name": "Alice",
+                "schema:affiliation": "https://ror.org/02s376052",
+            },
+            {
+                "id": "bob",
+                "type": "schema:Person",
+                "schema:name": "Bob",
+                "schema:affiliation": [
+                    "https://ror.org/02s376052",
+                    "https://ror.org/05a28rw58",
+                ],
+            },
+        ],
+    )
+    payload = build_jsonld_output(
+        assembled=assembled,
+        jsonld_context=_context(),
+    )
+
+    graph = Graph()
+    graph.parse(data=json.dumps(payload), format="json-ld")
+
+    schema_affiliation = URIRef("http://schema.org/affiliation")
+    alice = URIRef(f"{ENTITY_URI_PREFIX}alice")
+    bob = URIRef(f"{ENTITY_URI_PREFIX}bob")
+
+    # Single-value: one IRI-node triple, NOT a literal string.
+    alice_objects = list(graph.objects(alice, schema_affiliation))
+    assert alice_objects == [URIRef("https://ror.org/02s376052")]
+    assert not any(isinstance(o, Literal) for o in alice_objects)
+
+    # Multi-value: two distinct IRI-node triples (no RDF list, since
+    # the @context declares `@container: @set`).
+    bob_objects = set(graph.objects(bob, schema_affiliation))
+    assert bob_objects == {
+        URIRef("https://ror.org/02s376052"),
+        URIRef("https://ror.org/05a28rw58"),
+    }
+    assert not any(isinstance(o, Literal) for o in bob_objects)

--- a/tests/v2/test_ttl_schema_alignment.py
+++ b/tests/v2/test_ttl_schema_alignment.py
@@ -43,6 +43,18 @@ ENUM_CLASSES = {
 
 ENVELOPE_FIELDS = {"id", "type", "shacl", "identifiers", "idSource"}
 
+# Properties that intentionally exist in the strict JSON schema but
+# are NOT modelled in the SHACL ontology. The pipeline emits these at
+# runtime in cases where the ontology's preferred shape can't be
+# materialised (e.g. `schema:affiliation` on Person when there's no
+# Membership evidence to back a first-class `pulse:Membership`).
+# Listing them here documents the divergence and lets the
+# `test_json_schema_properties_exist_in_ttl_shape` alignment check
+# stay strict for everything else.
+ONTOLOGY_DIVERGENT_FIELDS: dict[str, set[str]] = {
+    "PersonShape": {"schema:affiliation"},
+}
+
 PREFIX_MAP = {
     str(SCHEMA): "schema:",
     str(ORG): "org:",
@@ -132,7 +144,11 @@ def test_ttl_shape_properties_exist_in_json_schema(shape_name: str) -> None:
 @pytest.mark.parametrize("shape_name", SHAPE_SCHEMA_MAP)
 def test_json_schema_properties_exist_in_ttl_shape(shape_name: str) -> None:
     ttl_properties = set(_shape_properties()[shape_name])
-    schema_properties = set(_load_schemas()[shape_name]["properties"]) - ENVELOPE_FIELDS
+    schema_properties = (
+        set(_load_schemas()[shape_name]["properties"])
+        - ENVELOPE_FIELDS
+        - ONTOLOGY_DIVERGENT_FIELDS.get(shape_name, set())
+    )
     assert schema_properties <= ttl_properties
 
 


### PR DESCRIPTION
…RDF round-trip

The resolver stages (resolve_company_to_ror, resolve_bio_to_ror, resolve_bio_to_ror_llm) all share a single SCHEMA_AFFILIATION constant that was set to the full IRI `http://schema.org/affiliation`. That key shape is outside every @context term mapping (the context has no @vocab fallback), so rdflib silently DROPPED the key on `Graph().parse( ..., format="json-ld")` and zero `schema:affiliation` triples landed in the SPARQL store even though stage logs reported persons_resolved
> 0. Strict validation flagged it too: `Additional properties are not
allowed ('http://schema.org/affiliation' was unexpected)`.

This commit applies a three-part fix so the affiliation flows end-to-end from stage → JSON-LD → SPARQL:

  1. Stage constant changed to the JSON-LD short form `schema:affiliation` — matches the prefixed shape every other Person field uses (`schema:name`, `schema:url`, ...) and the @context's `schema:` prefix.

  2. @context entry added in src/v2/schema/json/context/v2.0.jsonld:

        "schema:affiliation": { "@type": "@id", "@container": "@set" }

     Without `@type: @id` the ROR URL value would land as an RDF literal; with it, it expands to an IRI node, which is what downstream SPARQL queries need. `@container: @set` normalises single-string and list-of-strings stage output to the same multi-triple shape.

  3. `schema:affiliation` added to the Person JSON schemas (agent + strict, plus the byte-identical `dev/.../pulse_PersonShape.schema.json` mirrors). Silences the additionalProperties warning that fired once per resolved person.

The ontology TTL deliberately does NOT model `schema:affiliation` on Person — affiliation-with-evidence is `Membership`. The bare `schema:affiliation` triple is the schema.org standard we emit only when the resolver stages have no evidence to support a first-class Membership. To preserve that intentional divergence, `test_ttl_schema_alignment.py` gains an `ONTOLOGY_DIVERGENT_FIELDS` allowlist; the alignment check stays strict for every other property.

Verified end-to-end against github.com/caviri:

  Stage:  `@SwissDataScienceCenter` → resolved → `schema:affiliation
          = https://ror.org/02hdt9m26` (Swiss Data Science Center)
  JSON:   "schema:affiliation": {"@id": "https://ror.org/02hdt9m26"}
  SPARQL: <urn:pulse:caviri> <http://schema.org/affiliation>
           <https://ror.org/02hdt9m26>  (IRI-node, not a literal)

New regression test `test_schema_affiliation_round_trips_to_rdf_as_iri_node` locks the contract: single-value AND list-value affiliations both produce IRI-node triples after JSON-LD parsing.

940 passed / 1 skipped on the full v2 regression.