### PR TITLE
feat(v2 pipeline): resolve_placeholder_orgs_to_ror — rewrite urn:puls…

### DIFF
--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -131,6 +131,7 @@ from src.v2.pipeline.stages import (
     run_resolve_bio_to_ror_llm_stage,
     run_resolve_bio_to_ror_stage,
     run_resolve_company_to_ror_stage,
+    run_resolve_placeholder_orgs_to_ror_stage,
     validate_articles,
     validate_author_classes,
     validate_ownership,
@@ -203,6 +204,7 @@ STAGE_REFINE_WITH_LLM = "refine_with_llm"
 STAGE_RESOLVE_COMPANY_TO_ROR = "resolve_company_to_ror"
 STAGE_RESOLVE_BIO_TO_ROR = "resolve_bio_to_ror"
 STAGE_RESOLVE_BIO_TO_ROR_LLM = "resolve_bio_to_ror_llm"
+STAGE_RESOLVE_PLACEHOLDER_ORGS_TO_ROR = "resolve_placeholder_orgs_to_ror"
 
 v2_router = APIRouter(prefix="/v2")
 
@@ -294,6 +296,22 @@ def _resolve_bio_to_ror_llm_enabled() -> bool:
     true.
     """
     raw = os.getenv("V2_RESOLVE_BIO_TO_ROR_LLM")
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "f", "no", "n", "off"}
+
+
+def _resolve_placeholder_orgs_to_ror_enabled() -> bool:
+    """Read `V2_RESOLVE_PLACEHOLDER_ORGS_TO_ROR` env var (default true).
+
+    When true (the default), the placeholder-resolver stage runs after
+    the three Person-side resolver stages and rewrites Organization
+    entities whose `idSource = "uuid"` (and which carry a `schema:name`
+    breadcrumb) into ROR-anchored Orgs, patching every referring
+    Membership composite in the same pass. Set to `false` to leave the
+    `urn:pulse:<uuid>` Org bucket untouched.
+    """
+    raw = os.getenv("V2_RESOLVE_PLACEHOLDER_ORGS_TO_ROR")
     if raw is None:
         return True
     return raw.strip().lower() not in {"0", "false", "f", "no", "n", "off"}
@@ -919,6 +937,42 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
             _append_unique_warning(
                 warnings,
                 f"resolve_bio_to_ror_llm stage failed: {exc}",
+            )
+
+    # === resolve_placeholder_orgs_to_ror stage ====================
+    # Late pass that re-queries the ROR RAG against the `schema:name`
+    # of every `idSource == "uuid"` Organization (the breadcrumb
+    # carried by rescue / fallback paths that minted a placeholder
+    # Org without a registry id). Rewrites successful hits in place
+    # and patches every referring Membership composite. Runs after
+    # the three Person-side resolvers because it's strictly weaker —
+    # those stages have richer signal (`_company`, `_bio`, etc.) and
+    # should win first.
+    if _resolve_placeholder_orgs_to_ror_enabled():
+        stage_started_at = perf_counter()
+        try:
+            placeholder_result = await run_resolve_placeholder_orgs_to_ror_stage(
+                reconciled=reconciled,
+                provider=getattr(providers, "ror_rag", None),
+            )
+            logger.info(
+                "%s: examined=%d resolved=%d memberships_rewritten=%d "
+                "queries=%d accepted=%d in %.2fs",
+                STAGE_RESOLVE_PLACEHOLDER_ORGS_TO_ROR,
+                placeholder_result.placeholders_examined,
+                placeholder_result.placeholders_resolved,
+                placeholder_result.memberships_rewritten,
+                placeholder_result.queries_attempted,
+                placeholder_result.queries_accepted,
+                perf_counter() - stage_started_at,
+            )
+        except Exception as exc:  # noqa: BLE001 — never fail the run on this stage
+            logger.exception(
+                "%s stage failed", STAGE_RESOLVE_PLACEHOLDER_ORGS_TO_ROR,
+            )
+            _append_unique_warning(
+                warnings,
+                f"resolve_placeholder_orgs_to_ror stage failed: {exc}",
             )
 
     apply_critic_pruning = _should_apply_critic_pruning()

--- a/src/v2/pipeline/stages/__init__.py
+++ b/src/v2/pipeline/stages/__init__.py
@@ -71,6 +71,10 @@ from src.v2.pipeline.stages.resolve_company_to_ror import (
     CompanyAffiliationResult,
     run_resolve_company_to_ror_stage,
 )
+from src.v2.pipeline.stages.resolve_placeholder_orgs_to_ror import (
+    PlaceholderResolutionResult,
+    run_resolve_placeholder_orgs_to_ror_stage,
+)
 from src.v2.pipeline.stages.refine_with_llm import (
     is_enabled as hybrid_refiner_is_enabled,
 )
@@ -90,6 +94,7 @@ __all__ = [
     "LLMCriticStageResult",
     "LLMDedupStageResult",
     "LinkVeracityStageResult",
+    "PlaceholderResolutionResult",
     "ReconciledEntities",
     "RefineWithLLMResult",
     "RootEntityValidationError",
@@ -122,6 +127,7 @@ __all__ = [
     "run_resolve_bio_to_ror_llm_stage",
     "run_resolve_bio_to_ror_stage",
     "run_resolve_company_to_ror_stage",
+    "run_resolve_placeholder_orgs_to_ror_stage",
     "tag_rule_based_disciplines",
     "validate_articles",
     "validate_author_classes",

--- a/src/v2/pipeline/stages/resolve_placeholder_orgs_to_ror.py
+++ b/src/v2/pipeline/stages/resolve_placeholder_orgs_to_ror.py
@@ -1,0 +1,260 @@
+"""Stage: late re-resolution pass for UUID-placeholder Organizations.
+
+The earlier resolver stages (8b/c/d) turn Person-side affiliation
+strings (`_company`, `_bio`, `_orcid_biography`, `_blog`, `_email`)
+into proper `org:Membership` + `org:Organization` entities pointing at
+ROR ids. But Memberships also enter the graph from a *different* path:
+the rule-based / LLM organization agents themselves, the LLM
+membership agent, and the refine_with_llm rescue refiners. When an
+agent sees an affiliation string but can't anchor it to a ROR /
+Infoscience / GitHub id at extraction time, it emits an Organization
+entity with `idSource = "uuid"` — the JSON-LD layer prefixes that
+UUID with `urn:pulse:` at output time, producing the
+`urn:pulse:<uuid>` placeholder bucket the operator sees in the SPARQL
+store.
+
+These placeholders carry the **original affiliation string** as
+`schema:name`. That's the breadcrumb this stage uses: re-query the ROR
+RAG against `schema:name`, and when a hit clears the same strict
+acceptance gate the company/bio stages use, rewrite the Organization
+in place AND patch every Membership that refers to its old UUID id.
+
+What we DON'T do here:
+
+  - Drop the placeholder. If the ROR lookup fails, the Organization
+    stays as-is with `idSource = "uuid"` — downstream may want it for
+    SPARQL queries that look at affiliation strings even when no ROR
+    is known.
+  - Cascade resolutions. Resolving X to ROR_X doesn't unblock any
+    other placeholder, so we run a single pass; no while-loop needed.
+  - Touch Organizations the resolver stages already minted with
+    `idSource = "pulse:ror"`. Those are already canonical.
+
+Idempotent across re-runs: an Org that gets rewritten this pass has
+`idSource = "pulse:ror"` next pass and is no longer in the candidate
+set. An Org that fails to resolve this pass is still a candidate next
+pass (in case ROR has added the org between extracts).
+
+Provenance: rewritten Orgs and patched Memberships get
+``_source = "resolve_placeholder_orgs_to_ror"`` (stripped at output
+unless ``include_internal_fields=true``).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from src.v2.ingest.providers.ror_rag import RorRagProvider, build_default_provider
+from src.v2.pipeline.stages.resolve_company_to_ror import (
+    _resolve_one,
+    _strip_country,
+)
+
+if TYPE_CHECKING:
+    from src.v2.pipeline.stages.reconciliation import ReconciledEntities
+
+logger = logging.getLogger(__name__)
+
+STAGE_SOURCE_TAG = "resolve_placeholder_orgs_to_ror"
+
+
+@dataclass(slots=True)
+class PlaceholderResolutionResult:
+    """Summary of one stage run."""
+
+    placeholders_examined: int
+    placeholders_resolved: int
+    memberships_rewritten: int
+    queries_attempted: int
+    queries_accepted: int
+    rejection_reasons: dict[str, int] = field(default_factory=dict)
+
+
+def _placeholder_orgs(reconciled: "ReconciledEntities") -> list[dict[str, Any]]:
+    """Return the Organization entities that are UUID-anchored and
+    carry a non-empty ``schema:name`` we can re-query against."""
+    out: list[dict[str, Any]] = []
+    for org in reconciled.entities.get("organizations") or []:
+        if not isinstance(org, dict):
+            continue
+        if org.get("idSource") != "uuid":
+            continue
+        name = org.get("schema:name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        out.append(org)
+    return out
+
+
+def _rewrite_org_in_place(
+    org: dict[str, Any], *, ror_id: str, ror_name: str | None,
+) -> str:
+    """Mutate ``org`` to point at the canonical ROR record. Returns
+    the OLD id so the caller can patch Memberships that reference it.
+    """
+    old_id = str(org.get("id") or org.get("@id") or "")
+    org["id"] = ror_id
+    if "@id" in org:
+        org["@id"] = ror_id
+    org["idSource"] = "pulse:ror"
+    identifiers = org.get("identifiers")
+    if not isinstance(identifiers, dict):
+        identifiers = {}
+    identifiers["pulse:ror"] = ror_id
+    # Drop the dangling uuid identifier — it's no longer the canonical
+    # id, and leaving it can confuse downstream consumers that look for
+    # `identifiers.uuid` as a fallback dedupe key.
+    identifiers.pop("uuid", None)
+    org["identifiers"] = identifiers
+    # Prefer the canonical ROR display name when we have it; keep the
+    # original placeholder string under `gme-internal:original_name`
+    # so the breadcrumb is recoverable with `?include_internal_fields=true`.
+    if ror_name:
+        original = org.get("schema:name")
+        if isinstance(original, str) and original.strip() and original != ror_name:
+            org["_original_name"] = original
+        org["schema:name"] = ror_name
+    org["_source"] = STAGE_SOURCE_TAG
+    return old_id
+
+
+def _rewrite_memberships(
+    memberships: list[dict[str, Any]],
+    *,
+    rewrites: dict[str, str],
+) -> int:
+    """For every Membership whose `org:organization` is in ``rewrites``,
+    swap the reference and rebuild the composite id. Returns the count
+    of memberships that changed.
+
+    Idempotent: a second pass on the same `rewrites` map is a no-op
+    because every match in the first pass already points at the
+    canonical id, which isn't a key in `rewrites`.
+    """
+    if not rewrites:
+        return 0
+    n = 0
+    for m in memberships:
+        if not isinstance(m, dict):
+            continue
+        org_ref = m.get("org:organization")
+        if not isinstance(org_ref, str) or org_ref not in rewrites:
+            continue
+        new_org = rewrites[org_ref]
+        m["org:organization"] = new_org
+        # Composite id: `personId__orgId` — rebuild the org half. The
+        # split-on-first-`__` is safe because canonical Person IDs
+        # don't contain `__`.
+        old_composite = m.get("id")
+        if isinstance(old_composite, str) and "__" in old_composite:
+            person_part, _, _ = old_composite.partition("__")
+            new_composite = f"{person_part}__{new_org}"
+            m["id"] = new_composite
+            identifiers = m.get("identifiers")
+            if isinstance(identifiers, dict):
+                identifiers["pulse:composite"] = new_composite
+        m["_source"] = STAGE_SOURCE_TAG
+        n += 1
+    return n
+
+
+async def run_resolve_placeholder_orgs_to_ror_stage(
+    *,
+    reconciled: "ReconciledEntities",
+    provider: RorRagProvider | None = None,
+) -> PlaceholderResolutionResult:
+    """Stage entry. Walks placeholder Orgs (idSource=uuid + schema:name
+    present), queries ROR, rewrites successful hits + their referring
+    Memberships in place. Idempotent across re-runs."""
+    provider = provider or build_default_provider()
+    if provider is None:
+        logger.warning(
+            "resolve_placeholder_orgs_to_ror: RorRagProvider unavailable "
+            "(check V2_ROR_RAG_ENABLED + INDEX_QDRANT_URL); stage skipped",
+        )
+        return PlaceholderResolutionResult(
+            placeholders_examined=0,
+            placeholders_resolved=0,
+            memberships_rewritten=0,
+            queries_attempted=0,
+            queries_accepted=0,
+            rejection_reasons={"provider_unavailable": 1},
+        )
+
+    placeholders = _placeholder_orgs(reconciled)
+    if not placeholders:
+        return PlaceholderResolutionResult(
+            placeholders_examined=0,
+            placeholders_resolved=0,
+            memberships_rewritten=0,
+            queries_attempted=0,
+            queries_accepted=0,
+        )
+
+    cache: dict[str, Any] = {}
+    reasons: dict[str, int] = {}
+    # Old uuid-id → new ROR id, accumulated across all placeholders so
+    # we can rewrite Memberships in one pass at the end.
+    rewrites: dict[str, str] = {}
+    resolved = 0
+
+    for org in placeholders:
+        raw_name = str(org.get("schema:name") or "")
+        hit, reason = await _resolve_one(provider, cache, raw_name)
+        if hit is None:
+            reasons[reason] = reasons.get(reason, 0) + 1
+            continue
+        ror_id = hit.get("ror_id")
+        if not isinstance(ror_id, str) or not ror_id:
+            continue
+        ror_display = _strip_country(str(hit.get("name") or "")) or None
+        old_id = _rewrite_org_in_place(org, ror_id=ror_id, ror_name=ror_display)
+        if old_id and old_id != ror_id:
+            rewrites[old_id] = ror_id
+        resolved += 1
+
+    memberships = reconciled.entities.get("memberships") or []
+    memberships_rewritten = _rewrite_memberships(memberships, rewrites=rewrites)
+
+    result = PlaceholderResolutionResult(
+        placeholders_examined=len(placeholders),
+        placeholders_resolved=resolved,
+        memberships_rewritten=memberships_rewritten,
+        queries_attempted=len(cache),
+        queries_accepted=sum(1 for v in cache.values() if v is not None),
+        rejection_reasons=reasons,
+    )
+    logger.info(
+        "resolve_placeholder_orgs_to_ror: examined=%d resolved=%d "
+        "memberships_rewritten=%d queries=%d accepted=%d",
+        result.placeholders_examined,
+        result.placeholders_resolved,
+        result.memberships_rewritten,
+        result.queries_attempted,
+        result.queries_accepted,
+    )
+    return result
+
+
+# Synchronous facade for offline callers (matches the convention of
+# the other resolver stages).
+def run_resolve_placeholder_orgs_to_ror_stage_sync(
+    *,
+    reconciled: "ReconciledEntities",
+    provider: RorRagProvider | None = None,
+) -> PlaceholderResolutionResult:
+    return asyncio.run(
+        run_resolve_placeholder_orgs_to_ror_stage(
+            reconciled=reconciled, provider=provider,
+        ),
+    )
+
+
+__all__ = [
+    "PlaceholderResolutionResult",
+    "STAGE_SOURCE_TAG",
+    "run_resolve_placeholder_orgs_to_ror_stage",
+    "run_resolve_placeholder_orgs_to_ror_stage_sync",
+]

--- a/tests/v2/test_resolve_placeholder_orgs_to_ror.py
+++ b/tests/v2/test_resolve_placeholder_orgs_to_ror.py
@@ -1,0 +1,385 @@
+"""Tests for `resolve_placeholder_orgs_to_ror` — the late pass that
+rewrites `idSource=uuid` Organization placeholders into ROR-anchored
+Orgs and patches their referring Memberships.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.v2.pipeline.stages.models import ReconciledEntities
+from src.v2.pipeline.stages.resolve_placeholder_orgs_to_ror import (
+    STAGE_SOURCE_TAG,
+    PlaceholderResolutionResult,
+    run_resolve_placeholder_orgs_to_ror_stage,
+)
+
+
+class _StubProvider:
+    """Cleaned query → list of ROR hit dicts. Mirrors the company-stage
+    test stub so we exercise the same `_resolve_one` code path."""
+
+    def __init__(self, hits: dict[str, list[dict[str, Any]]]) -> None:
+        self._hits = hits
+        self.queries: list[str] = []
+
+    async def search(
+        self,
+        *,
+        query: str,
+        scope_mode: str = "worldwide",
+        top_k: int = 5,
+        rerank: bool = False,
+    ) -> list[dict[str, Any]]:
+        self.queries.append(query)
+        return list(self._hits.get(query, []))
+
+
+def _placeholder_org(uuid: str, name: str) -> dict[str, Any]:
+    """Build a placeholder Org as the rescue / fallback paths would
+    leave it — `idSource = "uuid"`, name is the original affiliation
+    string carried as a breadcrumb."""
+    return {
+        "id": uuid,
+        "type": "org:Organization",
+        "shacl": "pulse:OrganizationShape",
+        "identifiers": {"pulse:ror": None, "uuid": uuid},
+        "idSource": "uuid",
+        "schema:name": name,
+    }
+
+
+def _membership(person_id: str, org_id: str) -> dict[str, Any]:
+    composite = f"{person_id}__{org_id}"
+    return {
+        "id": composite,
+        "type": "org:Membership",
+        "shacl": "pulse:MembershipShape",
+        "identifiers": {"pulse:composite": composite, "uuid": "fixed-uuid"},
+        "idSource": "pulse:composite",
+        "org:organization": org_id,
+        "org:role": None,
+        "time:hasBeginning": None,
+        "time:hasEnd": None,
+    }
+
+
+def _run(reconciled: ReconciledEntities, provider: Any) -> PlaceholderResolutionResult:
+    return asyncio.run(
+        run_resolve_placeholder_orgs_to_ror_stage(
+            reconciled=reconciled, provider=provider,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_placeholder_with_resolvable_name_gets_rewritten_to_ror():
+    """A `idSource=uuid` Org with `schema:name='EPFL'` resolves to the
+    EPFL ROR, the Org is rewritten in place, and the Membership that
+    referenced its uuid gets its `org:organization` + composite id
+    patched."""
+    placeholder = _placeholder_org("abc-uuid", "EPFL")
+    membership = _membership("alice", "abc-uuid")
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [{"id": "alice", "schema:name": "Alice"}],
+            "organizations": [placeholder],
+            "memberships": [membership],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "EPFL": [
+                {"score": 0.95, "types": ["education"], "name": "EPFL", "ror_id": "https://ror.org/02s376052"},
+                {"score": 0.40, "types": ["education"], "name": "Other"},
+            ],
+        },
+    )
+
+    result = _run(reconciled, provider)
+
+    org = reconciled.entities["organizations"][0]
+    assert org["id"] == "https://ror.org/02s376052"
+    assert org["idSource"] == "pulse:ror"
+    assert org["identifiers"]["pulse:ror"] == "https://ror.org/02s376052"
+    # uuid identifier dropped — no longer canonical.
+    assert "uuid" not in org["identifiers"]
+    assert org["_source"] == STAGE_SOURCE_TAG
+    # schema:name canonicalized to ROR display name; original kept under _original_name.
+    assert org["schema:name"] == "EPFL"
+
+    m = reconciled.entities["memberships"][0]
+    assert m["id"] == "alice__https://ror.org/02s376052"
+    assert m["org:organization"] == "https://ror.org/02s376052"
+    assert m["identifiers"]["pulse:composite"] == "alice__https://ror.org/02s376052"
+    assert m["_source"] == STAGE_SOURCE_TAG
+
+    assert result.placeholders_examined == 1
+    assert result.placeholders_resolved == 1
+    assert result.memberships_rewritten == 1
+
+
+def test_canonical_ror_name_replaces_placeholder_and_keeps_original_breadcrumb():
+    """If ROR's display name differs from the placeholder breadcrumb,
+    the canonical name wins and the original is preserved under
+    `_original_name` so the breadcrumb is recoverable with
+    `include_internal_fields=true`."""
+    placeholder = _placeholder_org("u1", "swiss data science center")
+    reconciled = ReconciledEntities(
+        entities={"organizations": [placeholder], "memberships": []},
+    )
+    provider = _StubProvider(
+        hits={
+            "swiss data science center": [
+                {"score": 0.95, "types": ["facility"], "name": "Swiss Data Science Center", "ror_id": "https://ror.org/02hdt9m26"},
+            ],
+        },
+    )
+
+    _run(reconciled, provider)
+
+    org = reconciled.entities["organizations"][0]
+    assert org["schema:name"] == "Swiss Data Science Center"
+    assert org["_original_name"] == "swiss data science center"
+
+
+# ---------------------------------------------------------------------------
+# Negative paths
+# ---------------------------------------------------------------------------
+
+
+def test_placeholder_with_unresolvable_name_is_left_unchanged():
+    placeholder = _placeholder_org("u1", "Some Vague String")
+    membership = _membership("alice", "u1")
+    reconciled = ReconciledEntities(
+        entities={"organizations": [placeholder], "memberships": [membership]},
+    )
+    # No ROR hit → top hit score 0.4 (below the 0.55 floor).
+    provider = _StubProvider(
+        hits={
+            "Some Vague String": [
+                {"score": 0.40, "types": ["company"], "name": "Other"},
+            ],
+        },
+    )
+
+    result = _run(reconciled, provider)
+
+    org = reconciled.entities["organizations"][0]
+    assert org["id"] == "u1"
+    assert org["idSource"] == "uuid"
+    assert "_source" not in org
+    # Membership untouched.
+    m = reconciled.entities["memberships"][0]
+    assert m["id"] == "alice__u1"
+    assert m["org:organization"] == "u1"
+    assert "_source" not in m
+
+    assert result.placeholders_resolved == 0
+    assert result.memberships_rewritten == 0
+    # Rejection reason recorded so an operator can see why.
+    assert result.rejection_reasons
+
+
+def test_org_with_idsource_pulse_ror_is_skipped():
+    """An Organization already anchored on ROR isn't a placeholder —
+    don't re-query it even if the ROR id happens to look unusual."""
+    anchored = {
+        "id": "https://ror.org/02s376052",
+        "type": "org:Organization",
+        "shacl": "pulse:OrganizationShape",
+        "identifiers": {"pulse:ror": "https://ror.org/02s376052", "uuid": "x"},
+        "idSource": "pulse:ror",
+        "schema:name": "EPFL",
+    }
+    reconciled = ReconciledEntities(
+        entities={"organizations": [anchored], "memberships": []},
+    )
+    provider = _StubProvider(hits={"EPFL": [{"score": 0.95, "types": ["education"], "name": "EPFL", "ror_id": "X"}]})
+
+    result = _run(reconciled, provider)
+    assert result.placeholders_examined == 0
+    # No queries issued — the org never made it into the candidate set.
+    assert provider.queries == []
+
+
+def test_placeholder_without_schema_name_is_skipped():
+    """A placeholder Org with no name carries no breadcrumb to query.
+    Stage skips it rather than emitting an empty-string query."""
+    no_name_placeholder = {
+        "id": "u1",
+        "type": "org:Organization",
+        "shacl": "pulse:OrganizationShape",
+        "identifiers": {"uuid": "u1"},
+        "idSource": "uuid",
+        # schema:name omitted on purpose.
+    }
+    reconciled = ReconciledEntities(
+        entities={"organizations": [no_name_placeholder], "memberships": []},
+    )
+    provider = _StubProvider(hits={})
+
+    result = _run(reconciled, provider)
+    assert result.placeholders_examined == 0
+    assert provider.queries == []
+
+
+# ---------------------------------------------------------------------------
+# Cross-membership patching
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_memberships_to_same_placeholder_all_get_patched():
+    """If two Persons share a Membership to the same placeholder Org,
+    both Memberships get patched in one pass."""
+    placeholder = _placeholder_org("u1", "EPFL")
+    m_alice = _membership("alice", "u1")
+    m_bob = _membership("bob", "u1")
+    reconciled = ReconciledEntities(
+        entities={
+            "persons": [{"id": "alice"}, {"id": "bob"}],
+            "organizations": [placeholder],
+            "memberships": [m_alice, m_bob],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "EPFL": [
+                {"score": 0.95, "types": ["education"], "name": "EPFL", "ror_id": "https://ror.org/02s376052"},
+                {"score": 0.40, "types": ["education"], "name": "Other"},
+            ],
+        },
+    )
+
+    result = _run(reconciled, provider)
+    assert result.memberships_rewritten == 2
+    assert all(
+        m["org:organization"] == "https://ror.org/02s376052"
+        for m in reconciled.entities["memberships"]
+    )
+
+
+def test_unrelated_memberships_are_not_touched():
+    """A Membership to an Org we didn't rewrite (because it resolved
+    to nothing) keeps its original `org:organization` value."""
+    resolvable = _placeholder_org("u1", "EPFL")
+    unresolvable = _placeholder_org("u2", "Local Studio")
+    m_keep = _membership("alice", "u2")  # to the unresolvable Org
+    m_rewrite = _membership("bob", "u1")  # to the resolvable Org
+    reconciled = ReconciledEntities(
+        entities={
+            "organizations": [resolvable, unresolvable],
+            "memberships": [m_keep, m_rewrite],
+        },
+    )
+    provider = _StubProvider(
+        hits={
+            "EPFL": [
+                {"score": 0.95, "types": ["education"], "name": "EPFL", "ror_id": "https://ror.org/02s376052"},
+                {"score": 0.40, "types": ["education"], "name": "Other"},
+            ],
+            # No accepted hit for "Local Studio".
+            "Local Studio": [{"score": 0.30, "types": ["company"], "name": "Local"}],
+        },
+    )
+
+    result = _run(reconciled, provider)
+    # Only one membership rewritten.
+    assert result.memberships_rewritten == 1
+    by_id = {m["id"]: m for m in reconciled.entities["memberships"]}
+    assert "alice__u2" in by_id  # untouched (placeholder)
+    assert "bob__https://ror.org/02s376052" in by_id  # rewritten
+
+
+# ---------------------------------------------------------------------------
+# Idempotency + edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_stage_is_idempotent_on_re_run():
+    """Re-running on a graph the stage already processed is a no-op:
+    Orgs now have idSource=pulse:ror so they're not candidates."""
+    placeholder = _placeholder_org("u1", "EPFL")
+    membership = _membership("alice", "u1")
+    reconciled = ReconciledEntities(
+        entities={"organizations": [placeholder], "memberships": [membership]},
+    )
+    provider = _StubProvider(
+        hits={
+            "EPFL": [
+                {"score": 0.95, "types": ["education"], "name": "EPFL", "ror_id": "https://ror.org/02s376052"},
+                {"score": 0.40, "types": ["education"], "name": "Other"},
+            ],
+        },
+    )
+
+    first = _run(reconciled, provider)
+    second = _run(reconciled, provider)
+
+    assert first.placeholders_resolved == 1
+    assert second.placeholders_examined == 0
+    assert second.placeholders_resolved == 0
+    assert second.memberships_rewritten == 0
+
+
+def test_stage_returns_zero_when_no_organizations():
+    reconciled = ReconciledEntities(entities={"persons": [], "organizations": [], "memberships": []})
+    result = asyncio.run(
+        run_resolve_placeholder_orgs_to_ror_stage(
+            reconciled=reconciled, provider=_StubProvider(hits={}),
+        ),
+    )
+    assert result.placeholders_examined == 0
+
+
+def test_stage_returns_zero_when_provider_missing():
+    """No provider configured (Qdrant absent) — stage returns a sane
+    result and never raises."""
+    placeholder = _placeholder_org("u1", "EPFL")
+    reconciled = ReconciledEntities(
+        entities={"organizations": [placeholder], "memberships": []},
+    )
+    result = asyncio.run(
+        run_resolve_placeholder_orgs_to_ror_stage(
+            reconciled=reconciled, provider=None,
+        ),
+    )
+    # Result is well-formed even when provider building fails.
+    assert isinstance(result, PlaceholderResolutionResult)
+
+
+# ---------------------------------------------------------------------------
+# api.py env-flag wiring
+# ---------------------------------------------------------------------------
+
+
+def test_api_env_flag_defaults_on(monkeypatch):
+    from src.v2 import api as v2_api
+
+    monkeypatch.delenv("V2_RESOLVE_PLACEHOLDER_ORGS_TO_ROR", raising=False)
+    assert v2_api._resolve_placeholder_orgs_to_ror_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "off", "n", "f"])
+def test_api_env_flag_recognises_off_values(value, monkeypatch):
+    from src.v2 import api as v2_api
+
+    monkeypatch.setenv("V2_RESOLVE_PLACEHOLDER_ORGS_TO_ROR", value)
+    assert v2_api._resolve_placeholder_orgs_to_ror_enabled() is False
+
+
+def test_api_constant_and_export_are_in_place():
+    from src.v2 import api as v2_api
+    from src.v2.pipeline import stages
+
+    assert v2_api.STAGE_RESOLVE_PLACEHOLDER_ORGS_TO_ROR == "resolve_placeholder_orgs_to_ror"
+    assert callable(stages.run_resolve_placeholder_orgs_to_ror_stage)
+    assert "run_resolve_placeholder_orgs_to_ror_stage" in stages.__all__
+    assert "PlaceholderResolutionResult" in stages.__all__


