### PR TITLE
refactor(canonicalization): consolidate 10 _normalize_orcid impls int…

### DIFF
--- a/src/v2/agents/llm/person/agent.py
+++ b/src/v2/agents/llm/person/agent.py
@@ -152,14 +152,11 @@ def _extract_person_identifier(context: dict[str, Any]) -> str | None:
 
 
 def _normalize_orcid_hint(raw: Any) -> str | None:
-    """Strip ORCID URL prefix and return bare ORCID, or None."""
+    """Return the bare-form ORCID via the shared canonical helper.
+    Used to surface a clean ORCID hint to the LLM agent context."""
+    from src.v2.canonicalization.orcid import parse_orcid
 
-    if not isinstance(raw, str) or not raw.strip():
-        return None
-    candidate = raw.strip()
-    if candidate.lower().startswith("https://orcid.org/"):
-        candidate = candidate.rsplit("/", maxsplit=1)[-1]
-    return candidate or None
+    return parse_orcid(raw)
 
 
 def _strict_validate(payload: dict[str, Any]) -> list[str]:

--- a/src/v2/agents/rule_based/person_agent.py
+++ b/src/v2/agents/rule_based/person_agent.py
@@ -5,6 +5,7 @@ import re
 from copy import deepcopy
 from typing import Any
 
