### PR TITLE
fix(zenodo ingest): drop grant/ISSN ids from record communities (#6)

### DIFF
--- a/src/index/zenodo_records/ingest/records.py
+++ b/src/index/zenodo_records/ingest/records.py
@@ -181,8 +181,34 @@ def _project_creators(item: dict[str, Any]) -> list[tuple[dict[str, Any], int]]:
     return out
 
 
+# A real Zenodo community slug is a human-chosen, alphanumeric handle
+# (`epfl`, `iccm-19`, `eu`). Some records carry non-community identifiers in
+# `metadata.communities` — EU grant numbers (`101060684`) and journal ISSNs
+# (`1807-1260`) — which `community_iri()` would blindly wrap into
+# `…/communities/<id>` URLs that then 404 on `GET /api/communities/<id>`. Reject
+# those two shapes so they never pollute `community_ids` / `primary_community_id`.
+_ISSN_SLUG_RE = re.compile(r"^\d{4}-\d{3}[\dxX]$")
+_NUMERIC_SLUG_RE = re.compile(r"^\d{4,}$")
+
+
+def _is_plausible_community_slug(slug: str) -> bool:
+    s = slug.strip()
+    if not s:
+        return False
+    if _ISSN_SLUG_RE.match(s):  # journal ISSN, not a community
+        return False
+    if _NUMERIC_SLUG_RE.match(s):  # grant number, not a community
+        return False
+    return True
+
+
 def _project_communities(item: dict[str, Any]) -> list[str]:
-    """Return canonical community IRIs, one per linked community."""
+    """Return canonical community IRIs, one per linked community.
+
+    Non-community identifiers that some records carry under
+    `metadata.communities` (grant numbers, ISSNs) are dropped — see
+    `_is_plausible_community_slug`.
+    """
     from src.index.zenodo_records.iri import community_iri  # noqa: PLC0415
 
     metadata = item.get("metadata") or {}
@@ -190,8 +216,14 @@ def _project_communities(item: dict[str, Any]) -> list[str]:
     out: list[str] = []
     for b in blocks:
         slug = b.get("id") if isinstance(b, dict) else b
-        if isinstance(slug, str) and slug.strip():
-            out.append(community_iri(slug))
+        if not isinstance(slug, str) or not slug.strip():
+            continue
+        if not _is_plausible_community_slug(slug):
+            LOGGER.debug(
+                "zenodo_records: dropping non-community id %r from communities", slug,
+            )
+            continue
+        out.append(community_iri(slug))
     return out
 
 
@@ -240,7 +272,11 @@ def persist_record(
     row["community_ids"] = list(communities)
     from src.index.zenodo_records.iri import community_iri  # noqa: PLC0415
 
-    if crawling_community and not row.get("primary_community_id"):
+    if (
+        crawling_community
+        and _is_plausible_community_slug(crawling_community)
+        and not row.get("primary_community_id")
+    ):
         # Callers pass bare slugs ("epfl") for the community they were
         # iterating; promote to the canonical IRI to match the new PK form.
         row["primary_community_id"] = community_iri(crawling_community)

--- a/tests/index/zenodo_records/test_community_projection.py
+++ b/tests/index/zenodo_records/test_community_projection.py
@@ -1,0 +1,48 @@
+"""Non-community identifiers must not pollute `community_ids` /
+`primary_community_id` (field report #6).
+
+Some Zenodo records carry EU grant numbers (`101060684`) and journal ISSNs
+(`1807-1260`) under `metadata.communities`; blindly wrapping them produces
+`…/communities/<id>` URLs that 404. `_project_communities` must drop them.
+"""
+
+from __future__ import annotations
+
+from src.index.zenodo_records.ingest.records import (
+    _is_plausible_community_slug,
+    _project_communities,
+)
+from src.index.zenodo_records.iri import community_iri
+
+
+def _item(*community_ids: str) -> dict:
+    return {"metadata": {"communities": [{"id": c} for c in community_ids]}}
+
+
+def test_grant_number_dropped_real_community_kept() -> None:
+    # Record 19371895 from the report: ["101060684", "eu"] → only "eu" survives.
+    out = _project_communities(_item("101060684", "eu"))
+    assert out == [community_iri("eu")]
+
+
+def test_issn_only_yields_no_community() -> None:
+    # Record 4008755 from the report: ["1807-1260"] → empty (no false community).
+    assert _project_communities(_item("1807-1260")) == []
+
+
+def test_valid_slugs_all_kept() -> None:
+    out = _project_communities(_item("epfl", "iccm-19", "hubble_tension_resolution"))
+    assert out == [
+        community_iri("epfl"),
+        community_iri("iccm-19"),
+        community_iri("hubble_tension_resolution"),
+    ]
+
+
+def test_slug_validator_patterns() -> None:
+    # grants (pure numeric, 4+) and ISSNs are rejected
+    for bad in ("101060684", "44994575", "220725", "10061983", "1807-1260", "1234"):
+        assert not _is_plausible_community_slug(bad), bad
+    # real community slugs are accepted
+    for good in ("eu", "epfl", "iccm-19", "cern", "spi-ace", "aams2025microcity"):
+        assert _is_plausible_community_slug(good), good


### PR DESCRIPTION
Field report #6. 25 of 5777 `zenodo_records` had a `primary_community_id` that 404s — EU grant numbers (`101060684`, `44994575`, …) and a journal ISSN (`1807-1260`) leaking in via `metadata.communities`.

`community_iri()` blindly wrapped those into `…/communities/<id>` URLs, polluting both `community_ids` and `primary_community_id` (= `communities[0]`). `_project_communities` now filters slugs through `_is_plausible_community_slug` (rejects pure-numeric grant ids and ISSN-shaped ids); `crawling_community` is guarded the same way before promotion to primary.

For the reported record `19371895` (`['101060684','eu']`) primary now resolves to the real `eu` community; the ISSN-only record `4008755` yields no false community; valid slugs (`epfl`, `iccm-19`, …) are untouched.

Tests: `tests/index/zenodo_records/test_community_projection.py` with the exact reported cases (4 tests).

**Operator note:** this prevents *future* bad writes. The 25 existing dirty rows need a re-ingest of those records (or a one-off `UPDATE records SET primary_community_id = NULL WHERE primary_community_id ~ 'communities/([0-9]{4,}|[0-9]{4}-[0-9]{3}[0-9xX])$'`).