### PR TITLE
feat(v2 ownership): web-domain evidence (Tier A1) for owner→ROR + ROR v2 links fix

### DIFF
--- a/src/v2/ingest/providers/ror_provider.py
+++ b/src/v2/ingest/providers/ror_provider.py
@@ -115,8 +115,25 @@ def _normalize_ror_organization(item: dict[str, Any]) -> dict[str, Any]:  # noqa
                     "country_code": country_code,
                 }
 
+    # ROR API v2 changed `links` from bare strings to `{type, value}` objects
+    # (same shape change as `name` -> `names`). Read both forms, and also fold
+    # in the v2 `domains` field, so the website/domain signal isn't silently
+    # lost (it powers the owner->ROR web-domain match).
     links = item.get("links")
-    links_list = [value for value in links if isinstance(value, str)] if isinstance(links, list) else []
+    links_list: list[str] = []
+    if isinstance(links, list):
+        for entry in links:
+            if isinstance(entry, str) and entry.strip():
+                links_list.append(entry)
+            elif isinstance(entry, dict):
+                value = entry.get("value")
+                if isinstance(value, str) and value.strip():
+                    links_list.append(value)
+    domains = item.get("domains")
+    if isinstance(domains, list):
+        for domain in domains:
+            if isinstance(domain, str) and domain.strip():
+                links_list.append(domain if "//" in domain else f"https://{domain}")
     relationships = item.get("relationships")
     relationships_payload = _normalize_relationships(
         relationships if isinstance(relationships, list) else [],

--- a/src/v2/pipeline/stages/ownership_check.py
+++ b/src/v2/pipeline/stages/ownership_check.py
@@ -935,6 +935,76 @@ def _ror_match_has_nexus(
     )
 
 
+# --- web-domain evidence (Tier A1) -----------------------------------------
+# A web-domain match is the highest-precision, zero-cost owner→ROR signal and
+# resolves the residual token-coincidence cases name comparison can't
+# (cloud.google.com vs deepmind.google; opig.stats.ox.ac.uk vs
+# oxfordresearchgroup.org.uk). Comparison is on the *registrable label* (the
+# name immediately left of the public suffix), so single labels colliding
+# ("google" in both cloud.google.com and deepmind.google) don't false-match —
+# google.com vs deepmind.google differ.
+
+# Common two-label public suffixes, so the registrable label is the org name
+# (opig.stats.ox.ac.uk -> "ox") and not the suffix ("ac").
+_TWO_PART_SUFFIXES = frozenset(
+    """
+    co.uk ac.uk org.uk gov.uk me.uk net.uk sch.uk plc.uk ltd.uk
+    co.jp ac.jp or.jp ne.jp go.jp com.au org.au edu.au gov.au net.au asn.au
+    co.nz ac.nz org.nz govt.nz net.nz com.br org.br edu.br gov.br net.br
+    co.in ac.in org.in gov.in edu.in net.in com.cn edu.cn gov.cn org.cn net.cn
+    co.za ac.za org.za gov.za com.mx org.mx edu.mx gob.mx com.sg edu.sg gov.sg org.sg
+    com.hk edu.hk gov.hk org.hk co.kr or.kr ac.kr go.kr com.tw edu.tw gov.tw org.tw
+    co.il ac.il org.il gov.il
+    """.split(),
+)
+
+# Hosts that are not institutional domains — they carry no org-identity signal.
+_GENERIC_HOSTS = frozenset(
+    {
+        "github", "gitlab", "bitbucket", "readthedocs", "wikipedia", "sites",
+        "wordpress", "blogspot", "medium", "notion", "gitbook", "netlify",
+        "vercel", "herokuapp", "pages",
+    },
+)
+
+
+def _registrable_label(host: str) -> str | None:
+    """Registrable name label of a host (the label left of the public suffix)."""
+    host = host.strip().lower().rstrip(".")
+    labels = [part for part in host.split(".") if part]
+    if len(labels) < 2:
+        return None
+    if len(labels) >= 3 and ".".join(labels[-2:]) in _TWO_PART_SUFFIXES:
+        return labels[-3]
+    return labels[-2]
+
+
+def _registrable_label_from_url(url: Any) -> str | None:
+    if not isinstance(url, str) or not url.strip():
+        return None
+    netloc = urlparse(url if "//" in url else f"//{url}").netloc.lower()
+    netloc = netloc.split("@")[-1].split(":")[0]  # strip any auth / port
+    return _registrable_label(netloc)
+
+
+def _org_domain_label(org_context: dict[str, Any] | None) -> str | None:
+    """The org's own web-domain registrable label, or None when absent/generic."""
+    if not org_context:
+        return None
+    label = _registrable_label_from_url(org_context.get("homepage", ""))
+    return label if label and label not in _GENERIC_HOSTS else None
+
+
+def _ror_domain_labels(record: dict[str, Any]) -> set[str]:
+    """Registrable labels of a ROR record's website link(s), generic hosts dropped."""
+    labels: set[str] = set()
+    for url in record.get("links") or []:
+        label = _registrable_label_from_url(url)
+        if label and label not in _GENERIC_HOSTS:
+            labels.add(label)
+    return labels
+
+
 def _build_minimal_ror_org(ror_record: dict[str, Any]) -> dict[str, Any] | None:
     """Construct a minimal `org:Organization` entity from a ROR search hit.
 
@@ -1133,89 +1203,116 @@ async def _select_ror_parent(
     if not shortlist:
         return None
 
+    org_label = _org_domain_label(org_context)
+
+    # TIER A1 — web-domain match is decisive. Pick the shortlist candidate whose
+    # ROR website shares the org's registrable domain, ignoring name-token score
+    # (broadinstitute.org == www.broadinstitute.org). This is the cheapest, most
+    # precise signal and resolves the token-coincidence residual.
+    if org_label:
+        for _score, hit in shortlist:
+            if org_label in _ror_domain_labels(hit):
+                warnings.append(
+                    f"github_handle_parents: web-domain match ('{org_label}') "
+                    f"selected ROR '{hit.get('id')}' for handle '{handle}'.",
+                )
+                return hit
+
+    # --- candidate selection: rule-based unambiguous winner, or the LLM picker ---
     if parent_selector is None:
         ranked = sorted(shortlist, key=lambda item: -item[0])
         best_score, best_hit = ranked[0]
         second_score = ranked[1][0] if len(ranked) > 1 else -1
-        if best_score >= _RULE_BASED_ROR_MIN_SCORE and best_score > second_score:
-            return best_hit
-        return None
+        if not (best_score >= _RULE_BASED_ROR_MIN_SCORE and best_score > second_score):
+            return None
+        chosen_hit: dict[str, Any] | None = best_hit
+        chosen_ror_id = best_hit.get("id")
+        provenance = f"token-overlap winner (score={best_score})"
+    else:
+        # LLM-backed selection. Lazy import keeps this deterministic-by-default
+        # module free of the LLM runtime dependency unless a selector is wired in.
+        from src.v2.agents.llm.refiners.ror_parent.agent import (  # noqa: PLC0415
+            RorCandidate,
+            RorParentSelectorInput,
+        )
 
-    # (LLM path continues below; nexus guard applied to its pick before return.)
-
-    # LLM-backed selection. Lazy import keeps this deterministic-by-default
-    # module free of the LLM runtime dependency unless a selector is wired in.
-    from src.v2.agents.llm.refiners.ror_parent.agent import (  # noqa: PLC0415
-        RorCandidate,
-        RorParentSelectorInput,
-    )
-
-    by_ror_id: dict[str, dict[str, Any]] = {}
-    candidates: list[RorCandidate] = []
-    for score, hit in shortlist:
-        ror_id = hit.get("id")
-        if not isinstance(ror_id, str) or not ror_id:
-            continue
-        by_ror_id[ror_id] = hit
-        country = hit.get("country")
-        candidates.append(
-            RorCandidate(
-                ror_id=ror_id,
-                name=hit.get("name") if isinstance(hit.get("name"), str) else ror_id,
-                aliases=[a for a in (hit.get("aliases") or []) if isinstance(a, str)],
-                acronyms=[a for a in (hit.get("acronyms") or []) if isinstance(a, str)],
-                types=[t for t in (hit.get("types") or []) if isinstance(t, str)],
-                country=(
-                    country.get("country_name") if isinstance(country, dict) else None
+        by_ror_id: dict[str, dict[str, Any]] = {}
+        candidates: list[RorCandidate] = []
+        for score, hit in shortlist:
+            ror_id = hit.get("id")
+            if not isinstance(ror_id, str) or not ror_id:
+                continue
+            by_ror_id[ror_id] = hit
+            country = hit.get("country")
+            candidates.append(
+                RorCandidate(
+                    ror_id=ror_id,
+                    name=hit.get("name") if isinstance(hit.get("name"), str) else ror_id,
+                    aliases=[a for a in (hit.get("aliases") or []) if isinstance(a, str)],
+                    acronyms=[a for a in (hit.get("acronyms") or []) if isinstance(a, str)],
+                    types=[t for t in (hit.get("types") or []) if isinstance(t, str)],
+                    country=(
+                        country.get("country_name") if isinstance(country, dict) else None
+                    ),
+                    token_overlap_score=score,
                 ),
-                token_overlap_score=score,
-            ),
-        )
-    if not candidates:
+            )
+        if not candidates:
+            return None
+        try:
+            patch = await parent_selector.run(
+                refiner_input=RorParentSelectorInput(
+                    github_handle=handle,
+                    github_org_name=org_name,
+                    org_context=org_context,
+                    candidates=candidates,
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(
+                f"github_handle_parents: ROR parent selector failed for handle "
+                f"'{handle}': {exc}. Leaving the org standalone.",
+            )
+            return None
+        chosen_ror_id = patch.accepted_ror_id()
+        if chosen_ror_id is None:
+            warnings.append(
+                f"github_handle_parents: ROR parent selector declined for handle "
+                f"'{handle}' ({len(candidates)} candidate(s)); no parent stamped.",
+            )
+            return None
+        chosen_hit = by_ror_id.get(chosen_ror_id)
+        provenance = f"LLM selector (confidence={patch.confidence:.2f}): {patch.reason}"
+
+    if chosen_hit is None:
         return None
 
-    try:
-        patch = await parent_selector.run(
-            refiner_input=RorParentSelectorInput(
-                github_handle=handle,
-                github_org_name=org_name,
-                org_context=org_context,
-                candidates=candidates,
-            ),
-        )
-    except Exception as exc:  # noqa: BLE001
+    # TIER B — distinctive-token nexus guard (applies to both selection paths):
+    # reject a pick that shares no distinctive token/acronym/substring with the
+    # org (the generic-token coincidence: `foundry` -> Jøtul, `ai` -> Ai Corp).
+    if not _ror_match_has_nexus(handle=handle, name=org_name, ror_record=chosen_hit):
         warnings.append(
-            f"github_handle_parents: ROR parent selector failed for handle "
-            f"'{handle}': {exc}. Leaving the org standalone.",
+            f"github_handle_parents: rejected ROR '{chosen_ror_id}' for handle "
+            f"'{handle}' — no distinctive name nexus (coincidental match).",
         )
         return None
 
-    chosen_ror_id = patch.accepted_ror_id()
-    if chosen_ror_id is None:
-        warnings.append(
-            f"github_handle_parents: ROR parent selector declined for handle "
-            f"'{handle}' ({len(candidates)} candidate(s)); no parent stamped.",
-        )
-        return None
-    chosen_hit = by_ror_id.get(chosen_ror_id)
-    # Nexus guard: even when the selector picks a candidate, reject it if it
-    # shares NOTHING with the org (no token/alias/acronym overlap and no
-    # substring match). The shortlist is seeded by generic single-token ROR
-    # queries, so a confident-looking pick can still be a coincidental company
-    # (`foundry` -> Jøtul, `ai` -> Ai Corporation). Concatenated handles and
-    # acronyms still pass via `_ror_match_has_nexus`.
-    if chosen_hit is not None and not _ror_match_has_nexus(
-        handle=handle, name=org_name, ror_record=chosen_hit,
-    ):
-        warnings.append(
-            f"github_handle_parents: rejected ROR parent '{chosen_ror_id}' for "
-            f"handle '{handle}' — shares no token/substring with the org "
-            f"(coincidental match); leaving the org standalone.",
-        )
-        return None
+    # Decisive negative: both sides have a web domain and they differ -> they are
+    # different orgs (cloud.google.com vs deepmind.google; ox.ac.uk vs
+    # oxfordresearchgroup.org.uk). Only fires when the org has a usable domain.
+    if org_label:
+        ror_labels = _ror_domain_labels(chosen_hit)
+        if ror_labels and org_label not in ror_labels:
+            warnings.append(
+                f"github_handle_parents: rejected ROR '{chosen_ror_id}' for handle "
+                f"'{handle}' — web-domain mismatch (org '{org_label}' vs ROR "
+                f"{sorted(ror_labels)}).",
+            )
+            return None
+
     warnings.append(
-        f"github_handle_parents: ROR parent selector picked '{chosen_ror_id}' "
-        f"for handle '{handle}' (confidence={patch.confidence:.2f}): {patch.reason}",
+        f"github_handle_parents: selected ROR '{chosen_ror_id}' for handle "
+        f"'{handle}' — {provenance}.",
     )
     return chosen_hit
 

--- a/tests/v2/test_ror_domain_cascade.py
+++ b/tests/v2/test_ror_domain_cascade.py
@@ -1,0 +1,105 @@
+"""Web-domain evidence (Tier A1) in the owner→ROR resolver (field report §7).
+
+The decisive, zero-cost signal: compare the org's registrable web domain with
+the ROR record's. A match accepts (broadinstitute.org == www.broadinstitute.org);
+a mismatch rejects (cloud.google.com vs deepmind.google; opig.stats.ox.ac.uk vs
+oxfordresearchgroup.org.uk). This catches the token-coincidence residual the
+name-only nexus guard can't. Requires the ROR v2 `links` (objects) / `domains`
+fix in the provider — without it the GME never saw a ROR domain.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.v2.ingest.providers.ror_provider import _normalize_ror_organization
+from src.v2.pipeline.stages.ownership_check import (
+    _org_domain_label,
+    _registrable_label,
+    _ror_domain_labels,
+    _select_ror_parent,
+)
+
+
+# --- registrable-label extraction -------------------------------------------
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("cloud.google.com", "google"),
+        ("deepmind.google", "deepmind"),
+        ("www.broadinstitute.org", "broadinstitute"),
+        ("opig.stats.ox.ac.uk", "ox"),  # 2-part suffix ac.uk
+        ("oxfordresearchgroup.org.uk", "oxfordresearchgroup"),  # org.uk
+        ("nanoporetech.com", "nanoporetech"),
+    ],
+)
+def test_registrable_label(host: str, expected: str) -> None:
+    assert _registrable_label(host) == expected
+
+
+def test_org_domain_label_ignores_generic_hosts() -> None:
+    assert _org_domain_label({"homepage": "https://edinburgh-genome-foundry.github.io"}) is None
+    assert _org_domain_label({"homepage": "https://www.broadinstitute.org"}) == "broadinstitute"
+    assert _org_domain_label(None) is None
+
+
+# --- ROR v2 links/domains parsing (provider) --------------------------------
+def test_normalize_ror_v2_links_objects_and_domains() -> None:
+    item = {
+        "id": "https://ror.org/00971b260",
+        "names": [{"types": ["ror_display"], "value": "Google DeepMind (United Kingdom)"}],
+        "links": [
+            {"type": "website", "value": "https://deepmind.google"},
+            {"type": "wikipedia", "value": "https://en.wikipedia.org/wiki/DeepMind"},
+        ],
+        "domains": ["deepmind.google"],
+    }
+    rec = _normalize_ror_organization(item)
+    assert "https://deepmind.google" in rec["links"]
+    assert _ror_domain_labels(rec) == {"deepmind"}  # wikipedia dropped as generic
+
+
+# --- cascade ----------------------------------------------------------------
+def _hit(ror_id: str, name: str, *, links: list[str] | None = None) -> dict:
+    return {"id": ror_id, "name": name, "aliases": [], "acronyms": [], "links": links or []}
+
+
+def _select(shortlist, *, org_name, homepage):
+    return asyncio.run(
+        _select_ror_parent(
+            handle=org_name.replace(" ", "-"),
+            org_name=org_name,
+            shortlist=shortlist,
+            parent_selector=None,  # rule-based; A1 + guards still apply
+            org_context={"homepage": homepage} if homepage else None,
+            warnings=[],
+        ),
+    )
+
+
+def test_a1_domain_match_is_decisive() -> None:
+    # Low token score, but the web domain matches -> accepted decisively.
+    shortlist = [(1, _hit("ror:broad", "Broad Institute", links=["https://www.broadinstitute.org"]))]
+    pick = _select(shortlist, org_name="broadinstitute", homepage="https://www.broadinstitute.org")
+    assert pick is not None and pick["id"] == "ror:broad"
+
+
+def test_a1_domain_mismatch_rejects_a_token_winner() -> None:
+    # GCP-style: the token winner's domain differs from the org's -> reject.
+    shortlist = [(3, _hit("ror:dm", "Google DeepMind", links=["https://deepmind.google"]))]
+    pick = _select(shortlist, org_name="Google Cloud Platform", homepage="https://cloud.google.com")
+    assert pick is None
+
+
+def test_no_domain_falls_back_to_nexus_guard() -> None:
+    # Org has no usable domain (github.io); a generic-token coincidence with no
+    # distinctive nexus is rejected by Tier B.
+    shortlist = [(2, _hit("ror:jotul", "Jøtul (Norway)", links=["http://jotul.com"]))]
+    pick = _select(
+        shortlist,
+        org_name="Edinburgh Genome Foundry",
+        homepage="https://edinburgh-genome-foundry.github.io",
+    )
+    assert pick is None


