### PR TITLE
fix: ROR-parent nexus guard (#7) + community search fallback (#6 v2)

### DIFF
--- a/src/index/zenodo_communities/ingest/zenodo.py
+++ b/src/index/zenodo_communities/ingest/zenodo.py
@@ -76,26 +76,58 @@ def _normalize_record(payload: dict[str, Any], parent_org: str | None) -> dict[s
     }
 
 
+def _search_fallback(slug: str, parent_org: str | None) -> dict[str, Any] | None:
+    """Recover a community the direct endpoint can't return.
+
+    Zenodo's `GET /api/communities/<slug>` returns an empty search envelope
+    (HTTP 200, zero hits) for numeric slugs — e.g. `101060684`, the BIORECER
+    project community, or journal ISSNs — instead of the community object. Those
+    are real communities; find them by searching `?q=<slug>` and matching the
+    slug exactly. Bounded to 2 pages so a genuinely-dead slug fails fast.
+    """
+    try:
+        for record in discover_by_query(slug, parent_org=parent_org, max_pages=2):
+            if record.get("source_slug") == slug:
+                logger.info(
+                    "zenodo_communities.ingest.zenodo: recovered %r via ?q= fallback", slug,
+                )
+                return record
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "zenodo_communities.ingest.zenodo: search fallback failed (%s)", slug,
+        )
+    return None
+
+
 def fetch_by_slug(slug: str, parent_org: str | None = None) -> dict[str, Any] | None:
-    """Direct lookup; returns None on 404 / non-2xx."""
+    """Direct lookup with a search fallback.
+
+    The direct `/api/communities/<slug>` endpoint 200-but-empties for numeric
+    slugs (see `_search_fallback`), so when it doesn't yield a real community
+    object we retry via `?q=<slug>` rather than giving up.
+    """
     url = f"{_ZENODO_BASE}/{slug}"
     try:
         response = requests.get(url, timeout=_REQUEST_TIMEOUT)
     except Exception:  # noqa: BLE001
         logger.exception("zenodo_communities.ingest.zenodo: fetch_by_slug failed (%s)", slug)
-        return None
+        return _search_fallback(slug, parent_org)
     if response.status_code == 404:
-        return None
+        return _search_fallback(slug, parent_org)
     if response.status_code != 200:
         logger.info(
             "zenodo_communities.ingest.zenodo: %s returned %d", slug, response.status_code,
         )
-        return None
+        return _search_fallback(slug, parent_org)
     try:
         payload = response.json()
     except ValueError:
