### PR TITLE
feat(v2 extract): per-request model override + job cancel endpoint (#1b)

### DIFF
--- a/src/v2/agents/llm/runtime.py
+++ b/src/v2/agents/llm/runtime.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import logging
 import os
+from contextvars import ContextVar
 from dataclasses import dataclass
 from time import perf_counter
 from typing import Any
@@ -182,6 +183,62 @@ def _coerce_output_payload(output: Any) -> dict[str, Any]:
     return output
 
 
+# --- per-request model override --------------------------------------------
+# Lets a single `/v2/extract` call target a different model/provider (e.g. an
+# RCP OpenAI-compatible chat model) without editing the global deploy config.
+# Carried in a ContextVar so it propagates through the async pipeline without
+# threading it down every agent signature. Honored ONLY when
+# `V2_ALLOW_REQUEST_MODEL_OVERRIDE` is truthy, because an override may carry a
+# `base_url`/`api_key_env` (a request pointing the LLM at an arbitrary host /
+# naming an arbitrary env var is a mild SSRF / secret-surface risk that stays
+# opt-in).
+_REQUEST_OVERRIDE_FLAG_ENV = "V2_ALLOW_REQUEST_MODEL_OVERRIDE"
+_OVERRIDABLE_CONFIG_KEYS = ("provider", "model", "base_url", "api_key_env")
+_request_model_override: ContextVar[dict[str, Any] | None] = ContextVar(
+    "v2_request_model_override", default=None,
+)
+
+
+def set_request_model_override(override: dict[str, Any] | None) -> object:
+    """Set the per-request model override; returns the ContextVar token.
+
+    Pass the token to ``reset_request_model_override`` to restore the previous
+    value when the request finishes. Keys outside ``_OVERRIDABLE_CONFIG_KEYS``
+    and empty values are dropped.
+    """
+    cleaned = (
+        {k: v for k, v in override.items() if k in _OVERRIDABLE_CONFIG_KEYS and v}
+        if override
+        else None
+    )
+    return _request_model_override.set(cleaned or None)
+
+
+def reset_request_model_override(token: object) -> None:
+    _request_model_override.reset(token)  # type: ignore[arg-type]
+
+
+def _request_override_enabled() -> bool:
+    raw = os.getenv(_REQUEST_OVERRIDE_FLAG_ENV)
+    return bool(raw) and raw.strip().lower() in _TRUE_ENV_VALUES
+
+
+_TRUE_ENV_VALUES = {"1", "true", "t", "yes", "y", "on"}
+
+
+def _apply_request_override(config: dict[str, Any]) -> dict[str, Any]:
+    """Merge an active, enabled per-request override onto ``config``."""
+    override = _request_model_override.get()
+    if not override or not _request_override_enabled():
+        return config
+    merged = {**config, **override}
+    logger.info(
+        "LLM runtime: applying per-request model override (provider=%s, model=%s)",
+        merged.get("provider"), merged.get("model"),
+    )
+    return merged
+
+
 class V2LLMRuntime:
     def __init__(self, *, analysis_type: str = "run_llm_analysis") -> None:
         self._analysis_type = analysis_type
@@ -199,6 +256,9 @@ class V2LLMRuntime:
 
         for config in configs:
             if isinstance(config, dict) and validate_config(config):
+                # Apply any enabled per-request override before the credential
+                # check so the overridden api_key_env is what gets validated.
+                config = _apply_request_override(config)
                 # Surface missing credentials by env var name only.
                 missing_env_vars = [
                     env_name

--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -23,6 +23,10 @@ from rdflib import Graph as RDFGraph
 
 from src.v2.agents import AgentRuntime, ProviderSet, parse_agent_runtime
 from src.v2.agents.llm.refiners.ror_parent.agent import RorParentSelectorAgent
+from src.v2.agents.llm.runtime import (
+    reset_request_model_override,
+    set_request_model_override,
+)
 from src.v2.api_models import (
     DockerhubIngestRequest,
     EthzResearchCollectionIngestRequest,
@@ -442,6 +446,15 @@ def _resolve_job_store(request: Request) -> JobStore | None:
     return JobStore(cache)
 
 
+_TERMINAL_JOB_STATUSES = frozenset(
+    {
+        V2ExtractJobStatus.COMPLETED,
+        V2ExtractJobStatus.FAILED,
+        V2ExtractJobStatus.CANCELLED,
+    },
+)
+
+
 def _track_background_task(request: Request, task: asyncio.Task[Any]) -> None:
     """Hold a strong reference to a background task so it isn't GC'd mid-flight."""
     tasks: set[asyncio.Task[Any]] | None = getattr(
@@ -454,6 +467,25 @@ def _track_background_task(request: Request, task: asyncio.Task[Any]) -> None:
         request.app.state._v2_job_tasks = tasks  # noqa: SLF001
     tasks.add(task)
     task.add_done_callback(tasks.discard)
+
+
+def _register_job_task(request: Request, job_id: str, task: asyncio.Task[Any]) -> None:
+    """Index a running extract job's task by job id so it can be cancelled."""
+    registry: dict[str, asyncio.Task[Any]] | None = getattr(
+        request.app.state, "_v2_job_task_by_id", None,
+    )
+    if registry is None:
+        registry = {}
+        request.app.state._v2_job_task_by_id = registry  # noqa: SLF001
+    registry[job_id] = task
+    task.add_done_callback(lambda _t: registry.pop(job_id, None))
+
+
+def _get_job_task(request: Request, job_id: str) -> asyncio.Task[Any] | None:
+    registry = getattr(request.app.state, "_v2_job_task_by_id", None)
+    if not isinstance(registry, dict):
+        return None
+    return registry.get(job_id)
 
 
 def _job_status_path(job_id: str) -> str:
@@ -474,6 +506,11 @@ async def _run_extract_job(
     success/error result onto the persisted V2ExtractJob record.
     """
     heartbeat_task: asyncio.Task[Any] | None = None
+    override_token = set_request_model_override(
+        payload.model_override.model_dump(exclude_none=True)
+        if payload.model_override is not None
+        else None,
+    )
     try:
         existing = job_store.get(job_id)
         if existing is None:
@@ -534,6 +571,17 @@ async def _run_extract_job(
                     source_url=payload.source_url,
                 )
         job_store.set(finished)
+    except asyncio.CancelledError:
+        # Cooperative cancel via POST /v2/jobs/{id}/cancel (task.cancel()).
+        # Mark the record cancelled, then re-raise so the task ends cleanly.
+        logger.info("extract job %s cancelled", job_id)
+        record = job_store.get(job_id)
+        if record is not None and record.status not in _TERMINAL_JOB_STATUSES:
+            record.status = V2ExtractJobStatus.CANCELLED
+            record.completed_at = datetime.now(timezone.utc)
+            record.last_heartbeat_at = record.completed_at
+            job_store.set(record)
+        raise
     except Exception as exc:
         logger.exception("extract job %s failed", job_id)
         record = job_store.get(job_id)
@@ -549,6 +597,7 @@ async def _run_extract_job(
         )
         job_store.set(record)
     finally:
+        reset_request_model_override(override_token)
         if heartbeat_task is not None:
             heartbeat_task.cancel()
             with contextlib.suppress(Exception):
@@ -2221,6 +2270,7 @@ async def extract_post(
         ),
     )
     _track_background_task(request, task)
+    _register_job_task(request, job_id, task)
 
     logger.info(
         "extract job submitted: job_id=%s url=%s detected_type=%s",
@@ -2323,6 +2373,50 @@ async def extract_job(
     """Retrieve a previously submitted extraction job (full record + graph)."""
 
     return _resolve_extract_record(request, job_id)
+
+
+@v2_router.post(
+    "/jobs/{job_id}/cancel",
+    response_model=V2ExtractJob,
+    response_model_exclude_none=True,
+    tags=["Extraction"],
+)
+async def cancel_extract_job(
+    job_id: Annotated[str, Path(description="Job id returned by POST /v2/extract.")],
+    request: Request,
+    _token: Annotated[str, Depends(verify_token)],
+) -> V2ExtractJob | JSONResponse:
+    """Cancel a pending/running extract job and free its worker.
+
+    Cooperative async cancellation: cancels the job's asyncio task (which
+    interrupts the pipeline at its next ``await`` — e.g. an in-flight LLM or
+    HTTP call) and marks the record ``cancelled``. Idempotent: a job already in
+    a terminal state is returned unchanged. 404 if no job matches, 503 if the
+    async job store is unavailable.
+    """
+    resolved = _resolve_extract_record(request, job_id)
+    if isinstance(resolved, JSONResponse):
+        return resolved
+    if resolved.status in _TERMINAL_JOB_STATUSES:
+        return resolved
+
+    task = _get_job_task(request, job_id)
+    if task is not None and not task.done():
+        task.cancel()
+
+    # Mark cancelled immediately for an authoritative response even if the task
+    # is wedged on a blocking call; the task's own CancelledError handler is a
+    # no-op then (status already terminal).
+    job_store = _resolve_job_store(request)
+    if job_store is not None:
+        record = job_store.get(job_id)
+        if record is not None and record.status not in _TERMINAL_JOB_STATUSES:
+            record.status = V2ExtractJobStatus.CANCELLED
+            record.completed_at = datetime.now(timezone.utc)
+            record.last_heartbeat_at = record.completed_at
+            job_store.set(record)
+            resolved = record
+    return resolved
 
 
 @v2_router.get(

--- a/src/v2/api_models/contracts.py
+++ b/src/v2/api_models/contracts.py
@@ -35,6 +35,31 @@ class V2JSONOutputEnvelope(BaseModel):
     entities_by_type: dict[str, list[dict[str, Any]]]
 
 
+class V2ModelOverride(BaseModel):
+    """Per-request LLM model/provider override.
+
+    Only honored when the server sets ``V2_ALLOW_REQUEST_MODEL_OVERRIDE`` (it
+    can carry a ``base_url``/``api_key_env``, a mild SSRF / secret surface that
+    stays opt-in). Lets a single ``/v2/extract`` target a different chat model
+    or endpoint — e.g. an RCP OpenAI-compatible model — without editing the
+    global deploy config. All fields optional; only the provided ones override.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str | None = Field(
+        default=None,
+        description="Provider kind: 'openai', 'openai-compatible', 'openrouter', 'ollama'.",
+    )
+    model: str | None = Field(default=None, description="Model name, e.g. 'Qwen/Qwen3-235B'.")
+    base_url: str | None = Field(
+        default=None, description="OpenAI-compatible base URL (e.g. RCP '/v1').",
+    )
+    api_key_env: str | None = Field(
+        default=None, description="Env var holding the API key (e.g. 'RCP_TOKEN').",
+    )
+
+
 class V2ExtractRequest(BaseModel):
     source_url: str = Field(
         description="GitHub repository, user, or organization URL or handle.",
@@ -64,6 +89,14 @@ class V2ExtractRequest(BaseModel):
             "aren't part of the Open Pulse ontology yet. Strict SHACL "
             "validation still runs identically — this flag only affects what "
             "the consumer sees. Default false for ontology compliance."
+        ),
+    )
+    model_override: V2ModelOverride | None = Field(
+        default=None,
+        description=(
+            "Per-request LLM model/provider override for `llm`/`hybrid` runtimes. "
+            "Only applied when the server enables V2_ALLOW_REQUEST_MODEL_OVERRIDE; "
+            "ignored otherwise. Target a different chat model/endpoint for a single run."
         ),
     )
 
@@ -100,6 +133,7 @@ class V2ExtractJobStatus(str, Enum):
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 class V2ExtractJob(BaseModel):

--- a/tests/v2/test_llm_runtime_adapter.py
+++ b/tests/v2/test_llm_runtime_adapter.py
@@ -175,3 +175,55 @@ def test_llm_runtime_rejects_non_json_string_outputs(
                 user_prompt="user prompt",
             ),
         )
+
+
+# --- per-request model override (#1b) ---------------------------------------
+
+
+def _base_config() -> dict[str, Any]:
+    return {"provider": "openai", "model": "gpt-4o", "api_key_env": "OPENAI_API_KEY"}
+
+
+def test_request_override_ignored_when_flag_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("V2_ALLOW_REQUEST_MODEL_OVERRIDE", raising=False)
+    token = runtime_module.set_request_model_override(
+        {"model": "Qwen/Qwen3", "base_url": "https://rcp/v1", "api_key_env": "RCP_TOKEN"},
+    )
+    try:
+        assert runtime_module._apply_request_override(_base_config()) == _base_config()
+    finally:
+        runtime_module.reset_request_model_override(token)
+
+
+def test_request_override_applied_when_flag_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("V2_ALLOW_REQUEST_MODEL_OVERRIDE", "true")
+    token = runtime_module.set_request_model_override(
+        {
+            "provider": "openai-compatible",
+            "model": "Qwen/Qwen3",
+            "base_url": "https://rcp/v1",
+            "api_key_env": "RCP_TOKEN",
+        },
+    )
+    try:
+        merged = runtime_module._apply_request_override(_base_config())
+    finally:
+        runtime_module.reset_request_model_override(token)
+    assert merged["provider"] == "openai-compatible"
+    assert merged["model"] == "Qwen/Qwen3"
+    assert merged["base_url"] == "https://rcp/v1"
+    assert merged["api_key_env"] == "RCP_TOKEN"
+
+
+def test_request_override_drops_unknown_and_empty_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("V2_ALLOW_REQUEST_MODEL_OVERRIDE", "on")
+    token = runtime_module.set_request_model_override(
+        {"model": "m", "evil": "x", "base_url": ""},
+    )
+    try:
+        merged = runtime_module._apply_request_override(_base_config())
+    finally:
+        runtime_module.reset_request_model_override(token)
+    assert merged["model"] == "m"
+    assert "evil" not in merged  # unknown key dropped
+    assert "base_url" not in merged  # empty override value dropped, base had none


### PR DESCRIPTION
Implements the two feature asks from finding #1.

## Per-request model override
`V2ExtractRequest` gains optional `model_override` (`provider`/`model`/`base_url`/`api_key_env`). It rides a ContextVar through the async pipeline (no signature threading) and is merged onto the resolved LLM config in `_resolve_model_config` **before** the credential check. **Gated by `V2_ALLOW_REQUEST_MODEL_OVERRIDE`** (default off) — `base_url`/`api_key_env` from a request are a mild SSRF/secret surface, so the capability is opt-in. Lets a single run target e.g. an RCP OpenAI-compatible chat model without editing global config.

## Job cancel
`POST /v2/jobs/{job_id}/cancel` cancels the job's asyncio task (interrupts the pipeline at its next `await` — in-flight LLM/HTTP call) and marks the record `cancelled` (new `V2ExtractJobStatus.CANCELLED`). Idempotent on terminal jobs; 404/503 consistent with other job routes. `_run_extract_job` registers its task by id, resets the override in `finally`, and maps `CancelledError` → cancelled (not failed).

Together with the #1 default LLM timeout (already merged), this gives operators a way to both *prevent* (timeout) and *recover from* (cancel) a stuck worker, plus point a run at RCP without a redeploy.

Tests: override gating (off / on / unknown+empty-key drop). 179 touched-area tests green + 6 runtime-adapter tests.