### PR DESCRIPTION
Implements **Tier A1** of the cascading owner→ROR resolver design (cheap-deterministic-first), and fixes the root ROR v2 shape bug that made it inert.

## Root fix — ROR v2 `links` shape
`_normalize_ror_organization` read `links` as bare strings, but ROR API v2 returns `{type, value}` objects (same class of bug as `name`→`names`). So the GME **never saw any ROR website/domain**. Now parses link objects + folds in the v2 `domains` field.

## Tier A1 — web-domain evidence (decisive, zero-cost, no LLM)
`_select_ror_parent` is now a cascade:
- **A1 match (accept)** — pick the shortlist candidate whose ROR registrable domain equals the org's (`broadinstitute.org` == `www.broadinstitute.org`), ignoring token score. Also rescues correct matches the rule-based tie-break used to abstain on.
- **B** — distinctive-token nexus guard (#103), now applied to both selection paths.
- **A1 mismatch (reject)** — both sides have a domain and they differ ⇒ different orgs (`cloud.google.com` vs `deepmind.google`; `ox.ac.uk` vs `oxfordresearchgroup.org.uk`).

Comparison is on the **registrable label** (name left of the public suffix, with common 2-part ccTLD suffixes), so `google` shared across `cloud.google.com` and `deepmind.google` does **not** false-match (`google.com` ≠ `deepmind.google`).

## Validated against live ROR
| case | before | now |
|---|---|---|
| GoogleCloudPlatform | → Google **DeepMind** | → a Google entity (domain match) — no longer DeepMind |
| oxpig | → Oxford Research Group | **rejected** (domain mismatch) |
| Edinburgh-Genome-Foundry | → Jøtul | **rejected** (no domain / nexus) |
| broadinstitute / huggingface / nanoporetech / AstraZeneca | (token tie / disjoint) | **resolved via domain match** |

351 ror/ownership/provider tests green; new `test_ror_domain_cascade.py`.

**Remaining (per your incremental plan, future PRs):** A2 external-id (Wikidata/GRID/ISNI), provenance/confidence, agent shadow-mode behind a flag, backfill with `refresh`/`no_cache`. GCP→Google still picks a region (right company); full regional disambiguation is out of scope here. Tuning against the full 138-pair gold set needs `gme7_ror_resolutions.txt`.