### PR TITLE
feat(repository): surface SECURITY.md URL pointer + LLM context excerpt

### DIFF
--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -43,6 +43,11 @@ _REPO_AUX_FILE_LOOKUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     # ships in a handful of older research projects.
     ("_contributing_url",  ("contributing.md", "contribution.md")),
     ("_publiccode_url",    ("publiccode.yml", "publiccode.yaml")),
+    # SECURITY.md — GitHub's first-class security policy file. Surfacing
+    # this lets dashboards flag repos with explicit vulnerability-
+    # reporting guidance separately from undocumented ones, and gives
+    # LLM agents a place to read for embargo / disclosure timelines.
+    ("_security_url",      ("security.md",)),
 )
 
 

--- a/src/v2/pipeline/stages/refine_with_llm.py
+++ b/src/v2/pipeline/stages/refine_with_llm.py
@@ -86,6 +86,7 @@ _AUX_FILE_CONTEXT_LOOKUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("authors",       ("authors", "authors.md", "authors.rst", "authors.txt")),
     ("contributing",  ("contributing.md", "contribution.md")),
     ("publiccode",    ("publiccode.yml", "publiccode.yaml")),
+    ("security",      ("security.md",)),
 )
 DEFAULT_MAX_CONCURRENCY = 4
 

--- a/tests/v2/test_refine_with_llm_aux_files.py
+++ b/tests/v2/test_refine_with_llm_aux_files.py
@@ -31,21 +31,25 @@ def _wrap_context(aux_files: dict[str, str] | None) -> dict[str, dict[str, objec
     }
 
 
-def test_summary_forwards_all_four_aux_files_when_present():
+def test_summary_forwards_all_aux_files_when_present():
     summary = _build_repo_context_summary(
         gathered_context=_wrap_context({
             "CITATION.cff": "cff-version: 1.2.0\nauthors:\n - given-names: Octo",
             "AUTHORS.md": "- Octo Cat\n- Alice",
             "CONTRIBUTING.md": "Open a PR.",
             "publiccode.yml": "publiccodeYmlVersion: '0.4'",
+            "SECURITY.md": "Report vulnerabilities to security@example.com.",
         }),
     )
     aux = summary["aux_files"]
-    assert set(aux.keys()) == {"citation_cff", "authors", "contributing", "publiccode"}
+    assert set(aux.keys()) == {
+        "citation_cff", "authors", "contributing", "publiccode", "security",
+    }
     assert aux["citation_cff"].startswith("cff-version:")
     assert aux["authors"].startswith("- Octo")
     assert aux["contributing"] == "Open a PR."
     assert aux["publiccode"].startswith("publiccodeYmlVersion:")
+    assert aux["security"].startswith("Report vulnerabilities")
 
 
 def test_summary_case_insensitive_match():

--- a/tests/v2/test_repository_agent.py
+++ b/tests/v2/test_repository_agent.py
@@ -191,6 +191,7 @@ def test_repository_agent_emits_aux_file_urls_for_present_files() -> None:
                         "AUTHORS.md": "- Octo Cat",
                         "CONTRIBUTING.md": "Open a PR.",
                         "publiccode.yaml": "publiccodeYmlVersion: '0.4'",
+                        "SECURITY.md": "Report vulnerabilities to security@example.com.",
                     },
                 },
             },
@@ -203,6 +204,7 @@ def test_repository_agent_emits_aux_file_urls_for_present_files() -> None:
     assert raw["_authors_url"] == "https://github.com/octocat/Hello-World/blob/HEAD/AUTHORS.md"
     assert raw["_contributing_url"] == "https://github.com/octocat/Hello-World/blob/HEAD/CONTRIBUTING.md"
     assert raw["_publiccode_url"] == "https://github.com/octocat/Hello-World/blob/HEAD/publiccode.yaml"
+    assert raw["_security_url"] == "https://github.com/octocat/Hello-World/blob/HEAD/SECURITY.md"
 
 
 def test_repository_agent_emits_none_for_absent_aux_files() -> None:
@@ -241,6 +243,7 @@ def test_repository_agent_emits_none_for_absent_aux_files() -> None:
     assert raw["_authors_url"] is None
     assert raw["_contributing_url"] is None
     assert raw["_publiccode_url"] is None
+    assert raw["_security_url"] is None
 
 
 def test_repository_agent_parses_publiccode_into_internal_field() -> None:


### PR DESCRIPTION
`security.md` was already in the GitHub provider's `_AUX_FILE_PATTERNS` (so the content was being fetched for free) but nothing surfaced it on the Repository entity or to LLM refiners.

This commit closes that loop:

  - New `_security_url` internal field on every Repository, pointing at `https://github.com/<owner>/<repo>/blob/HEAD/SECURITY.md` when the file exists at repo root (`None` otherwise — explicit absence is queryable so dashboards can flag repos without a published security policy).
  - `refine_with_llm._build_repo_context_summary` now forwards a 4 KB excerpt of SECURITY.md to LLM refiners alongside the existing citation / authors / contributing / publiccode slugs, under the `security` key. LLM agents that handle disclosure / embargo / contact-extraction can quote it verbatim.

No new env var. No new provider call. Just exposing data we were already pulling.

Tests: extended the existing aux-file-URL fixture in `tests/v2/test_repository_agent.py` (present + absent assertions) and `tests/v2/test_refine_with_llm_aux_files.py` (slug + content assertion).