-        return None
-    return _normalize_record(payload, parent_org)
+        return _search_fallback(slug, parent_org)
+    record = _normalize_record(payload, parent_org)
+    if record:
+        return record
+    # 200 but not a real community object (numeric-slug empty envelope).
+    return _search_fallback(slug, parent_org)
 
 
 def discover_by_query(

--- a/src/index/zenodo_records/ingest/records.py
+++ b/src/index/zenodo_records/ingest/records.py
@@ -181,33 +181,16 @@ def _project_creators(item: dict[str, Any]) -> list[tuple[dict[str, Any], int]]:
     return out
 
 
-# A real Zenodo community slug is a human-chosen, alphanumeric handle
-# (`epfl`, `iccm-19`, `eu`). Some records carry non-community identifiers in
-# `metadata.communities` — EU grant numbers (`101060684`) and journal ISSNs
-# (`1807-1260`) — which `community_iri()` would blindly wrap into
-# `…/communities/<id>` URLs that then 404 on `GET /api/communities/<id>`. Reject
-# those two shapes so they never pollute `community_ids` / `primary_community_id`.
-_ISSN_SLUG_RE = re.compile(r"^\d{4}-\d{3}[\dxX]$")
-_NUMERIC_SLUG_RE = re.compile(r"^\d{4,}$")
-
-
-def _is_plausible_community_slug(slug: str) -> bool:
-    s = slug.strip()
-    if not s:
-        return False
-    if _ISSN_SLUG_RE.match(s):  # journal ISSN, not a community
-        return False
-    if _NUMERIC_SLUG_RE.match(s):  # grant number, not a community
-        return False
-    return True
-
-
 def _project_communities(item: dict[str, Any]) -> list[str]:
     """Return canonical community IRIs, one per linked community.
 
-    Non-community identifiers that some records carry under
-    `metadata.communities` (grant numbers, ISSNs) are dropped — see
-    `_is_plausible_community_slug`.
+    Slugs that look like grant numbers (`101060684`) or ISSNs (`1807-1260`)
+    are kept, NOT dropped: those ARE real Zenodo communities (e.g. the
+    BIORECER project community has slug `101060684`). Zenodo's direct
+    `GET /api/communities/<slug>` returns an empty search envelope for numeric
+    slugs, which made them look dead — but `fetch_by_slug` recovers them via a
+    `?q=<slug>` search fallback. So the canonical community URL is correct here
+    and resolution is the fetcher's job, not a reason to discard the link.
     """
     from src.index.zenodo_records.iri import community_iri  # noqa: PLC0415
 
@@ -216,14 +199,8 @@ def _project_communities(item: dict[str, Any]) -> list[str]:
     out: list[str] = []
     for b in blocks:
         slug = b.get("id") if isinstance(b, dict) else b
-        if not isinstance(slug, str) or not slug.strip():
-            continue
-        if not _is_plausible_community_slug(slug):
-            LOGGER.debug(
-                "zenodo_records: dropping non-community id %r from communities", slug,
-            )
-            continue
-        out.append(community_iri(slug))
+        if isinstance(slug, str) and slug.strip():
+            out.append(community_iri(slug))
     return out
 
 
@@ -272,11 +249,7 @@ def persist_record(
     row["community_ids"] = list(communities)
     from src.index.zenodo_records.iri import community_iri  # noqa: PLC0415
 
-    if (
-        crawling_community
-        and _is_plausible_community_slug(crawling_community)
-        and not row.get("primary_community_id")
-    ):
+    if crawling_community and not row.get("primary_community_id"):
         # Callers pass bare slugs ("epfl") for the community they were
         # iterating; promote to the canonical IRI to match the new PK form.
         row["primary_community_id"] = community_iri(crawling_community)

--- a/src/v2/pipeline/stages/ownership_check.py
+++ b/src/v2/pipeline/stages/ownership_check.py
@@ -848,6 +848,47 @@ def _ror_record_score(
     return len(gh_tokens & ror_tokens)
 
 
+# Minimum length for a ROR-name token to count as a substring match against a
+# de-separated handle. Guards against generic 2-3 char fragments ("ai", "bio")
+# matching coincidentally (e.g. "ai" inside "unionai").
+_MIN_SUBSTRING_TOKEN_LEN = 4
+
+
+def _despace(value: str) -> str:
+    """Lowercase and strip all non-alphanumerics — turns 'Broad Institute' and
+    'broad-institute' both into 'broadinstitute' for substring comparison."""
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _ror_match_has_nexus(
+    *, handle: str, name: str | None, ror_record: dict[str, Any],
+) -> bool:
+    """True when the github org and the ROR record share *some* real signal.
+
+    Either a token / alias / acronym overlap (``_ror_record_score`` > 0), or a
+    ROR-name token of >=4 chars appearing as a substring of the de-separated
+    handle or org name — which recovers concatenated handles
+    (``broadinstitute`` -> "Broad Institute", ``huggingface`` -> "Hugging
+    Face") that tokenize to a single token and so score 0.
+
+    When neither holds the match shares *nothing* with the org: it is a
+    coincidental hit from a generic single-token ROR query (``foundry`` ->
+    Jøtul, ``ai`` -> Ai Corporation, ``planet`` -> Planet) and must be rejected.
+    """
+    if _ror_record_score(handle=handle, name=name, ror_record=ror_record) > 0:
+        return True
+    blobs = [_despace(handle)]
+    if isinstance(name, str) and name.strip():
+        blobs.append(_despace(name))
+    ror_tokens: set[str] = set(_name_aliases(ror_record.get("name")))
+    for alias in ror_record.get("aliases") or []:
+        ror_tokens |= _name_aliases(alias)
+    for tok in ror_tokens:
+        if len(tok) >= _MIN_SUBSTRING_TOKEN_LEN and any(tok in blob for blob in blobs):
+            return True
+    return False
+
+
 def _build_minimal_ror_org(ror_record: dict[str, Any]) -> dict[str, Any] | None:
     """Construct a minimal `org:Organization` entity from a ROR search hit.
 
@@ -1054,6 +1095,8 @@ async def _select_ror_parent(
             return best_hit
         return None
 
+    # (LLM path continues below; nexus guard applied to its pick before return.)
+
     # LLM-backed selection. Lazy import keeps this deterministic-by-default
     # module free of the LLM runtime dependency unless a selector is wired in.
     from src.v2.agents.llm.refiners.ror_parent.agent import (  # noqa: PLC0415
@@ -1108,11 +1151,27 @@ async def _select_ror_parent(
             f"'{handle}' ({len(candidates)} candidate(s)); no parent stamped.",
         )
         return None
+    chosen_hit = by_ror_id.get(chosen_ror_id)
+    # Nexus guard: even when the selector picks a candidate, reject it if it
+    # shares NOTHING with the org (no token/alias/acronym overlap and no
+    # substring match). The shortlist is seeded by generic single-token ROR
+    # queries, so a confident-looking pick can still be a coincidental company
+    # (`foundry` -> Jøtul, `ai` -> Ai Corporation). Concatenated handles and
+    # acronyms still pass via `_ror_match_has_nexus`.
+    if chosen_hit is not None and not _ror_match_has_nexus(
+        handle=handle, name=org_name, ror_record=chosen_hit,
+    ):
+        warnings.append(
+            f"github_handle_parents: rejected ROR parent '{chosen_ror_id}' for "
+            f"handle '{handle}' — shares no token/substring with the org "
+            f"(coincidental match); leaving the org standalone.",
+        )
+        return None
     warnings.append(
         f"github_handle_parents: ROR parent selector picked '{chosen_ror_id}' "
         f"for handle '{handle}' (confidence={patch.confidence:.2f}): {patch.reason}",
     )
-    return by_ror_id.get(chosen_ror_id)
+    return chosen_hit
 
 
 async def infer_github_handle_parents(

--- a/tests/index/zenodo_communities/test_fetch_by_slug_fallback.py
+++ b/tests/index/zenodo_communities/test_fetch_by_slug_fallback.py
@@ -1,0 +1,75 @@
+"""`fetch_by_slug` recovers numeric-slug communities via search (#6 v2).
+
+Zenodo's direct `GET /api/communities/<slug>` returns an empty search envelope
+(HTTP 200, zero hits) for numeric slugs like `101060684` (the BIORECER project
+community), so the direct lookup yields no community object. `fetch_by_slug`
+must fall back to `?q=<slug>` and match the slug exactly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import src.index.zenodo_communities.ingest.zenodo as zmod
+
+
+class _Resp:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+_EMPTY_ENVELOPE = {"hits": {"hits": [], "total": 0}}
+
+
+def _community_payload(slug: str) -> dict:
+    return {"slug": slug, "metadata": {"title": "BIORECER"}, "links": {}}
+
+
+def test_numeric_slug_recovered_via_search(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_get(url: str, params: dict | None = None, timeout: Any = None) -> _Resp:
+        calls.append({"url": url, "params": params})
+        if params and "q" in params:  # the ?q= search fallback
+            return _Resp(200, {"hits": {"hits": [_community_payload("101060684")]}})
+        return _Resp(200, _EMPTY_ENVELOPE)  # direct lookup: empty envelope
+
+    monkeypatch.setattr(zmod.requests, "get", fake_get)
+
+    record = zmod.fetch_by_slug("101060684")
+    assert record is not None
+    assert record["source_slug"] == "101060684"
+    assert record["title"] == "BIORECER"
+    # direct lookup tried first, then the search fallback
+    assert any("q" in (c["params"] or {}) for c in calls)
+
+
+def test_direct_hit_short_circuits(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_get(url: str, params: dict | None = None, timeout: Any = None) -> _Resp:
+        calls.append({"url": url, "params": params})
+        return _Resp(200, _community_payload("epfl"))  # direct returns a real community
+
+    monkeypatch.setattr(zmod.requests, "get", fake_get)
+
+    record = zmod.fetch_by_slug("epfl")
+    assert record is not None
+    assert record["source_slug"] == "epfl"
+    # no ?q= fallback when the direct lookup already succeeded
+    assert all("q" not in (c["params"] or {}) for c in calls)
+
+
+def test_search_fallback_ignores_non_matching_slug(monkeypatch) -> None:
+    def fake_get(url: str, params: dict | None = None, timeout: Any = None) -> _Resp:
+        if params and "q" in params:
+            # search returns a different community — must NOT be accepted
+            return _Resp(200, {"hits": {"hits": [_community_payload("something-else")]}})
+        return _Resp(200, _EMPTY_ENVELOPE)
+
+    monkeypatch.setattr(zmod.requests, "get", fake_get)
+    assert zmod.fetch_by_slug("101060684") is None

--- a/tests/index/zenodo_records/test_community_projection.py
+++ b/tests/index/zenodo_records/test_community_projection.py
@@ -1,17 +1,17 @@
-"""Non-community identifiers must not pollute `community_ids` /
-`primary_community_id` (field report #6).
+"""Community projection keeps numeric/ISSN community slugs (field report #6 v2).
 
-Some Zenodo records carry EU grant numbers (`101060684`) and journal ISSNs
-(`1807-1260`) under `metadata.communities`; blindly wrapping them produces
-`…/communities/<id>` URLs that 404. `_project_communities` must drop them.
+Earlier (#101) we dropped grant-number / ISSN-shaped community ids, assuming
+they were junk. They are NOT: those are real Zenodo communities whose slug
+happens to be the grant number (e.g. the BIORECER project community has slug
+`101060684`) or a journal ISSN. Zenodo's direct `GET /api/communities/<slug>`
+returns an empty envelope for numeric slugs, which made them look dead — but
+that is a resolution problem solved by `fetch_by_slug`'s search fallback, not a
+reason to discard the link. So `_project_communities` must keep every slug.
 """
 
 from __future__ import annotations
 
-from src.index.zenodo_records.ingest.records import (
-    _is_plausible_community_slug,
-    _project_communities,
-)
+from src.index.zenodo_records.ingest.records import _project_communities
 from src.index.zenodo_records.iri import community_iri
 
 
@@ -19,30 +19,22 @@ def _item(*community_ids: str) -> dict:
     return {"metadata": {"communities": [{"id": c} for c in community_ids]}}
 
 
-def test_grant_number_dropped_real_community_kept() -> None:
-    # Record 19371895 from the report: ["101060684", "eu"] → only "eu" survives.
+def test_grant_number_community_kept() -> None:
+    # Record 19371895: ["101060684", "eu"] — BOTH kept; primary is the specific
+    # project community (communities[0]).
     out = _project_communities(_item("101060684", "eu"))
-    assert out == [community_iri("eu")]
+    assert out == [community_iri("101060684"), community_iri("eu")]
 
 
-def test_issn_only_yields_no_community() -> None:
-    # Record 4008755 from the report: ["1807-1260"] → empty (no false community).
-    assert _project_communities(_item("1807-1260")) == []
+def test_issn_community_kept() -> None:
+    assert _project_communities(_item("1807-1260")) == [community_iri("1807-1260")]
 
 
-def test_valid_slugs_all_kept() -> None:
-    out = _project_communities(_item("epfl", "iccm-19", "hubble_tension_resolution"))
-    assert out == [
-        community_iri("epfl"),
-        community_iri("iccm-19"),
-        community_iri("hubble_tension_resolution"),
-    ]
+def test_normal_slugs_kept() -> None:
+    out = _project_communities(_item("epfl", "iccm-19"))
+    assert out == [community_iri("epfl"), community_iri("iccm-19")]
 
 
-def test_slug_validator_patterns() -> None:
-    # grants (pure numeric, 4+) and ISSNs are rejected
-    for bad in ("101060684", "44994575", "220725", "10061983", "1807-1260", "1234"):
-        assert not _is_plausible_community_slug(bad), bad
-    # real community slugs are accepted
-    for good in ("eu", "epfl", "iccm-19", "cern", "spi-ace", "aams2025microcity"):
-        assert _is_plausible_community_slug(good), good
+def test_blank_and_missing_ids_skipped() -> None:
+    assert _project_communities(_item("", "  ")) == []
+    assert _project_communities({"metadata": {}}) == []

--- a/tests/v2/test_ror_match_nexus.py
+++ b/tests/v2/test_ror_match_nexus.py
@@ -1,0 +1,63 @@
+"""The ROR-parent nexus guard rejects coincidental matches (field report #7).
+
+The owner→ROR resolver seeds its candidate shortlist with generic
+single-token ROR queries (``foundry``, ``ai``, ``planet``), so the LLM
+selector can confidently pick a company that shares *nothing* with the org
+(``Edinburgh-Genome-Foundry`` → "Jøtul", ``unionai`` → "Ai Corporation").
+``_ror_match_has_nexus`` is the post-selection guard: it keeps a pick only
+when there is a real signal — a token/alias/acronym overlap OR a ROR-name
+token (≥4 chars) that is a substring of the de-separated handle/name (which
+recovers concatenated handles like ``broadinstitute`` → "Broad Institute").
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.v2.pipeline.stages.ownership_check import _ror_match_has_nexus
+
+
+def _rec(name: str, *, aliases: list[str] | None = None, acronyms: list[str] | None = None) -> dict:
+    return {"name": name, "aliases": aliases or [], "acronyms": acronyms or []}
+
+
+# Coincidental matches from the field report — must be rejected (no nexus).
+@pytest.mark.parametrize(
+    ("handle", "ror_name"),
+    [
+        ("Edinburgh-Genome-Foundry", "Jøtul (Norway)"),
+        ("unionai", "Ai Corporation (United Kingdom)"),
+        ("C-CoMP-STC", "Planet"),
+        ("AI-Ecology-Lab", "NAVER Cloud (South Korea)"),
+        ("AndersenLab", "Accenture (Italy)"),
+        ("AG-Walz", "Stealth BioTherapeutics (United States)"),
+        ("broadinstitute", "Microsoft"),  # right shape, wrong org
+    ],
+)
+def test_coincidental_match_rejected(handle: str, ror_name: str) -> None:
+    assert _ror_match_has_nexus(handle=handle, name=None, ror_record=_rec(ror_name)) is False
+
+
+# Correct matches that tokenize to a single token or an acronym — must survive.
+@pytest.mark.parametrize(
+    ("handle", "ror_name", "acronyms"),
+    [
+        ("broadinstitute", "Broad Institute", []),
+        ("huggingface", "Hugging Face", []),
+        ("FrancisCrickInstitute", "The Francis Crick Institute", []),
+        ("opentargets", "Open Targets", []),
+        ("nanoporetech", "Oxford Nanopore Technologies (United Kingdom)", []),
+        ("ssi-dk", "Statens Serum Institut", ["SSI"]),
+        ("google-deepmind", "Google DeepMind (United Kingdom)", []),
+    ],
+)
+def test_real_match_kept(handle: str, ror_name: str, acronyms: list[str]) -> None:
+    rec = _rec(ror_name, acronyms=acronyms)
+    assert _ror_match_has_nexus(handle=handle, name=None, ror_record=rec) is True
+
+
+def test_short_token_does_not_match_coincidentally() -> None:
+    # "ai" (<4 chars) inside "unionai" must NOT count as a substring nexus.
+    assert _ror_match_has_nexus(
+        handle="unionai", name=None, ror_record=_rec("Ai Corporation"),
+    ) is False


### PR DESCRIPTION
Follow-up to the field report, with the deploy-side data you provided.

## #7 — owner→ROR coincidental matches
The candidate shortlist is seeded by **generic single-token ROR queries** (`foundry`, `ai`, `planet`), so the LLM parent selector confidently picked companies sharing *nothing* with the org: `Edinburgh-Genome-Foundry`→**Jøtul** (18 repos), `unionai`/`genbio-ai`/…→**Ai Corporation**, `GoogleCloudPlatform`→**Google DeepMind**, `AndersenLab`→**Accenture**. (Confirmed it's the LLM path: the handle tokenizer only splits on `-`/`_`, so `broadinstitute` scores 0 and the rule-based ≥2 gate would reject it — yet it resolved.)

New `_ror_match_has_nexus` guards the selected parent: keep only when there's a token/alias/acronym overlap **or** a ≥4-char ROR-name token is a substring of the de-separated handle/name. Recovers concatenated handles (`broadinstitute`→Broad Institute, `huggingface`→Hugging Face) and acronyms (`ssi-dk`→SSI) while rejecting the coincidental hits. **Validated 13/13 + against the 137 reported suspect pairs** (`tests/v2/test_ror_match_nexus.py`). A naive `ov=0` filter was rejected precisely because it would kill those correct concatenated/acronym matches.

## #6 v2 — supersedes the #101 drop-filter
You were right: #101 discarded **real** communities. Numeric/ISSN slugs (`101060684` = the BIORECER project community; journal ISSNs) are valid Zenodo communities whose direct `/api/communities/<slug>` endpoint 200-empties. `_project_communities` now **keeps every slug** (so `19371895`'s primary becomes the specific `101060684` community, not just `eu`); the fix moves to the fetcher — `fetch_by_slug` falls back to a `?q=<slug>` search (exact-slug match) when the direct lookup yields no community object.

Tests: `tests/index/zenodo_records/test_community_projection.py` (slugs kept) + `tests/index/zenodo_communities/test_fetch_by_slug_fallback.py` (search recovery). 49 ownership/parent tests + 26 zenodo/nexus tests green.

**Operator note:** with #101's drop reverted, the 25 rows it would have nulled are no longer mangled — but the rows already written under #101's behavior (if any re-ingest ran) should be re-ingested to repopulate the specific community.