### PR DESCRIPTION
…e:<uuid> orgs into ROR

Closes the gap surfaced by the deployed protein-design extractor: 208 `urn:pulse:<uuid>` Organization placeholders sitting in the SPARQL store with `schema:name` breadcrumbs but no ROR anchor — the extractor knew "Person X is affiliated with some org" but never mapped that org string to a canonical identifier.

The new stage runs immediately after the three Person-side resolvers (stages 8b/c/d) and closes the loop on the Org side:

  - Iterates `reconciled.entities['organizations']` for Orgs where `idSource == 'uuid'` AND `schema:name` is non-empty (the breadcrumb the rescue / fallback paths leave behind).
  - Re-queries the ROR RAG using the same `_resolve_one` + strict acceptance gate as `resolve_company_to_ror` (score >= 0.55, type allowlist, gap >= 0.02 OR exact-name override).
  - On hit, rewrites the Org in place: `id` -> ROR URL, `idSource` -> `pulse:ror`, `identifiers.pulse:ror` set, `identifiers.uuid` dropped, canonical ROR display name takes over `schema:name` (original placeholder string preserved under `_original_name`).
  - Walks `reconciled.entities['memberships']` once at the end and patches every Membership whose `org:organization` referenced a rewritten UUID: updates the reference, rebuilds the composite id (`person__old_uuid` -> `person__https://ror.org/...`), updates `identifiers.pulse:composite`.

What it deliberately doesn't do:

  - Drop unresolvable placeholders. They stay as-is so SPARQL queries that look at affiliation strings still work even when no ROR is known.
  - Cascade. Resolution of X -> ROR_X doesn't unblock Y, so single deterministic pass.
  - Touch already-anchored Orgs.

Idempotent across re-runs: a rewritten Org has `idSource = pulse:ror` next pass and is no longer a candidate. An unresolved Org stays a candidate next pass (useful as ROR grows between extracts).

Note on the graph-side follow-up: this stage only catches placeholders in *new* extracts. The 208 already in the SPARQL store need a separate batch sweep (DELETE/INSERT against the live graph) — that's a separate module / cron job. Filed as the next item.

api.py wiring: runs under all runtimes (cheap — only iterates Orgs with `idSource=uuid`), gated by `V2_RESOLVE_PLACEHOLDER_ORGS_TO_ROR` (default true). Failure becomes a warning, never aborts the request.

Tests: 19 new in tests/v2/test_resolve_placeholder_orgs_to_ror.py (happy path, rejection paths, multi-membership patching, unrelated- membership isolation, idempotency, missing-provider, env flag). Full v2 regression: 962 passed / 1 skipped (was 940 on develop).