### PR TITLE
fix(v2 ownership): require a DISTINCTIVE token for ROR-parent nexus (#7)

### DIFF
--- a/src/v2/pipeline/stages/ownership_check.py
+++ b/src/v2/pipeline/stages/ownership_check.py
@@ -860,33 +860,79 @@ def _despace(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", value.lower())
 
 
+# Generic organisation words that collide across unrelated orgs and so must
+# NOT count as a name-match nexus on their own. ROR's relevance ranking puts a
+# token-coincident org at #1 for these (`Edinburgh Genome Foundry` -> "Jøtul",
+# whose alias is "Kværner Foundry"; `... Genomics` -> any genomics company),
+# and the github→ROR resolver accepts ROR's #1 without a similarity check. The
+# nexus must be a *distinctive* shared token, not one of these.
+_GENERIC_ORG_TOKENS = frozenset(
+    """
+    foundry research lab labs laboratory laboratories group institute institut
+    institutes university college center centre data hub science sciences scientific
+    bio biotech biosciences genomics genome genomic cloud platform tech technology
+    technologies systems system solutions computational national international
+    corporation corp company foundation association network project team engineering
+    medical medicine health information intelligence machine learning open source
+    global services consulting consultants digital software therapeutics pharma
+    pharmaceuticals biology biological dynamics analytics consortium initiative
+    of the and for de la el du des inc ltd gmbh llc co
+    """.split(),
+)
+
+
+def _distinctive(tokens: set[str]) -> set[str]:
+    """Tokens that distinguish one org from another — drops generic org words
+    and 1-2 char fragments that match coincidentally."""
+    return {t for t in tokens if len(t) >= 3 and t not in _GENERIC_ORG_TOKENS}
+
+
 def _ror_match_has_nexus(
     *, handle: str, name: str | None, ror_record: dict[str, Any],
 ) -> bool:
-    """True when the github org and the ROR record share *some* real signal.
+    """True when the github org and the ROR record share a *distinctive* signal.
 
-    Either a token / alias / acronym overlap (``_ror_record_score`` > 0), or a
-    ROR-name token of >=4 chars appearing as a substring of the de-separated
-    handle or org name — which recovers concatenated handles
-    (``broadinstitute`` -> "Broad Institute", ``huggingface`` -> "Hugging
-    Face") that tokenize to a single token and so score 0.
+    ROR's free-text ranking happily returns a coincidental top hit whose only
+    overlap with the org is a generic word (`Edinburgh Genome Foundry` -> Jøtul
+    via the alias "Kværner Foundry"; `unionai` -> "Ai Corporation" via "ai"),
+    and the resolver accepts ROR's #1 without verifying the name. This guard is
+    that verification: keep a match only when there is
 
-    When neither holds the match shares *nothing* with the org: it is a
-    coincidental hit from a generic single-token ROR query (``foundry`` ->
-    Jøtul, ``ai`` -> Ai Corporation, ``planet`` -> Planet) and must be rejected.
+      1. a shared *distinctive* (non-generic, >=3 char) name token, OR
+      2. an acronym match (acronyms are inherently distinctive), OR
+      3. a distinctive ROR-name token (>=4 chars) appearing as a substring of
+         the de-separated handle/name — recovering concatenated handles
+         (`broadinstitute` -> "Broad Institute", `huggingface` -> "Hugging Face").
+
+    Generic-word-only overlaps (the Jøtul / Ai Corporation failure mode) share
+    no distinctive token and are rejected. Validated against the reported
+    suspect pairs using the live ROR records (incl. Jøtul's aliases).
     """
-    if _ror_record_score(handle=handle, name=name, ror_record=ror_record) > 0:
-        return True
-    blobs = [_despace(handle)]
-    if isinstance(name, str) and name.strip():
-        blobs.append(_despace(name))
+    gh_tokens = _handle_aliases(handle)
+    if isinstance(name, str):
+        gh_tokens |= _name_aliases(name)
+    gh_distinctive = _distinctive(gh_tokens)
+
     ror_tokens: set[str] = set(_name_aliases(ror_record.get("name")))
     for alias in ror_record.get("aliases") or []:
         ror_tokens |= _name_aliases(alias)
-    for tok in ror_tokens:
-        if len(tok) >= _MIN_SUBSTRING_TOKEN_LEN and any(tok in blob for blob in blobs):
-            return True
-    return False
+    ror_distinctive = _distinctive(ror_tokens)
+
+    # 1) shared distinctive token
+    if gh_distinctive & ror_distinctive:
+        return True
+    # 2) acronym match
+    acronyms = {a.lower() for a in (ror_record.get("acronyms") or []) if isinstance(a, str)}
+    if gh_tokens & acronyms:
+        return True
+    # 3) distinctive ROR token as a substring of the de-separated handle/name
+    blobs = [_despace(handle)]
+    if isinstance(name, str) and name.strip():
+        blobs.append(_despace(name))
+    return any(
+        len(tok) >= _MIN_SUBSTRING_TOKEN_LEN and any(tok in blob for blob in blobs)
+        for tok in ror_distinctive
+    )
 
 
 def _build_minimal_ror_org(ror_record: dict[str, Any]) -> dict[str, Any] | None:

--- a/tests/v2/test_ror_match_nexus.py
+++ b/tests/v2/test_ror_match_nexus.py
@@ -1,13 +1,16 @@
 """The ROR-parent nexus guard rejects coincidental matches (field report #7).
 
-The owner→ROR resolver seeds its candidate shortlist with generic
-single-token ROR queries (``foundry``, ``ai``, ``planet``), so the LLM
-selector can confidently pick a company that shares *nothing* with the org
-(``Edinburgh-Genome-Foundry`` → "Jøtul", ``unionai`` → "Ai Corporation").
-``_ror_match_has_nexus`` is the post-selection guard: it keeps a pick only
-when there is a real signal — a token/alias/acronym overlap OR a ROR-name
-token (≥4 chars) that is a substring of the de-separated handle/name (which
-recovers concatenated handles like ``broadinstitute`` → "Broad Institute").
+ROR's free-text ranking returns a token-coincident org at #1 even on an idle
+deploy with the full result list — e.g. "Edinburgh Genome Foundry" → "Jøtul
+(Norway)" (ror 042epp307), because Jøtul's aliases include "Kværner **Foundry**".
+The github→ROR resolver accepted ROR's #1 without verifying the name.
+
+``_ror_match_has_nexus`` keeps a match only when there is a *distinctive*
+(non-generic) shared token, an acronym match, or a distinctive substring — so a
+generic-word-only overlap ("foundry", "ai", "genomics") is rejected while
+concatenated handles ("broadinstitute" → "Broad Institute") and acronyms
+("ssi-dk" → SSI) survive. Records here mirror the LIVE ROR shapes (incl.
+aliases), which is what exposed the earlier, weaker guard.
 """
 
 from __future__ import annotations
@@ -21,43 +24,47 @@ def _rec(name: str, *, aliases: list[str] | None = None, acronyms: list[str] | N
     return {"name": name, "aliases": aliases or [], "acronyms": acronyms or []}
 
 
-# Coincidental matches from the field report — must be rejected (no nexus).
+# Coincidental matches — generic-word-only overlap — must be rejected. Records
+# carry the real aliases that made the naive guard fail.
 @pytest.mark.parametrize(
-    ("handle", "ror_name"),
+    ("handle", "name", "record"),
     [
-        ("Edinburgh-Genome-Foundry", "Jøtul (Norway)"),
-        ("unionai", "Ai Corporation (United Kingdom)"),
-        ("C-CoMP-STC", "Planet"),
-        ("AI-Ecology-Lab", "NAVER Cloud (South Korea)"),
-        ("AndersenLab", "Accenture (Italy)"),
-        ("AG-Walz", "Stealth BioTherapeutics (United States)"),
-        ("broadinstitute", "Microsoft"),  # right shape, wrong org
+        # Jøtul's "Kværner Foundry" alias shares only the generic "foundry".
+        (
+            "Edinburgh-Genome-Foundry",
+            "Edinburgh Genome Foundry",
+            _rec("Jøtul (Norway)", aliases=["Kværner Foundry", "Kværner Jernstøberi"]),
+        ),
+        ("unionai", "unionai", _rec("Ai Corporation (United Kingdom)")),  # only "ai"/"corporation"
+        ("C-CoMP-STC", "C-CoMP-STC", _rec("Planet")),
+        ("AI-Ecology-Lab", "AI Ecology Lab", _rec("NAVER Cloud (South Korea)")),  # "lab"/"cloud"
+        ("AndersenLab", "AndersenLab", _rec("Accenture (Italy)")),
+        ("broadinstitute", "Broad Institute", _rec("Microsoft")),  # right shape, wrong org
     ],
 )
-def test_coincidental_match_rejected(handle: str, ror_name: str) -> None:
-    assert _ror_match_has_nexus(handle=handle, name=None, ror_record=_rec(ror_name)) is False
+def test_coincidental_match_rejected(handle: str, name: str, record: dict) -> None:
+    assert _ror_match_has_nexus(handle=handle, name=name, ror_record=record) is False
 
 
-# Correct matches that tokenize to a single token or an acronym — must survive.
+# Correct matches (concatenated handles / acronyms / distinctive tokens) survive.
 @pytest.mark.parametrize(
-    ("handle", "ror_name", "acronyms"),
+    ("handle", "name", "record"),
     [
-        ("broadinstitute", "Broad Institute", []),
-        ("huggingface", "Hugging Face", []),
-        ("FrancisCrickInstitute", "The Francis Crick Institute", []),
-        ("opentargets", "Open Targets", []),
-        ("nanoporetech", "Oxford Nanopore Technologies (United Kingdom)", []),
-        ("ssi-dk", "Statens Serum Institut", ["SSI"]),
-        ("google-deepmind", "Google DeepMind (United Kingdom)", []),
+        ("broadinstitute", "Broad Institute", _rec("Broad Institute")),
+        ("huggingface", "Hugging Face", _rec("Hugging Face")),
+        ("FrancisCrickInstitute", "Francis Crick Institute", _rec("The Francis Crick Institute")),
+        ("opentargets", "Open Targets", _rec("Open Targets")),
+        ("nanoporetech", "Oxford Nanopore", _rec("Oxford Nanopore Technologies (United Kingdom)")),
+        ("ssi-dk", "ssi-dk", _rec("Statens Serum Institut", acronyms=["SSI"])),
+        ("google-deepmind", "google-deepmind", _rec("Google DeepMind (United Kingdom)")),
     ],
 )
-def test_real_match_kept(handle: str, ror_name: str, acronyms: list[str]) -> None:
-    rec = _rec(ror_name, acronyms=acronyms)
-    assert _ror_match_has_nexus(handle=handle, name=None, ror_record=rec) is True
+def test_real_match_kept(handle: str, name: str, record: dict) -> None:
+    assert _ror_match_has_nexus(handle=handle, name=name, ror_record=record) is True
 
 
-def test_short_token_does_not_match_coincidentally() -> None:
-    # "ai" (<4 chars) inside "unionai" must NOT count as a substring nexus.
-    assert _ror_match_has_nexus(
-        handle="unionai", name=None, ror_record=_rec("Ai Corporation"),
-    ) is False
+def test_generic_alias_token_is_not_a_nexus() -> None:
+    # The exact #102 regression: a generic token shared only via a ROR alias
+    # ("foundry" in "Kværner Foundry") must NOT count.
+    rec = _rec("Jøtul (Norway)", aliases=["Kværner Foundry"])
+    assert _ror_match_has_nexus(handle="Edinburgh-Genome-Foundry", name="Edinburgh Genome Foundry", ror_record=rec) is False


### PR DESCRIPTION
Strengthens the #102 nexus guard, which was **insufficient against the live ROR records** (thanks to the deploy-side repro).

**Root cause confirmed deterministic** (not rate-limiting / partial shortlist): ROR's free-text ranking returns a token-coincident org at #1 — `Edinburgh Genome Foundry` → **Jøtul (Norway)** (`042epp307`), whose alias is **"Kværner Foundry"** — and the resolver accepts ROR's #1 without a name-similarity check. (Also confirmed the GME reads the ROR v2 `names` shape correctly; the `name=None` was a repro-script artifact, not a GME bug.)

The #102 guard used `_ror_record_score` (name+aliases+acronyms), so the generic alias token "foundry" produced a **false nexus** and Jøtul survived. `_ror_match_has_nexus` now requires a **distinctive** signal: a shared non-generic (≥3-char) name token, an acronym match, or a distinctive (≥4-char) ROR-name token as a substring of the de-separated handle/name. Generic org words (`foundry/research/lab/ai/genomics/…`) no longer count on their own.

**Validated 7/7 against LIVE ROR records** — `Edinburgh-Genome-Foundry`→Jøtul (WITH its real aliases) rejected; `broadinstitute`/`huggingface`/`nanoporetech`/`ssi-dk`/`google-deepmind` kept. Tests in `test_ror_match_nexus.py` now mirror the live record shapes (incl. the Kværner Foundry alias that exposed the regression).

The query-failure guard idea is dropped: the ROR query doesn't fail here — it returns a bad #1 — so only a name-match threshold catches it.