### PR TITLE
fix: LLM call timeout (#1) + migration snapshot republish (#2) + ship scripts/ in image (#8)

### DIFF
--- a/scripts/v2/migrate_monolith_to_split.py
+++ b/scripts/v2/migrate_monolith_to_split.py
@@ -234,9 +234,30 @@ def _migrate_provider(plan: ProviderPlan, *, apply: bool) -> list[TableResult] |
         results = [
             _copy_table(conn, ot, nt, apply=apply) for ot, nt in plan.tables
         ]
+        if apply and any(r.inserted for r in results):
+            _publish_snapshot(conn, new_path)
     finally:
         conn.close()
     return results
+
+
+def _publish_snapshot(conn: duckdb.DuckDBPyConnection, live_path: Path) -> None:
+    """Refresh the store's ``.ro.duckdb`` snapshot the Hub reads from.
+
+    The split DuckDB is the live (writer) file; the Hub serves the RO
+    snapshot, so a migration that writes the live file but skips the
+    snapshot leaves the Hub on stale data. Forced (no debounce) because
+    this is a one-shot bulk mutation that must publish immediately.
+    """
+    from src.index._snapshot import publish_snapshot, snapshot_path_for  # noqa: PLC0415
+
+    result = publish_snapshot(conn, live_path, force=True)
+    if result.get("published"):
+        print(f"    snapshot republished: {snapshot_path_for(live_path).name}")
+    elif result.get("enabled") is False:
+        print("    snapshot skipped (INDEX_DUCKDB_SNAPSHOT disabled)")
+    else:
+        print(f"    snapshot: {result}")
 
 
 def _run_embed(plan: ProviderPlan, *, force: bool) -> str:
@@ -293,6 +314,11 @@ def _run_embed(plan: ProviderPlan, *, force: bool) -> str:
     store = store_cls.open(cfg.paths.duckdb_path)
     try:
         summary: Any = embed_fn(config=cfg, store=store)
+        # Embed wrote new `chunks` rows (skipped from the snapshot) but also
+        # confirms the store is current; republish so the Hub's RO snapshot
+        # reflects this store even when the copy phase ran under an older
+        # script that didn't snapshot.
+        _publish_snapshot(store.connect(), Path(cfg.paths.duckdb_path))
     finally:
         close = getattr(store, "close", None)
         if callable(close):

--- a/src/index/_snapshot.py
+++ b/src/index/_snapshot.py
@@ -71,12 +71,17 @@ def publish_snapshot(
     live_path: Path,
     *,
     skip_tables: frozenset[str] = SNAPSHOT_SKIP_TABLES,
+    force: bool = False,
 ) -> dict[str, Any]:
     """Publish a read-only snapshot of ``live_path``'s data tables.
 
     ``conn`` is the live (writer) connection to ``live_path``; the copy is
     made through it so it sees committed data. Best-effort: any failure is
     logged and returned, never raised. Returns a small status dict.
+
+    ``force`` bypasses the min-interval debounce — use it for one-shot bulk
+    mutations (e.g. a migration) that must publish immediately regardless of
+    how recently a snapshot was written.
     """
     if not _enabled():
         return {"enabled": False}
@@ -85,7 +90,7 @@ def publish_snapshot(
     snap = snapshot_path_for(live_path)
 
     interval = _min_interval_seconds()
-    if interval > 0 and snap.exists():
+    if not force and interval > 0 and snap.exists():
         try:
             if (time.time() - snap.stat().st_mtime) < interval:
                 return {"enabled": True, "published": False, "reason": "debounced"}

--- a/src/v2/agents/llm/runtime.py
+++ b/src/v2/agents/llm/runtime.py
@@ -112,6 +112,30 @@ def _coerce_positive_int_env(name: str, fallback: int) -> int:
     return max(1, value)
 
 
+_DEFAULT_LLM_TIMEOUT_SECONDS = 120.0
+_LLM_TIMEOUT_ENV = "V2_LLM_TIMEOUT_SECONDS"
+
+
+def _default_timeout_seconds() -> float:
+    """Per-request timeout floor for the LLM chat call.
+
+    Without it, a chat request to an unreachable/misconfigured provider
+    (empty key, wrong base_url, dead host) blocks the agent — and the single
+    extract worker — *forever*: the job never returns and can't be cancelled.
+    Applying a default per-request timeout turns that into a bounded failure
+    (the call raises, surfaced as an LLM runtime error) so the worker frees.
+    Tunable via ``V2_LLM_TIMEOUT_SECONDS``.
+    """
+    raw = os.getenv(_LLM_TIMEOUT_ENV)
+    if raw is None:
+        return _DEFAULT_LLM_TIMEOUT_SECONDS
+    try:
+        value = float(raw.strip())
+    except ValueError:
+        return _DEFAULT_LLM_TIMEOUT_SECONDS
+    return value if value > 0 else _DEFAULT_LLM_TIMEOUT_SECONDS
+
+
 def _default_usage_limits() -> UsageLimits:
     """Per-agent caps on LLM roundtrips and tool calls.
 
@@ -242,6 +266,10 @@ class V2LLMRuntime:
             timeout = config.get("timeout")
             if isinstance(timeout, (int, float)) and timeout > 0:
                 model_parameters["timeout"] = float(timeout)
+            else:
+                # No explicit per-config timeout → apply a default so a stuck
+                # provider call can't hang the worker forever (see #1).
+                model_parameters["timeout"] = _default_timeout_seconds()
             # Pass model tuning knobs only when the backend supports the kwarg.
             if model_parameters and "model_settings" in run_parameters:
                 run_kwargs["model_settings"] = model_parameters

--- a/tools/image/Dockerfile
+++ b/tools/image/Dockerfile
@@ -24,6 +24,10 @@ COPY src ./src
 # index provider fails `load_config()` and silently disables itself.
 # Deploy-specific values (Qdrant URL, tokens, scope) stay env-overridable.
 COPY config ./config
+# Ship operational scripts (e.g. scripts/v2/migrate_monolith_to_split.py) so
+# operators can run migrations/re-ingest inside the container without
+# bind-mounting them from a checkout.
+COPY scripts ./scripts
 COPY pyproject.toml .
 COPY tools/config/gunicorn_conf.py ./gunicorn_conf.py
 


### PR DESCRIPTION
Addresses three findings from the Hub-side field report (2026-06-03).

**#1 [bug] LLM runtime hung forever on a misconfigured/unreachable provider.** The chat call only got a timeout when the model config carried one; otherwise `agent.run()` blocked the single extract worker indefinitely (no error, no cancel route). Now applies a default per-request timeout (120s, override `V2_LLM_TIMEOUT_SECONDS`) so a stuck provider fails bounded.

**#2 [gap] Migration didn't republish the `.ro.duckdb` snapshot.** The Hub reads the RO snapshot, so a migration that filled the live store left the Hub on stale data. Now republishes (forced, debounce-bypassed) after the copy phase and after embed; adds `force=` to `publish_snapshot`. Verified: spaces `.ro.duckdb` 0/missing → 71.

**#8 [minor] `scripts/` absent from the image.** `tools/image/Dockerfile` shipped only `src/`+`config/`; now `COPY scripts ./scripts` so the migration driver ships.

Verified: 12 targeted tests (snapshot / embed-step / llm agent) green.

Remaining report items (cancel endpoint + per-request model override from #1; #4 #5 #6 #7 #9) triaged separately — not in this PR.