### PR TITLE
fix(v2 indices): freshness + fail-soft search for CLI catalogs (ror/snsf/infoscience/ethz)

### DIFF
--- a/scripts/v2/reingest_indices.py
+++ b/scripts/v2/reingest_indices.py
@@ -20,6 +20,25 @@ resets them and skips ingest with an explanatory log line.
 
 Designed to be safe to re-run: the only destructive action is the
 explicit ``DELETE`` reset, which can be skipped with ``--no-reset``.
+
+Why HTTP and not ``python -m src.index.<provider> ingest``
+----------------------------------------------------------
+DuckDB allows **N readers OR one writer**, and the running GME keeps a
+long-lived read-WRITE handle cached on ``app.state`` for every index it
+serves (``github_repos``, ``huggingface_models``, ``zenodo_records``,
+…). A standalone ``python -m src.index.<provider> ingest`` is a
+*separate process*: it would try to open the same DuckDB read-write and
+fail with ``Could not set lock on file`` — so re-ingesting via the CLI
+forces you to **stop GME for the whole ingest (hours)**.
+
+This driver avoids that entirely. It posts to
+``POST /v2/indices/{provider}/ingest``, whose job runner writes through
+GME's *already-open* cached handle **in-process** — same lock, no
+contention — so the API keeps serving reads (and publishes a refreshed
+``.ro.duckdb`` snapshot) throughout. **Re-ingest the 17 HTTP-ingest
+providers this way with zero downtime; never run their per-process CLIs
+against a live GME.** The 5 reset-only catalogs above have no in-process
+ingest route yet, so they remain CLI/batch-driven.
 """
 
 from __future__ import annotations

--- a/src/v2/indices/cli_catalogs.py
+++ b/src/v2/indices/cli_catalogs.py
@@ -83,7 +83,11 @@ async def run_ror_search(
     except Exception as exc:  # noqa: BLE001
         LOGGER.warning("ror search: config init failed — %s", exc)
         return None
-    records = await query_rag(cfg, payload.query, top_k=payload.top_k)
+    try:
+        records = await query_rag(cfg, payload.query, top_k=payload.top_k)
+    except Exception as exc:  # noqa: BLE001 — Qdrant/backend down → fail soft to 503
+        LOGGER.warning("ror search: query backend unavailable — %s", exc)
+        return None
     return IndexSearchResponse(
         index_name="ror",
         target=payload.target,
@@ -112,7 +116,11 @@ async def run_snsf_search(
     except Exception as exc:  # noqa: BLE001
         LOGGER.warning("snsf search: config init failed — %s", exc)
         return None
-    records = await query_rag(cfg, payload.query, top_k=payload.top_k)
+    try:
+        records = await query_rag(cfg, payload.query, top_k=payload.top_k)
+    except Exception as exc:  # noqa: BLE001 — Qdrant/backend down → fail soft to 503
+        LOGGER.warning("snsf search: query backend unavailable — %s", exc)
+        return None
     return IndexSearchResponse(
         index_name="snsf",
         target=payload.target,
@@ -158,6 +166,9 @@ async def run_infoscience_search(
             hits=[],
             extra={"error": str(exc)},
         )
+    except Exception as exc:  # noqa: BLE001 — Qdrant/backend down → fail soft to 503
+        LOGGER.warning("infoscience search: query backend unavailable — %s", exc)
+        return None
     records: Iterable[Any]
     if hasattr(result, "results"):
         records = result.results

--- a/src/v2/indices/stats.py
+++ b/src/v2/indices/stats.py
@@ -241,12 +241,12 @@ def fetch_store_for_stats(provider: str, app_state: Any) -> Any | None:
     if provider == "ethz_research_collection":
         try:
             from src.index.ethz_research_collection.storage import (  # noqa: PLC0415
-                DuckDBStore,
+                EthzResearchCollectionStore,
             )
         except Exception:  # noqa: BLE001 — optional dependency
             return None
         try:
-            return DuckDBStore.open()
+            return EthzResearchCollectionStore.open()
         except Exception:  # noqa: BLE001 — config / disk issues
             return None
 
@@ -255,17 +255,17 @@ def fetch_store_for_stats(provider: str, app_state: Any) -> Any | None:
     if provider == "ror":
         return _cli_store(
             app_state, "v2_ror_store",
-            "src.index.ror.storage.duckdb_store", "DuckDBStore",
+            "src.index.ror.storage.duckdb_store", "RorStore",
         )
     if provider == "infoscience":
         return _cli_store(
             app_state, "v2_infoscience_store",
-            "src.index.infoscience.storage.duckdb_store", "DuckDBStore",
+            "src.index.infoscience.storage.duckdb_store", "InfoscienceStore",
         )
     if provider == "snsf":
         return _cli_store(
             app_state, "v2_snsf_store",
-            "src.index.snsf.storage.duckdb_store", "DuckDBStore",
+            "src.index.snsf.storage.duckdb_store", "SnsfStore",
         )
     if provider == "epfl_graph":
         return _cli_store(


### PR DESCRIPTION
Two 3.0.0rc1 regressions on the CLI-managed catalogs + a re-ingest ops note.

## Freshness=0 despite intact data (confirmed bug)
`stats.fetch_store_for_stats` still asked for the old class name `DuckDBStore`, but the stores were renamed: `RorStore` / `SnsfStore` / `InfoscienceStore` / `EthzResearchCollectionStore`. `getattr` raised `AttributeError`, the wide `_cli_store` except swallowed it → `None` → count=0. GME never opened the store. Fixed to the real names (`epfl_graph` already used its renamed `EpflGraphStore`, hence unaffected). **Verified: ror reports 301386 rows instead of 0.**

## Search returned non-JSON
`run_{ror,snsf,infoscience}_search` left `await query_rag(...)` unguarded → a Qdrant/backend failure propagated as an unhandled 500 (non-JSON body). Wrapped so a backend outage fails soft to the existing **503 JSON** (`index module unavailable on this deployment`).

## Re-ingest without downtime (docs)
Documented in `reingest_indices.py` why re-ingest must go through `POST /v2/indices/<p>/ingest` (writes on GME's cached RW handle, in-process, zero downtime) instead of the per-process `python -m src.index.<p> ingest` CLIs, which deadlock on the DuckDB write lock.

## Verification
48 targeted tests (stats / cli_catalogs / indices) green.

## Known follow-up (not in this PR)
The non-JSON search may have a deeper cause (Qdrant collection absent/renamed for these 4 in this deploy). This PR makes search fail soft; populating results needs the deploy's actual error body.