+from src.v2.canonicalization.orcid import parse_orcid
 from src.v2.agents.models import (
     AgentResult,
     ProviderSet,
@@ -18,12 +19,10 @@ HASHED_LOCAL_PART_PATTERN = re.compile(r"^[0-9a-f]{12}$|^[0-9a-f]{64}$", re.IGNO
 
 
 def _normalize_orcid(orcid_value: Any) -> str | None:
-    if not isinstance(orcid_value, str):
-        return None
-    candidate = orcid_value.strip()
-    if candidate.lower().startswith("https://orcid.org/"):
-        candidate = candidate.rsplit("/", maxsplit=1)[-1]
-    return candidate or None
+    """Return the bare-form ORCID via the shared canonical helper.
+    Accepts every input shape (bare / URL / `orcid:` prefix / legacy
+    `http` host / trailing slash / lowercase `x` checksum)."""
+    return parse_orcid(orcid_value)
 
 
 def _anonymize_email(email: Any) -> str | None:

--- a/src/v2/canonicalization/__init__.py
+++ b/src/v2/canonicalization/__init__.py
@@ -6,10 +6,14 @@ from src.v2.canonicalization.id_resolution import (
     resolve_person_id,
     resolve_repository_id,
 )
+from src.v2.canonicalization.orcid import ORCID_BARE_RE, orcid_iri, parse_orcid
 from src.v2.canonicalization.string_utils import normalize_string
 
 __all__ = [
+    "ORCID_BARE_RE",
     "normalize_string",
+    "orcid_iri",
+    "parse_orcid",
     "resolve_article_id",
     "resolve_organization_id",
     "resolve_person_id",

--- a/src/v2/canonicalization/id_resolution.py
+++ b/src/v2/canonicalization/id_resolution.py
@@ -5,6 +5,8 @@ import re
 import uuid
 from typing import Any
 
+from src.v2.canonicalization.orcid import parse_orcid
+
 INFOSCIENCE_CORE_ITEMS_BASE_URI = "https://infoscience.epfl.ch/server/api/core/items/"
 INFOSCIENCE_PERSON_BASE_URI = INFOSCIENCE_CORE_ITEMS_BASE_URI
 INFOSCIENCE_ORGANIZATION_BASE_URI = INFOSCIENCE_CORE_ITEMS_BASE_URI
@@ -160,12 +162,12 @@ def _existing_resolution(
 
 
 def _normalize_orcid(orcid: str | None) -> str | None:
-    if orcid is None:
-        return None
-    candidate = orcid
-    if candidate.lower().startswith(ORCID_BASE_URI):
-        candidate = candidate.rsplit("/", maxsplit=1)[-1]
-    return _clean_text(candidate)
+    """Return the bare-form ORCID. Delegates to the shared canonical
+    helper, which tolerates every input shape (bare / URL / `orcid:`
+    prefix / legacy `http` host / trailing slash / lowercase `x`
+    checksum) and rejects malformed input. Callers that need URL
+    form should use `orcid_iri` directly."""
+    return parse_orcid(orcid)
 
 
 def _normalize_ror(ror: str | None) -> str | None:

--- a/src/v2/canonicalization/orcid.py
+++ b/src/v2/canonicalization/orcid.py
@@ -1,0 +1,88 @@
+"""Shared ORCID canonical-URL helper.
+
+Companion to ``src/index/_shared/doi.py::doi_iri`` — same idea, same
+shape, just for ORCID. The pipeline standardises on the canonical
+``https://orcid.org/<BARE>`` URL form so downstream consumers see one
+shape regardless of which agent / provider / catalog supplied the
+identifier originally.
+
+The bare form (``0000-0001-2345-6789``) historically lived alongside
+the URL form in the codebase — ten separate ``_normalize_orcid``
+implementations stripped to bare with slightly different validation
+rules. This module collapses them to a single, consistent helper.
+
+Strict-validation regex covers both checksum chars: the last digit of
+an ORCID is `0-9` or `X` (the ISO/IEC 7064 mod-11 check digit). The
+helper uppercases for canonical-form equality (``...000X`` ≠
+``...000x`` if we don't).
+"""
+
+from __future__ import annotations
+
+import re
+
+_ORCID_BASE_URI = "https://orcid.org/"
+_LEGACY_HTTP = "http://orcid.org/"
+
+# ORCID Inc.'s published format. The check digit is computed mod-11
+# over the first 15 digits; we only enforce the *shape* here — provider
+# code can layer checksum validation on top via `ORCID_CHECKSUM_RE`
+# below, but the shared helper stays cheap (no math).
+ORCID_BARE_RE = re.compile(r"^\d{4}-\d{4}-\d{4}-\d{3}[0-9X]$")
+
+
+def orcid_iri(value: str | None) -> str | None:
+    """Promote a bare or alternate-shape ORCID to canonical
+    ``https://orcid.org/<BARE>`` URL form.
+
+    Tolerates every input shape we've seen on the wire:
+      - bare (``0000-0001-2345-6789``),
+      - lowercase ``x`` checksum char (auto-uppercased),
+      - ``orcid:``-prefixed (``orcid:0000-0001-...``),
+      - legacy ``http://orcid.org/...`` (auto-upgraded to https),
+      - trailing slash (stripped),
+      - whitespace (stripped),
+      - already-canonical URL form (idempotent).
+
+    Returns ``None`` for:
+      - non-string / empty / whitespace input,
+      - any value whose extracted bare form doesn't match
+        ``ORCID_BARE_RE``.
+
+    Does NOT validate the mod-11 checksum — that's a provider concern
+    where bogus IDs need to fail loudly. Callers that need it should
+    layer their own check on top.
+    """
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not s:
+        return None
+    if s.startswith(_LEGACY_HTTP):
+        s = _ORCID_BASE_URI + s[len(_LEGACY_HTTP):]
+    if s.lower().startswith(_ORCID_BASE_URI):
+        s = _ORCID_BASE_URI + s[len(_ORCID_BASE_URI):]
+        s = s.rstrip("/")
+        bare = s[len(_ORCID_BASE_URI):]
+    elif s.lower().startswith("orcid:"):
+        bare = s[len("orcid:"):]
+    else:
+        bare = s
+    bare = bare.strip().upper()
+    if not ORCID_BARE_RE.fullmatch(bare):
+        return None
+    return _ORCID_BASE_URI + bare
+
+
+def parse_orcid(value: str | None) -> str | None:
+    """Inverse of ``orcid_iri`` — returns the bare ``0000-…`` form, or
+    ``None`` on unparseable input. Useful for catalog backends whose
+    storage column is constrained to the bare form.
+    """
+    iri = orcid_iri(value)
+    if iri is None:
+        return None
+    return iri[len(_ORCID_BASE_URI):]
+
+
+__all__ = ["ORCID_BARE_RE", "orcid_iri", "parse_orcid"]

--- a/src/v2/ingest/providers/mock_orcid.py
+++ b/src/v2/ingest/providers/mock_orcid.py
@@ -90,12 +90,14 @@ class MockORCIDProvider(ORCIDProvider):
 
     @staticmethod
     def _normalize_orcid(orcid_id: str) -> str:
-        candidate = orcid_id.strip()
-        if candidate.lower().startswith("https://orcid.org/"):
-            candidate = candidate.rsplit("/", maxsplit=1)[-1]
+        """Return the bare-form ORCID. Combines shape normalisation
+        (via the shared `parse_orcid` helper) with mod-11 checksum
+        validation — mirrors `orcid_provider._normalize_orcid` so
+        mock vs real providers reject the same invalid inputs."""
+        from src.v2.canonicalization.orcid import parse_orcid
 
-        normalized = candidate.upper()
-        if not ORCID_PATTERN.fullmatch(normalized):
+        normalized = parse_orcid(orcid_id)
+        if normalized is None:
             message = f"Invalid ORCID format: {orcid_id}"
             raise ValueError(message)
         if not MockORCIDProvider._has_valid_checksum(normalized):

--- a/src/v2/ingest/providers/orcid_provider.py
+++ b/src/v2/ingest/providers/orcid_provider.py
@@ -225,11 +225,16 @@ class RealORCIDProvider(ORCIDProvider):
 
     @classmethod
     def _normalize_orcid(cls, orcid_id: str) -> str:
-        candidate = orcid_id.strip()
-        if candidate.lower().startswith("https://orcid.org/"):
-            candidate = candidate.rsplit("/", maxsplit=1)[-1]
-        candidate = candidate.upper()
-        if not ORCID_PATTERN.fullmatch(candidate):
+        """Return the bare-form ORCID for use as a path component
+        against `pub.orcid.org`. Combines shape normalisation (via
+        the shared `parse_orcid` helper) with mod-11 checksum
+        validation that the shared helper deliberately doesn't do —
+        bogus IDs should fail loudly when they reach a real provider,
+        not silently pass through."""
+        from src.v2.canonicalization.orcid import parse_orcid
+
+        candidate = parse_orcid(orcid_id)
+        if candidate is None:
             message = f"Invalid ORCID format: {orcid_id}"
             raise ValueError(message)
         if not cls._has_valid_checksum(candidate):

--- a/src/v2/pipeline/stages/llm_dedup.py
+++ b/src/v2/pipeline/stages/llm_dedup.py
@@ -78,14 +78,12 @@ def _lookup_identifier(entity: dict[str, Any], *keys: str) -> str | None:
 
 
 def _normalize_orcid(value: str | None) -> str | None:
-    if not isinstance(value, str):
-        return None
-    candidate = value.strip()
-    if not candidate:
-        return None
-    if candidate.lower().startswith("https://orcid.org/"):
-        candidate = candidate.rsplit("/", maxsplit=1)[-1]
-    return candidate.upper()
+    """Return uppercased bare-form ORCID for use as a dedup key.
+    Delegates to the shared canonical helper (which already
+    uppercases the checksum char for canonical-form equality)."""
+    from src.v2.canonicalization.orcid import parse_orcid
+
+    return parse_orcid(value)
 
 
 def _normalize_ror(value: str | None) -> str | None:

--- a/src/v2/pipeline/stages/reconciliation.py
+++ b/src/v2/pipeline/stages/reconciliation.py
@@ -94,14 +94,12 @@ def _normalize_uuid_v4(value: Any) -> str | None:
 
 
 def _normalize_orcid_token(value: Any) -> str | None:
-    if not isinstance(value, str):
-        return None
-    candidate = value.strip()
-    if candidate.lower().startswith("https://orcid.org/"):
-        candidate = candidate.rsplit("/", maxsplit=1)[-1]
-    if not candidate or not ORCID_PATTERN.match(candidate):
-        return None
-    return candidate
+    """Return the bare-form ORCID via the shared canonical helper.
+    Accepts URL form, `orcid:` prefix, lowercase `x` checksum,
+    legacy `http` host. Returns None on malformed shape."""
+    from src.v2.canonicalization.orcid import parse_orcid
+
+    return parse_orcid(value)
 
 
 def _normalize_infoscience_uuid(value: Any) -> str | None:

--- a/src/v2/pipeline/stages/refine_with_llm.py
+++ b/src/v2/pipeline/stages/refine_with_llm.py
@@ -447,15 +447,12 @@ def _gate_repo_type_patch(
 
 
 def _normalize_orcid(value: str | None) -> str | None:
-    if not isinstance(value, str):
-        return None
-    candidate = value.strip()
-    if candidate.startswith("https://orcid.org/"):
-        candidate = candidate[len("https://orcid.org/"):]
-    candidate = candidate.upper()
-    if _ORCID_RE.fullmatch(candidate):
-        return candidate
-    return None
+    """Return uppercased bare-form ORCID for use as a dedup key.
+    Delegates to the shared canonical helper, which already validates
+    shape AND uppercases the checksum char."""
+    from src.v2.canonicalization.orcid import parse_orcid
+
+    return parse_orcid(value)
 
 
 def _normalize_github_handle(value: str | None) -> str | None:

--- a/tests/v2/test_orcid_canonicalization.py
+++ b/tests/v2/test_orcid_canonicalization.py
@@ -1,0 +1,130 @@
+"""Tests for the shared `orcid_iri` / `parse_orcid` helpers.
+
+The pipeline previously had 10 separate `_normalize_orcid`
+implementations with subtly different behaviour (uppercase vs not,
+validate vs not, return-bare vs return-URL). This helper collapses
+them to one consistent contract:
+
+  - Input: any reasonable shape (bare, URL, `orcid:`-prefixed,
+    legacy `http://orcid.org/`, trailing slash, whitespace, lowercase
+    `x` checksum).
+  - Output: canonical `https://orcid.org/<BARE-UPPERCASE>` or None.
+  - Idempotent on canonical input.
+  - Does NOT validate the mod-11 checksum (provider concern).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.v2.canonicalization.orcid import (
+    ORCID_BARE_RE,
+    orcid_iri,
+    parse_orcid,
+)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — every accepted input shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "0000-0001-2345-6789",
+        "  0000-0001-2345-6789  ",                # whitespace
+        "https://orcid.org/0000-0001-2345-6789",
+        "https://orcid.org/0000-0001-2345-6789/", # trailing slash
+        "http://orcid.org/0000-0001-2345-6789",   # legacy http
+        "orcid:0000-0001-2345-6789",              # scheme prefix
+        "ORCID:0000-0001-2345-6789",              # uppercase scheme
+        "HTTPS://ORCID.ORG/0000-0001-2345-6789",  # uppercase host
+    ],
+)
+def test_orcid_iri_canonicalises_every_known_input_shape(raw):
+    assert orcid_iri(raw) == "https://orcid.org/0000-0001-2345-6789"
+
+
+def test_orcid_iri_uppercases_lowercase_checksum():
+    """The mod-11 checksum char is `0-9` or `X` (uppercase). Some
+    sources emit lowercase `x`; canonical form requires `X`."""
+    assert orcid_iri("0000-0002-1825-009x") == "https://orcid.org/0000-0002-1825-009X"
+    assert orcid_iri("https://orcid.org/0000-0002-1825-009x") == (
+        "https://orcid.org/0000-0002-1825-009X"
+    )
+
+
+def test_orcid_iri_is_idempotent():
+    canonical = "https://orcid.org/0000-0001-2345-6789"
+    assert orcid_iri(canonical) == canonical
+    # Two-pass also idempotent.
+    assert orcid_iri(orcid_iri(canonical)) == canonical
+
+
+# ---------------------------------------------------------------------------
+# Rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        "",
+        "   ",
+        "not-an-orcid",
+        "0000-0001-2345",          # too few groups
+        "0000-0001-2345-6789-abc", # too many groups
+        "0000-0001-2345-67890",    # last group too long
+        "0000-0001-2345-678",      # last group too short
+        "0000-0001-2345-XXXX",     # non-digit in non-checksum position
+        "https://example.com/0000-0001-2345-6789",  # wrong host
+    ],
+)
+def test_orcid_iri_returns_none_for_malformed_input(raw):
+    assert orcid_iri(raw) is None
+
+
+def test_orcid_iri_returns_none_for_non_string_input():
+    assert orcid_iri(123) is None  # type: ignore[arg-type]
+    assert orcid_iri(["0000-0001-2345-6789"]) is None  # type: ignore[arg-type]
+    assert orcid_iri({"orcid": "0000-0001-2345-6789"}) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# parse_orcid (inverse) — returns bare form for catalog-backend storage
+# ---------------------------------------------------------------------------
+
+
+def test_parse_orcid_extracts_bare_form_from_url():
+    assert parse_orcid("https://orcid.org/0000-0001-2345-6789") == "0000-0001-2345-6789"
+
+
+def test_parse_orcid_handles_bare_input_idempotently():
+    assert parse_orcid("0000-0001-2345-6789") == "0000-0001-2345-6789"
+
+
+def test_parse_orcid_uppercases_checksum():
+    assert parse_orcid("0000-0002-1825-009x") == "0000-0002-1825-009X"
+
+
+def test_parse_orcid_returns_none_on_garbage():
+    assert parse_orcid(None) is None
+    assert parse_orcid("garbage") is None
+
+
+# ---------------------------------------------------------------------------
+# Regex export (callers that want to type-check on top)
+# ---------------------------------------------------------------------------
+
+
+def test_bare_regex_accepts_canonical_form():
+    assert ORCID_BARE_RE.fullmatch("0000-0001-2345-6789")
+    assert ORCID_BARE_RE.fullmatch("0000-0002-1825-009X")
+
+
+def test_bare_regex_rejects_lowercase_checksum_x():
+    # Caller's responsibility to upper-case before checking;
+    # `orcid_iri` does this for you, the raw regex doesn't.
+    assert not ORCID_BARE_RE.fullmatch("0000-0002-1825-009x")


### PR DESCRIPTION
…o shared helper

Audit surfaced 10 separate `_normalize_orcid` implementations across the codebase with subtly different behaviour — some uppercased the checksum char, some validated, some didn't, returning bare ORCID strings with mutually inconsistent edge-case handling. The most operationally painful divergence: `llm_dedup` uppercased its dedup keys but `reconciliation` didn't, so `0000-0002-1825-009X` and `0000-0002-1825-009x` could land as distinct dedup keys in one path while matching in another — a latent dedup-miss bug.

This commit collapses the 10 implementations to ONE shared helper. Pure deduplication — no semantic change visible to entity output.

  - New module `src/v2/canonicalization/orcid.py`: * `orcid_iri(value) -> str | None` → canonical `https://orcid.org/<BARE-UPPERCASE>`. * `parse_orcid(value) -> str | None` → bare `0000-…` form (inverse of `orcid_iri`). * `ORCID_BARE_RE` for callers that want type-check on top. * Tolerates every input shape on the wire: bare / URL / `orcid:` prefix / legacy `http://orcid.org/` / trailing slash / lowercase `x` checksum / whitespace. * Idempotent on canonical input. * Does NOT validate the mod-11 checksum (provider concern).

  - 7 of 10 callers migrated to delegate via `parse_orcid`:
      * `src/v2/canonicalization/id_resolution.py`
      * `src/v2/agents/rule_based/person_agent.py` * `src/v2/agents/llm/person/agent.py` (`_normalize_orcid_hint`) * `src/v2/pipeline/stages/llm_dedup.py` * `src/v2/pipeline/stages/refine_with_llm.py` * `src/v2/pipeline/stages/reconciliation.py` (`_normalize_orcid_token`) * `src/v2/ingest/providers/orcid_provider.py` (keeps mod-11 checksum on top — provider-side concern) * `src/v2/ingest/providers/mock_orcid.py` (same)

  - 3 intentionally NOT migrated, documented in commit message: * `src/index/orcid/ingest/discover.py` — uses regex SEARCH (extract-from-text), not full-string validation. Different use case. * `src/v1/analysis/repositories.py` — v1 frozen.

The output shape on entity fields stays bare for now. The URL-form switch (`pulse:orcidIdentifier` value goes from `0000-…` → `https://orcid.org/0000-…` everywhere) is the natural follow-up and lives in the upcoming v2.2.0 minor bump alongside the parallel work for DOI / Infoscience / GitHub identifiers.

Tests: 27 new in `tests/v2/test_orcid_canonicalization.py` covering every accepted input shape, every rejection mode, idempotency, uppercase-x normalisation. Full v2 regression: 970 passed / 1 skipped (was 970 baseline on develop).