### PR TITLE
feat(repository): parse CITATION.cff into typed `_citation_cff` field

### DIFF
--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -12,6 +12,7 @@ from src.v2.agents.models import (
     generate_uuid,
     validate_permissive,
 )
+from src.v2.parsers.citation_cff import parse_citation_cff
 from src.v2.parsers.publiccode import parse_publiccode
 
 CompiledContextStage = Callable[[dict[str, Any], ProviderSet], dict[str, Any] | Awaitable[dict[str, Any]]]
@@ -58,6 +59,25 @@ def _resolve_publiccode_payload(aux_files: Any) -> dict[str, Any] | None:
         lower = filename.lower()
         if lower in ("publiccode.yml", "publiccode.yaml"):
             return parse_publiccode(content)
+    return None
+
+
+def _resolve_citation_cff_payload(aux_files: Any) -> dict[str, Any] | None:
+    """Locate CITATION.cff (any case) in the gathered ``aux_files`` and
+    return the parsed payload, or None when none is present / parseable.
+
+    Mirrors `_resolve_publiccode_payload` — Layer 1 of the citation
+    integration: pure parse, no enrichment of the Repository's
+    `schema:*` fields. Downstream consumers (LLM refiners, dashboards,
+    a future `enrich_repo_from_citation_cff` stage) read the typed
+    payload from `_citation_cff` instead of re-parsing YAML."""
+    if not isinstance(aux_files, dict):
+        return None
+    for filename, content in aux_files.items():
+        if not isinstance(filename, str) or not isinstance(content, str):
+            continue
+        if filename.lower() == "citation.cff":
+            return parse_citation_cff(content)
     return None
 
 
@@ -461,6 +481,17 @@ class RepositoryAgentV2:
             # softwareType, developmentStatus) to first-class
             # ontology terms via a `publiccode:` JSON-LD prefix.
             "_publiccode": _resolve_publiccode_payload(
+                compiled_context.get("aux_files"),
+            ),
+            # Parsed CITATION.cff payload (when present). Same Layer-1
+            # contract as `_publiccode` — pure data, no automatic
+            # enrichment of `schema:*` fields. A future stage
+            # (`enrich_repo_from_citation_cff`) is the right place to
+            # backfill `schema:citation` / `schema:dateCreated` /
+            # `schema:author` from the parsed payload; that's an
+            # opinionated policy (does CITATION.cff trump what an
+            # agent emitted?) and lives separately.
+            "_citation_cff": _resolve_citation_cff_payload(
                 compiled_context.get("aux_files"),
             ),
         }

--- a/src/v2/parsers/__init__.py
+++ b/src/v2/parsers/__init__.py
@@ -1,9 +1,10 @@
 """Format-specific parsers for repository-root supplementary metadata
-files (publiccode.yml, …). Each module exposes a single ``parse_*``
-entry point that takes the raw file contents and returns a typed
-dict; failure modes are observable (returns ``None``) so the caller
-never raises on a malformed file."""
+files (CITATION.cff, publiccode.yml, …). Each module exposes a single
+``parse_*`` entry point that takes the raw file contents and returns
+a typed dict; failure modes are observable (returns ``None``) so the
+caller never raises on a malformed file."""
 
+from src.v2.parsers.citation_cff import parse_citation_cff
 from src.v2.parsers.publiccode import parse_publiccode
 
-__all__ = ["parse_publiccode"]
+__all__ = ["parse_citation_cff", "parse_publiccode"]

--- a/src/v2/parsers/citation_cff.py
+++ b/src/v2/parsers/citation_cff.py
@@ -1,0 +1,369 @@
+"""Parser for ``CITATION.cff`` (Citation File Format).
+
+The Citation File Format (`https://citation-file-format.github.io/`)
+is the community standard for declaring how to cite software.
+v1.2.0 is the current schema. Every well-cited research-software
+repo on GitHub ships a CITATION.cff at root.
+
+The format carries strong identity signal the GME pipeline would
+otherwise have to extract from README prose:
+
+  - canonical project title, version, release date, license;
+  - software DOI(s) + URL identifiers + Software Heritage ID;
+  - author list with full names, ORCIDs, emails, affiliations
+    (PII-relevant — `_anonymize_email` should still be applied
+    downstream if needed);
+  - the `preferred-citation` block — a full bibliographic
+    reference for the paper that introduces the software,
+    typically with its own DOI distinct from the software DOI;
+  - cross-references in `references[]`.
+
+This parser is **lossy by design**: malformed sub-trees are
+silently dropped rather than failing the whole parse. Callers
+get either a populated dict or ``None``. The shape mirrors
+``src/v2/parsers/publiccode.py`` so the two parsers are
+behaviour-twins from the caller's perspective.
+
+Caller-side enrichment (lifting CITATION.cff fields onto the
+Repository's `schema:*` / `pulse:*` predicates) is intentionally
+NOT done here — that's a separate concern with policy questions
+(does CITATION.cff trump what an agent already wrote? etc.) and
+belongs in a future pipeline stage. This parser is pure data.
+
+Spec references:
+  - https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md
+  - https://citation-file-format.github.io/
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Any
+
+import yaml
+
+from src.index._shared.doi import doi_iri
+
+logger = logging.getLogger(__name__)
+
+
+# Top-level fields that are plain scalars in v1.2.0.
+_TOP_LEVEL_SCALAR_FIELDS: tuple[str, ...] = (
+    "cff-version",
+    "message",
+    "title",
+    "abstract",
+    "version",
+    "date-released",
+    "commit",
+    "doi",                 # deprecated but still in the wild — promoted into `identifiers`
+    "license",
+    "license-url",
+    "repository",
+    "repository-artifact",
+    "repository-code",
+    "type",                # "software" | "dataset" — defaults to software
+    "url",
+)
+
+# Top-level list-of-strings fields.
+_TOP_LEVEL_LIST_FIELDS: tuple[str, ...] = (
+    "keywords",
+)
+
+
+# Person fields (author / contact / editor / translator / sender / recipient).
+_PERSON_FIELDS: tuple[str, ...] = (
+    "given-names", "family-names", "name-particle", "name-suffix",
+    "name-suffix", "email", "affiliation", "orcid", "website",
+    "address", "city", "country", "region", "post-code", "tel", "fax",
+    "alias",
+)
+
+# Entity (group / organization) fields. The distinguishing field is `name`.
+_ENTITY_FIELDS: tuple[str, ...] = (
+    "name", "email", "address", "city", "country", "region",
+    "post-code", "tel", "fax", "location", "date-start", "date-end",
+    "website", "alias",
+)
+
+# Reference object (preferred-citation, references[]) — subset of the
+# spec's enormous field list. We capture the citation-critical ones.
+_REFERENCE_SCALAR_FIELDS: tuple[str, ...] = (
+    "type", "title", "abstract", "doi", "url", "year", "month",
+    "start", "end", "pages", "journal", "volume", "issue", "publisher",
+    "publisher-name", "edition", "isbn", "issn", "pmcid", "nihmsid",
+    "license", "license-url", "version", "commit",
+    "date-accessed", "date-downloaded", "date-released", "date-published",
+    "languages", "medium", "thesis-type", "status", "scope", "format",
+    "institution", "conference", "data-type", "database",
+    "database-provider", "department", "entry", "loc-start", "loc-end",
+    "number", "section", "term",
+)
+_REFERENCE_LIST_FIELDS: tuple[str, ...] = (
+    "keywords", "filename",
+)
+_REFERENCE_PERSON_FIELDS: tuple[str, ...] = (
+    "authors", "editors", "editors-series", "translators",
+    "senders", "recipients",
+)
+
+
+# ---------------------------------------------------------------------------
+# Coercion helpers
+# ---------------------------------------------------------------------------
+
+
+def _coerce_str(value: Any) -> str | None:
+    """Convert YAML scalar to a clean string, handling date/datetime
+    objects that PyYAML decodes natively from `YYYY-MM-DD` literals."""
+    if isinstance(value, str):
+        s = value.strip()
+        return s or None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, (datetime.date, datetime.datetime)):
+        return value.isoformat()
+    return None
+
+
+def _coerce_str_list(value: Any) -> list[str] | None:
+    if isinstance(value, str):
+        s = value.strip()
+        return [s] if s else None
+    if isinstance(value, list):
+        out = []
+        for item in value:
+            s = _coerce_str(item)
+            if s:
+                out.append(s)
+        return out or None
+    return None
+
+
+def _coerce_bool(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+# ---------------------------------------------------------------------------
+# Person / Entity parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_person_or_entity(value: Any) -> dict[str, Any] | None:
+    """Authors / contacts / editors are either Person dicts (with
+    `given-names`/`family-names`) or Entity dicts (with `name`).
+    Spec says they're either-or per item; we honour that — items
+    that have neither shape get dropped."""
+    if not isinstance(value, dict):
+        return None
+    has_person_name = any(
+        _coerce_str(value.get(k)) for k in ("given-names", "family-names")
+    )
+    has_entity_name = bool(_coerce_str(value.get("name")))
+    if not has_person_name and not has_entity_name:
+        return None
+
+    out: dict[str, Any] = {}
+    fields = _PERSON_FIELDS if has_person_name else _ENTITY_FIELDS
+    for k in fields:
+        coerced = _coerce_str(value.get(k))
+        if coerced:
+            out[k] = coerced
+    # Tag the kind so downstream consumers don't have to re-derive it.
+    out["__kind__"] = "person" if has_person_name else "entity"
+    return out
+
+
+def _parse_person_or_entity_list(value: Any) -> list[dict[str, Any]] | None:
+    if not isinstance(value, list):
+        return None
+    out = []
+    for item in value:
+        parsed = _parse_person_or_entity(item)
+        if parsed:
+            out.append(parsed)
+    return out or None
+
+
+# ---------------------------------------------------------------------------
+# Reference parsing (preferred-citation, references[])
+# ---------------------------------------------------------------------------
+
+
+def _parse_reference(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    out: dict[str, Any] = {}
+    for k in _REFERENCE_SCALAR_FIELDS:
+        coerced = _coerce_str(value.get(k))
+        if coerced:
+            out[k] = coerced
+    # DOI fields land as bare strings in the YAML wire format
+    # ('10.1234/example') but the rest of the project standardises on
+    # canonical `https://doi.org/<bare>` URL form — `src/index/_shared/
+    # doi.py::doi_iri` is the shared promotion helper, used by every
+    # index catalog. Apply it here too so downstream consumers see the
+    # same shape regardless of source.
+    if "doi" in out:
+        promoted = doi_iri(out["doi"])
+        if promoted:
+            out["doi"] = promoted
+    for k in _REFERENCE_LIST_FIELDS:
+        coerced_list = _coerce_str_list(value.get(k))
+        if coerced_list:
+            out[k] = coerced_list
+    for k in _REFERENCE_PERSON_FIELDS:
+        coerced_persons = _parse_person_or_entity_list(value.get(k))
+        if coerced_persons:
+            out[k] = coerced_persons
+    return out or None
+
+
+def _parse_references(value: Any) -> list[dict[str, Any]] | None:
+    if not isinstance(value, list):
+        return None
+    out = []
+    for item in value:
+        parsed = _parse_reference(item)
+        if parsed:
+            out.append(parsed)
+    return out or None
+
+
+# ---------------------------------------------------------------------------
+# Identifiers
+# ---------------------------------------------------------------------------
+
+
+def _parse_identifiers(value: Any) -> list[dict[str, Any]] | None:
+    """``identifiers`` is a list of ``{type, value, description?}``
+    where ``type`` is one of doi / url / swh / other.
+
+    DOI entries are canonicalised to `https://doi.org/<bare>` via the
+    shared `src.index._shared.doi.doi_iri` helper so they match the
+    URL form every other catalog uses.
+    """
+    if not isinstance(value, list):
+        return None
+    out: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        t = _coerce_str(item.get("type"))
+        v = _coerce_str(item.get("value"))
+        if not t or not v:
+            continue
+        kind = t.lower()
+        if kind == "doi":
+            promoted = doi_iri(v)
+            if promoted:
+                v = promoted
+        entry: dict[str, Any] = {"type": kind, "value": v}
+        desc = _coerce_str(item.get("description"))
+        if desc:
+            entry["description"] = desc
+        out.append(entry)
+    return out or None
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_citation_cff(content: str | None) -> dict[str, Any] | None:
+    """Parse a ``CITATION.cff`` document.
+
+    Returns a dict whose keys are the CFF v1.2.0 field names
+    (kebab-case, per spec) for fields that were present and
+    well-typed in the input. Always lossy by design — malformed
+    sub-trees are silently dropped rather than failing the whole
+    parse.
+
+    Returns ``None`` when:
+      - ``content`` is None / empty / whitespace,
+      - the YAML payload doesn't load to a mapping,
+      - the YAML is malformed.
+
+    Special handling:
+      - The deprecated top-level ``doi`` field is preserved
+        verbatim but ALSO promoted into ``identifiers`` as a
+        synthesised ``{type: "doi", value: <doi>}`` entry, so
+        downstream consumers can iterate ``identifiers`` uniformly
+        regardless of CFF spec age.
+      - Dates are coerced from native ``date`` / ``datetime`` objects
+        that PyYAML decodes from `YYYY-MM-DD` literals back into
+        ISO-8601 strings.
+      - Author / contact / preferred-citation.authors items carry
+        an internal ``__kind__`` tag (``"person"`` | ``"entity"``)
+        so callers don't have to re-derive the Person/Entity
+        distinction from field presence.
+    """
+    if not isinstance(content, str) or not content.strip():
+        return None
+    try:
+        loaded = yaml.safe_load(content)
+    except yaml.YAMLError:
+        logger.warning("CITATION.cff: YAML parse error; skipping")
+        return None
+    if not isinstance(loaded, dict):
+        return None
+
+    out: dict[str, Any] = {}
+
+    for field in _TOP_LEVEL_SCALAR_FIELDS:
+        coerced = _coerce_str(loaded.get(field))
+        if coerced:
+            out[field] = coerced
+
+    for field in _TOP_LEVEL_LIST_FIELDS:
+        coerced_list = _coerce_str_list(loaded.get(field))
+        if coerced_list:
+            out[field] = coerced_list
+
+    # Authors are required by spec but we don't gate on that — a
+    # malformed authors list shouldn't lose the rest of the file.
+    authors = _parse_person_or_entity_list(loaded.get("authors"))
+    if authors:
+        out["authors"] = authors
+
+    contacts = _parse_person_or_entity_list(loaded.get("contact"))
+    if contacts:
+        out["contact"] = contacts
+
+    identifiers = _parse_identifiers(loaded.get("identifiers")) or []
+    # Promote the deprecated top-level `doi` into `identifiers` if
+    # not already present there. Keeps the canonical reading shape:
+    # downstream walks `identifiers`, not `doi`. Also canonicalise the
+    # top-level `doi` field itself so both shapes match the URL
+    # convention every other catalog uses.
+    legacy_doi = out.get("doi")
+    if isinstance(legacy_doi, str):
+        promoted_legacy = doi_iri(legacy_doi)
+        if promoted_legacy:
+            out["doi"] = promoted_legacy
+            legacy_doi = promoted_legacy
+        if not any(
+            i.get("type") == "doi" and i.get("value") == legacy_doi
+            for i in identifiers
+        ):
+            identifiers.append({"type": "doi", "value": legacy_doi})
+    if identifiers:
+        out["identifiers"] = identifiers
+
+    preferred = _parse_reference(loaded.get("preferred-citation"))
+    if preferred:
+        out["preferred-citation"] = preferred
+
+    references = _parse_references(loaded.get("references"))
+    if references:
+        out["references"] = references
+
+    return out or None
+
+
+__all__ = ["parse_citation_cff"]

--- a/src/v2/pipeline/stages/refine_with_llm.py
+++ b/src/v2/pipeline/stages/refine_with_llm.py
@@ -59,6 +59,7 @@ from src.v2.agents.llm.refiners.org_resolver import (
 from src.v2.agents.llm.runtime import LLMRuntimeError
 from src.v2.api_models.enums import OrganizationTypeV2
 from src.v2.ingest.providers.epfl_graph_rag import EpflGraphRagProvider
+from src.v2.parsers.citation_cff import parse_citation_cff
 from src.v2.parsers.publiccode import parse_publiccode
 from src.v2.pipeline.stages.models import ReconciledEntities
 
@@ -207,6 +208,17 @@ def _build_repo_context_summary(
                 parsed = parse_publiccode(content)
                 if parsed:
                     summary["publiccode"] = parsed
+
+        # Same treatment for CITATION.cff — parsed payload alongside
+        # the raw excerpt so LLM refiners can read typed authors /
+        # identifiers / preferred-citation without YAML-grepping.
+        citation_filename = lower_to_original.get("citation.cff")
+        if citation_filename:
+            content = aux_files.get(citation_filename)
+            if isinstance(content, str):
+                parsed_cff = parse_citation_cff(content)
+                if parsed_cff:
+                    summary["citation_cff"] = parsed_cff
 
     return summary
 

--- a/tests/v2/fixtures/citation_cff_gimie.cff
+++ b/tests/v2/fixtures/citation_cff_gimie.cff
@@ -1,0 +1,44 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: gimie
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Cyril
+    family-names: Matthey-Doret
+    affiliation: Swiss Data Science Center
+    orcid: 'https://orcid.org/0000-0002-1126-1535'
+  - given-names: Sabine
+    family-names: Maennel
+    orcid: 'https://orcid.org/0009-0001-3022-8239'
+    affiliation: Swiss Data Science Center
+  - given-names: Robin
+    family-names: Franken
+    orcid: 'https://orcid.org/0009-0008-0143-9118'
+    affiliation: Swiss Data Science Center
+  - given-names: Martin
+    family-names: Fontanet
+    orcid: 'https://orcid.org/0000-0002-6441-8540'
+    affiliation: Swiss Data Science Center
+  - given-names: Laure
+    family-names: Vancauwenberghe
+    affiliation: Swiss Data Science Center
+  - given-names: Stefan
+    family-names: Milosavljevic
+    email: supermegaiperste@hotmail.com
+    affiliation: Swiss Data Science Center
+repository-code: 'https://github.com/sdsc-ordes/gimie'
+abstract: Extract linked metadata from repositories
+keywords:
+  - git
+  - cli
+  - library
+  - linked-open-data
+  - metadata-extraction
+  - fair-data
+  - scientific-software
+license: Apache-2.0

--- a/tests/v2/test_parsers_citation_cff.py
+++ b/tests/v2/test_parsers_citation_cff.py
@@ -1,0 +1,378 @@
+"""Tests for `src.v2.parsers.citation_cff.parse_citation_cff`.
+
+Layer 1 contract: pure parser, no enrichment. We pin every section
+of the v1.2.0 schema we surface, plus failure modes (malformed
+YAML, wrong root type, dropped sub-trees), plus a real-world fixture
+(sdsc-ordes/gimie's CITATION.cff) to catch spec drift.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+from src.v2.parsers.citation_cff import parse_citation_cff
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_returns_none_on_none_or_blank():
+    assert parse_citation_cff(None) is None
+    assert parse_citation_cff("") is None
+    assert parse_citation_cff("   \n   ") is None
+
+
+def test_returns_none_on_malformed_yaml():
+    assert parse_citation_cff("foo: : bar") is None
+
+
+def test_returns_none_when_top_level_is_not_a_mapping():
+    """YAML list at the root is well-formed YAML but not a CITATION.cff."""
+    assert parse_citation_cff("- a\n- b\n") is None
+
+
+def test_returns_none_when_nothing_recognised():
+    """Document loads but carries no recognised fields → None."""
+    assert parse_citation_cff("foo: bar\n") is None
+
+
+# ---------------------------------------------------------------------------
+# Top-level scalar fields
+# ---------------------------------------------------------------------------
+
+
+def test_parses_minimal_required_fields():
+    """`cff-version`, `title`, `message`, `version` — the most-common
+    populated subset of the required-or-near-required fields."""
+    doc = textwrap.dedent("""
+        cff-version: 1.2.0
+        title: My Software
+        message: Please cite this software.
+        version: 1.2.3
+        date-released: 2024-05-01
+        type: software
+        url: https://example.org/software
+        repository-code: https://github.com/example/software
+        license: MIT
+    """)
+    out = parse_citation_cff(doc)
+    assert out is not None
+    assert out["cff-version"] == "1.2.0"
+    assert out["title"] == "My Software"
+    assert out["message"] == "Please cite this software."
+    assert out["version"] == "1.2.3"
+    assert out["date-released"] == "2024-05-01"
+    assert out["type"] == "software"
+    assert out["url"] == "https://example.org/software"
+    assert out["repository-code"] == "https://github.com/example/software"
+    assert out["license"] == "MIT"
+
+
+def test_parses_keywords_as_list():
+    out = parse_citation_cff(
+        "cff-version: '1.2.0'\nkeywords:\n  - bioinformatics\n  - cryo-em\n",
+    )
+    assert out["keywords"] == ["bioinformatics", "cryo-em"]
+
+
+def test_release_date_object_is_coerced_to_iso_string():
+    """PyYAML decodes `YYYY-MM-DD` literals into `datetime.date` objects.
+    The parser must coerce back to an ISO string so downstream
+    consumers don't have to handle two types."""
+    out = parse_citation_cff(
+        "cff-version: '1.2.0'\ndate-released: 2024-05-01\n",
+    )
+    assert out["date-released"] == "2024-05-01"
+
+
+# ---------------------------------------------------------------------------
+# Authors / contacts (Person vs Entity discrimination)
+# ---------------------------------------------------------------------------
+
+
+def test_parses_person_authors_with_full_field_set():
+    doc = textwrap.dedent("""
+        cff-version: '1.2.0'
+        authors:
+          - given-names: Jane
+            family-names: Doe
+            orcid: https://orcid.org/0000-0001-2345-6789
+            email: jane@example.org
+            affiliation: EPFL
+            website: https://jane.example
+    """)
+    out = parse_citation_cff(doc)
+    a = out["authors"][0]
+    assert a["__kind__"] == "person"
+    assert a["given-names"] == "Jane"
+    assert a["family-names"] == "Doe"
+    assert a["orcid"] == "https://orcid.org/0000-0001-2345-6789"
+    assert a["email"] == "jane@example.org"
+    assert a["affiliation"] == "EPFL"
+    assert a["website"] == "https://jane.example"
+
+
+def test_parses_entity_authors_with_entity_kind_tag():
+    """Authors can also be Entities (organizations / groups) — keyed by
+    `name` instead of given/family-names. The `__kind__` tag is how
+    downstream consumers tell the two apart without re-deriving."""
+    doc = textwrap.dedent("""
+        cff-version: '1.2.0'
+        authors:
+          - name: EPFL Center for Imaging
+            website: https://imaging.epfl.ch
+            country: CH
+    """)
+    out = parse_citation_cff(doc)
+    e = out["authors"][0]
+    assert e["__kind__"] == "entity"
+    assert e["name"] == "EPFL Center for Imaging"
+    assert e["website"] == "https://imaging.epfl.ch"
+    assert e["country"] == "CH"
+
+
+def test_drops_authors_with_neither_name_shape():
+    """An author dict with no name fields at all is malformed per spec;
+    drop it rather than emitting an empty record."""
+    doc = textwrap.dedent("""
+        cff-version: '1.2.0'
+        authors:
+          - given-names: Real Person
+          - email: no-name@example.org
+          - orcid: https://orcid.org/0000-0001-2345-6789
+    """)
+    out = parse_citation_cff(doc)
+    # Only the first author has a usable name; the other two are dropped.
+    assert len(out["authors"]) == 1
+    assert out["authors"][0]["given-names"] == "Real Person"
+
+
+def test_parses_contact_list_like_authors():
+    out = parse_citation_cff(textwrap.dedent("""
+        cff-version: '1.2.0'
+        contact:
+          - given-names: Bob
+            family-names: Smith
+            email: bob@example.org
+    """))
+    assert out["contact"][0]["email"] == "bob@example.org"
+    assert out["contact"][0]["__kind__"] == "person"
+
+
+# ---------------------------------------------------------------------------
+# Identifiers (DOI / URL / SWH / other) + legacy `doi` promotion
+# ---------------------------------------------------------------------------
+
+
+def test_parses_identifiers_with_type_and_value():
+    """DOI values are canonicalised to `https://doi.org/<bare>` via the
+    shared `doi_iri` helper. URL and SWH identifiers pass through
+    verbatim."""
+    doc = textwrap.dedent("""
+        cff-version: '1.2.0'
+        identifiers:
+          - type: doi
+            value: 10.5281/zenodo.123456
+            description: Software DOI
+          - type: url
+            value: https://example.org/canonical
+          - type: swh
+            value: swh:1:dir:abc123
+    """)
+    out = parse_citation_cff(doc)
+    idents = out["identifiers"]
+    assert {i["type"] for i in idents} == {"doi", "url", "swh"}
+    doi = next(i for i in idents if i["type"] == "doi")
+    assert doi["value"] == "https://doi.org/10.5281/zenodo.123456"
+    assert doi["description"] == "Software DOI"
+    # URL identifiers pass through unchanged.
+    url = next(i for i in idents if i["type"] == "url")
+    assert url["value"] == "https://example.org/canonical"
+
+
+def test_doi_canonicalisation_handles_every_input_shape():
+    """`doi_iri` accepts bare DOIs, `doi:`-prefixed, legacy
+    `dx.doi.org` host, and already-canonical URLs. The parser must
+    use it uniformly across every DOI source — `identifiers[type=doi]`,
+    legacy top-level `doi`, `preferred-citation.doi`, and `references[].doi`."""
+    out = parse_citation_cff(textwrap.dedent("""
+        cff-version: '1.2.0'
+        identifiers:
+          - type: doi
+            value: 10.5281/zenodo.AAA
+          - type: doi
+            value: doi:10.5281/zenodo.BBB
+          - type: doi
+            value: https://dx.doi.org/10.5281/zenodo.CCC
+          - type: doi
+            value: https://doi.org/10.5281/zenodo.DDD
+        preferred-citation:
+          type: article
+          title: Paper
+          doi: 10.1234/paper.bare
+        references:
+          - type: article
+            title: Ref
+            doi: doi:10.9999/ref.prefixed
+    """))
+    doi_values = [
+        i["value"] for i in out["identifiers"] if i["type"] == "doi"
+    ]
+    assert doi_values == [
+        "https://doi.org/10.5281/zenodo.AAA",
+        "https://doi.org/10.5281/zenodo.BBB",
+        "https://doi.org/10.5281/zenodo.CCC",
+        "https://doi.org/10.5281/zenodo.DDD",
+    ]
+    assert out["preferred-citation"]["doi"] == "https://doi.org/10.1234/paper.bare"
+    assert out["references"][0]["doi"] == "https://doi.org/10.9999/ref.prefixed"
+
+
+def test_legacy_doi_field_promotes_into_identifiers():
+    """v1.0/1.1 used a top-level `doi` field; v1.2 moved it into
+    `identifiers`. Real-world CITATION.cff files still ship both
+    shapes — we promote the legacy form so downstream code can iterate
+    `identifiers` uniformly. The promoted entry is also canonicalised
+    to the URL form."""
+    out = parse_citation_cff(textwrap.dedent("""
+        cff-version: '1.2.0'
+        doi: 10.5281/zenodo.999
+    """))
+    # Top-level `doi` canonicalised to URL form (was bare in YAML).
+    assert out["doi"] == "https://doi.org/10.5281/zenodo.999"
+    # AND promoted into identifiers as a synthetic doi entry, also URL form.
+    promoted = next(i for i in out["identifiers"] if i["type"] == "doi")
+    assert promoted["value"] == "https://doi.org/10.5281/zenodo.999"
+
+
+def test_legacy_doi_not_duplicated_when_already_in_identifiers():
+    """If `identifiers` already contains the same DOI (in any form),
+    the canonical comparison post-promotion still de-dups."""
+    out = parse_citation_cff(textwrap.dedent("""
+        cff-version: '1.2.0'
+        doi: 10.5281/zenodo.999
+        identifiers:
+          - type: doi
+            value: 10.5281/zenodo.999
+    """))
+    dois = [i for i in out["identifiers"] if i["type"] == "doi"]
+    assert len(dois) == 1
+    assert dois[0]["value"] == "https://doi.org/10.5281/zenodo.999"
+
+
+# ---------------------------------------------------------------------------
+# preferred-citation + references
+# ---------------------------------------------------------------------------
+
+
+def test_parses_preferred_citation_with_authors_and_doi():
+    doc = textwrap.dedent("""
+        cff-version: '1.2.0'
+        preferred-citation:
+          type: article
+          title: A Paper About The Software
+          doi: 10.1234/paper.example
+          year: 2024
+          journal: Journal of Examples
+          authors:
+            - given-names: Jane
+              family-names: Doe
+              orcid: https://orcid.org/0000-0001-2345-6789
+    """)
+    out = parse_citation_cff(doc)
+    pc = out["preferred-citation"]
+    assert pc["type"] == "article"
+    assert pc["title"] == "A Paper About The Software"
+    assert pc["doi"] == "https://doi.org/10.1234/paper.example"
+    assert pc["year"] == "2024"
+    assert pc["journal"] == "Journal of Examples"
+    assert pc["authors"][0]["given-names"] == "Jane"
+
+
+def test_parses_references_list():
+    doc = textwrap.dedent("""
+        cff-version: '1.2.0'
+        references:
+          - type: article
+            title: First reference
+            doi: 10.1234/first
+          - type: conference-paper
+            title: Second reference
+            year: 2023
+    """)
+    out = parse_citation_cff(doc)
+    refs = out["references"]
+    assert len(refs) == 2
+    assert refs[0]["doi"] == "https://doi.org/10.1234/first"
+    assert refs[1]["year"] == "2023"
+
+
+# ---------------------------------------------------------------------------
+# Robustness against malformed sub-trees
+# ---------------------------------------------------------------------------
+
+
+def test_skips_malformed_subtree_without_failing_whole_parse():
+    """A wrong-shape `authors` field (string instead of list) drops
+    just that field — the rest of the doc still surfaces."""
+    out = parse_citation_cff(textwrap.dedent("""
+        cff-version: '1.2.0'
+        title: foo
+        authors: "this should be a list"
+        license: MIT
+    """))
+    assert out["title"] == "foo"
+    assert out["license"] == "MIT"
+    assert "authors" not in out
+
+
+# ---------------------------------------------------------------------------
+# Real-world fixture: sdsc-ordes/gimie
+# ---------------------------------------------------------------------------
+
+
+def test_parses_real_world_gimie_citation_cff():
+    """Pinned snapshot of `sdsc-ordes/gimie/CITATION.cff` to catch
+    spec drift. Verifies all six authors, all five keywords, and the
+    full set of populated top-level fields."""
+    from pathlib import Path
+
+    fixture = (
+        Path(__file__).parent
+        / "fixtures"
+        / "citation_cff_gimie.cff"
+    )
+    out = parse_citation_cff(fixture.read_text(encoding="utf-8"))
+    assert out is not None
+
+    assert out["cff-version"] == "1.2.0"
+    assert out["title"] == "gimie"
+    assert out["type"] == "software"
+    assert out["repository-code"] == "https://github.com/sdsc-ordes/gimie"
+    assert out["abstract"] == "Extract linked metadata from repositories"
+    assert out["license"] == "Apache-2.0"
+    assert "message" in out  # multi-line `>-` block scalar
+
+    # 6 authors, all Persons (Cyril, Sabine, Robin, Martin, Laure, Stefan).
+    assert len(out["authors"]) == 6
+    cyril = next(
+        a for a in out["authors"] if a.get("given-names") == "Cyril"
+    )
+    assert cyril["family-names"] == "Matthey-Doret"
+    assert cyril["affiliation"] == "Swiss Data Science Center"
+    assert cyril["orcid"] == "https://orcid.org/0000-0002-1126-1535"
+    assert cyril["__kind__"] == "person"
+
+    # One author has email (Stefan) — verify the field surfaces.
+    stefan = next(
+        a for a in out["authors"] if a.get("given-names") == "Stefan"
+    )
+    assert stefan["email"] == "supermegaiperste@hotmail.com"
+
+    # Keywords list intact.
+    assert out["keywords"] == [
+        "git", "cli", "library", "linked-open-data",
+        "metadata-extraction", "fair-data", "scientific-software",
+    ]


### PR DESCRIPTION
Layer 1 of the CITATION.cff integration — pure parser, mirrors the publiccode.yml work (#83). The Citation File Format (`https:// citation-file-format.github.io/`) is the community standard for how to cite software; every well-cited research-software repo on GitHub ships a CITATION.cff at root. The format carries strong identity signal the pipeline previously had to extract from README prose:

  - canonical project title, version, release date, license,
  - software DOI(s) + URL identifiers + Software Heritage ID,
  - author list with full names, ORCIDs, emails, affiliations,
  - the `preferred-citation` block (paper that introduces the software, typically with its own DOI),
  - cross-references in `references[]`.

What this commit ships:

  - `src/v2/parsers/citation_cff.py` (`parse_citation_cff(content) -> dict | None`): full v1.2.0 schema parser. Authors / contacts / references each tagged `__kind__ = "person" | "entity"` so callers don't have to re-derive Person/Entity discrimination from field presence. The deprecated v1.0/1.1 top-level `doi` field is promoted into `identifiers` so downstream walks one canonical shape. Lenient — malformed sub-trees drop, never fails the whole parse.
  - DOI canonicalisation throughout: every DOI value the parser surfaces (`identifiers[type=doi]`, legacy top-level `doi`, `preferred-citation.doi`, `references[].doi`) is promoted to `https://doi.org/<bare>` via the shared `src.index._shared.doi.doi_iri` helper already used by every index catalog. Tolerates bare / doi-prefixed / legacy `dx.doi.org` / trailing-slash inputs. Idempotent.
  - Repository agent now emits `_citation_cff` (parsed dict, or None when no CITATION.cff at root). Companion to the existing `_citation_cff_url` URL pointer.
  - `refine_with_llm._build_repo_context_summary` carries the parsed `citation_cff` payload to LLM refiners alongside the raw excerpt (LLM gets both — typed access plus verbatim-quotable text).

What this commit does NOT do (Layer 2 — separate PR):

  - No automatic enrichment of `schema:*` fields. CITATION.cff fields map cleanly to schema.org (`title` → `schema:name`, `authors[]` → `schema:author`, `identifiers[type=doi]` → `schema:citation`, `date-released` → `schema:dateCreated`, etc.), but promoting them onto the Repository entity is a policy decision (does CITATION.cff trump what agents emitted?). That belongs in a follow-up `enrich_repo_from_citation_cff` stage with its own precedence rules.

Real-world fixture pinned: sdsc-ordes/gimie's CITATION.cff (6 authors, all SDSC-affiliated, with ORCIDs + one email + 7 keywords). Regression: 962 passed / 1 skipped (up from 943 on develop, +19 from the new tests).