### PR TITLE
feat: @handle affiliations as GitHub orgs (_company/_bio) + owner→ROR validation harness

### DIFF
--- a/scripts/v2/validate_ror_resolution.py
+++ b/scripts/v2/validate_ror_resolution.py
@@ -1,0 +1,216 @@
+"""Validation harness for the owner→ROR resolver against a gold set.
+
+Replays the github-org → ROR resolution through the *current* cascade
+(`_select_ror_parent`: web-domain A1 → distinctive-token nexus guard) and
+compares the outcome to a gold file — the `gme7_ror_resolutions.txt` table
+produced from a real run:
+
+    github_owner            -> resolved_ROR                 ror_id   repos  ov=N  [<== SUSPECT ...]
+
+Each row is labelled from the `ov=`/SUSPECT marker:
+  * SUSPECT (ov=0, no distinctive overlap) → the *old* resolver likely matched
+    a token-coincidental org; the new cascade should REJECT it or re-resolve it
+    to a different (domain-confirmed) ROR.
+  * non-suspect (ov>=1)                    → likely correct; the new cascade
+    should KEEP it (not regress to standalone).
+
+NOTE the gold labels are heuristic (the SUSPECT flag conflates "coincidental
+wrong" with "concatenated-correct" like broadinstitute→Broad Institute), so the
+harness reports both an aggregate and a per-row old→new table for human review
+rather than treating ov=0 as ground truth. Run it in shadow mode — it never
+writes; it only resolves and reports.
+
+Usage
+-----
+    python scripts/v2/validate_ror_resolution.py gme7_ror_resolutions.txt
+    python scripts/v2/validate_ror_resolution.py gme7_ror_resolutions.txt --limit 30
+    python scripts/v2/validate_ror_resolution.py --self-test   # tiny embedded sample
+
+Needs network (GitHub org homepage + live ROR) and a GitHub token in the env
+(GITHUB_TOKEN / GME_GITHUB_TOKEN) for the homepage lookup; without one the
+domain tier is skipped and only the nexus guard runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+_ROW_RE = re.compile(
+    r"^(?P<handle>[\w.\-]+)\s+->\s+(?P<name>.+?)\s+(?P<ror>[0-9a-z]{9})\s+\d+\s+ov=(?P<ov>\d+)",
+)
+
+
+@dataclass
+class GoldRow:
+    handle: str
+    old_ror: str
+    old_name: str
+    ov: int
+
+    @property
+    def suspect(self) -> bool:
+        return self.ov == 0
+
+
+def parse_gold(path: Path) -> list[GoldRow]:
+    rows: list[GoldRow] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        m = _ROW_RE.match(line.strip())
+        if m:
+            rows.append(
+                GoldRow(
+                    handle=m["handle"],
+                    old_ror=m["ror"],
+                    old_name=m["name"].strip(),
+                    ov=int(m["ov"]),
+                ),
+            )
+    return rows
+
+
+def _github_org_meta(handle: str, token: str | None) -> tuple[str | None, str | None]:
+    """Return (homepage, display_name) for a github org/user, or (None, None).
+
+    The display name is passed as ``org_name`` so the shadow run has the same
+    name signal production does — otherwise the handle-only shortlist
+    under-resolves correct matches and the preserved-rate is misleading.
+    """
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    for kind in ("orgs", "users"):
+        try:
+            r = requests.get(
+                f"https://api.github.com/{kind}/{handle}", headers=headers, timeout=10,
+            )
+        except Exception:  # noqa: BLE001
+            continue
+        if r.status_code == 200:
+            data = r.json()
+            return (data.get("blog") or data.get("html_url"), data.get("name"))
+    return (None, None)
+
+
+async def _resolve(
+    handle: str, homepage: str | None, org_name: str | None, provider: Any,
+) -> dict[str, Any] | None:
+    from src.v2.pipeline.stages.ownership_check import (  # noqa: PLC0415
+        _github_handle_query_terms,
+        _ror_candidate_shortlist,
+        _select_ror_parent,
+    )
+
+    queries = _github_handle_query_terms(handle, org_name)
+    shortlist = _ror_candidate_shortlist(
+        handle=handle, org_name=org_name, ror_provider=provider,
+        queries=queries, max_candidates=10, warnings=[],
+    )
+    if not shortlist:
+        return None
+    return await _select_ror_parent(
+        handle=handle, org_name=org_name, shortlist=shortlist,
+        parent_selector=None,
+        org_context={"homepage": homepage} if homepage else None,
+        warnings=[],
+    )
+
+
+async def run(rows: list[GoldRow], token: str | None) -> None:
+    from src.v2.ingest.providers.ror_provider import RealRORProvider  # noqa: PLC0415
+
+    provider = RealRORProvider()
+    suspect_total = suspect_resolved_away = 0
+    correct_total = correct_preserved = 0
+    print(f"{'handle':28s} {'OLD ROR':28s} {'NEW (cascade)':28s} verdict")
+    print("-" * 100)
+    for row in rows:
+        homepage, org_name = _github_org_meta(row.handle, token)
+        pick = await _resolve(row.handle, homepage, org_name, provider)
+        new_name = (pick or {}).get("name")
+        new_ror = (pick or {}).get("id", "") or ""
+        new_ror = new_ror.rsplit("/", 1)[-1] if new_ror else None
+        changed = new_ror != row.old_ror
+
+        if row.suspect:
+            suspect_total += 1
+            # "resolved away" = the new cascade no longer keeps the suspect ROR
+            if new_ror != row.old_ror:
+                suspect_resolved_away += 1
+            verdict = "SUSPECT→fixed" if changed else "SUSPECT→still"
+        else:
+            correct_total += 1
+            if new_ror == row.old_ror:
+                correct_preserved += 1
+            verdict = "kept" if not changed else "CHANGED(review)"
+
+        print(
+            f"{row.handle:28.28s} {row.old_name:28.28s} "
+            f"{str(new_name or '— standalone'):28.28s} {verdict}",
+        )
+
+    print("-" * 100)
+    if suspect_total:
+        print(
+            f"SUSPECT pairs resolved away (rejected or re-resolved): "
+            f"{suspect_resolved_away}/{suspect_total} "
+            f"({100 * suspect_resolved_away / suspect_total:.0f}%)",
+        )
+    if correct_total:
+        print(
+            f"Non-suspect pairs preserved: "
+            f"{correct_preserved}/{correct_total} "
+            f"({100 * correct_preserved / correct_total:.0f}%)",
+        )
+
+
+_SELF_TEST = """
+Edinburgh-Genome-Foundry -> Jøtul (Norway)                  042epp307     18  ov=0  <== SUSPECT
+GoogleCloudPlatform      -> Google DeepMind (United Kingdom) 00971b260      2  ov=0  <== SUSPECT
+broadinstitute           -> Broad Institute                 05a0ya142      6  ov=0  <== SUSPECT
+google-deepmind          -> Google DeepMind (United Kingdom) 00971b260     89  ov=2
+nanoporetech             -> Oxford Nanopore Technologies     04hyfx005      1  ov=0  <== SUSPECT
+"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("gold", nargs="?", help="Path to gme7_ror_resolutions.txt")
+    ap.add_argument("--limit", type=int, default=None, help="Only the first N rows.")
+    ap.add_argument("--self-test", action="store_true", help="Run the embedded sample.")
+    args = ap.parse_args()
+
+    if args.self_test:
+        import tempfile  # noqa: PLC0415
+
+        tmp = Path(tempfile.mktemp(suffix=".txt"))
+        tmp.write_text(_SELF_TEST, encoding="utf-8")
+        rows = parse_gold(tmp)
+    elif args.gold:
+        rows = parse_gold(Path(args.gold))
+    else:
+        ap.error("provide a gold file or --self-test")
+        return 2
+
+    if args.limit:
+        rows = rows[: args.limit]
+    print(f"Parsed {len(rows)} gold rows.\n")
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GME_GITHUB_TOKEN")
+    if not token:
+        print("(no GITHUB_TOKEN — domain tier skipped, nexus guard only)\n")
+    asyncio.run(run(rows, token))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -939,6 +939,7 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
             company_result = await run_resolve_company_to_ror_stage(
                 reconciled=reconciled,
                 provider=getattr(providers, "ror_rag", None),
+                github_provider=getattr(providers, "github", None),
             )
             logger.info(
                 "%s: persons_examined=%d persons_resolved=%d "

--- a/src/v2/pipeline/stages/resolve_company_to_ror.py
+++ b/src/v2/pipeline/stages/resolve_company_to_ror.py
@@ -71,6 +71,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from src.v2.agents.models import generate_uuid
+from src.v2.canonicalization.github import github_org_iri
 from src.v2.ingest.providers.ror_rag import RorRagProvider, build_default_provider
 
 if TYPE_CHECKING:
@@ -123,6 +124,83 @@ def _read_company(person: dict[str, Any]) -> Any:
         if value:
             return value
     return None
+
+
+# `_company` / `_bio` are free text that often name an affiliation with a
+# GitHub `@handle` (e.g. company "@google-deepmind", bio "PhD @ucl, now @huggingface").
+# An @handle is far more reliably an *organization* via a GitHub lookup than via
+# free-text ROR search — and once linked as a github org it resolves to ROR
+# through the web-domain cascade. We mine both fields for @handles and check
+# each against GitHub.
+BIO_KEYS: tuple[str, ...] = ("_bio", "_orcid_biography", "_profile_readme")
+# GitHub handle grammar: alphanumeric + single hyphens, 1-39 chars.
+_AT_HANDLE_RE = re.compile(r"@([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)")
+
+
+def _extract_at_handles(person: dict[str, Any]) -> list[str]:
+    """Collect distinct `@handle` mentions from the person's company + bio
+    free-text fields, preserving first-seen order (lowercased)."""
+    texts: list[str] = []
+    company = _read_company(person)
+    if isinstance(company, str):
+        texts.append(company)
+    elif isinstance(company, list):
+        texts.extend(c for c in company if isinstance(c, str))
+    for key in BIO_KEYS:
+        value = person.get(key)
+        if isinstance(value, str):
+            texts.append(value)
+    seen: set[str] = set()
+    handles: list[str] = []
+    for text in texts:
+        for match in _AT_HANDLE_RE.finditer(text):
+            handle = match.group(1).lower()
+            if handle not in seen:
+                seen.add(handle)
+                handles.append(handle)
+    return handles
+
+
+def _github_org_iri_and_name(
+    github_provider: Any,
+    handle: str,
+    cache: dict[str, tuple[str, str] | None],
+) -> tuple[str, str] | None:
+    """If `handle` is a GitHub *organization*, return its canonical handle IRI
+    and display name; otherwise None. Cached per handle. Mirrors the
+    `validate_org_github_handles` check (`get_user(...)['type'] == Organization`)."""
+    if handle in cache:
+        return cache[handle]
+    result: tuple[str, str] | None = None
+    try:
+        data = github_provider.get_user(handle)
+    except Exception:  # noqa: BLE001 — provider/network hiccup → treat as unknown
+        data = None
+    if isinstance(data, dict) and str(data.get("type", "")).lower() == "organization":
+        iri = github_org_iri(handle) or f"https://github.com/{handle}"
+        name = data.get("name") or data.get("login") or handle
+        result = (iri, str(name))
+    cache[handle] = result
+    return result
+
+
+def _build_github_org_stub(handle_iri: str, name: str, source: str) -> dict[str, Any]:
+    """A github-org `org:Organization` stub (idSource = github handle). The
+    web-domain cascade in `ownership_check` later anchors it to a ROR id."""
+    return {
+        "id": handle_iri,
+        "type": "org:Organization",
+        "shacl": "pulse:OrganizationShape",
+        "identifiers": {
+            "pulse:githubOrganizationHandle": handle_iri,
+            "pulse:ror": None,
+            "uuid": generate_uuid(),
+        },
+        "idSource": "pulse:githubOrganizationHandle",
+        "schema:name": name,
+        "pulse:githubOrganizationHandle": handle_iri,
+        "_source": source,
+    }
 
 
 _COUNTRY_SUFFIX_RE = re.compile(r"\s*\([^)]+\)\s*$")
@@ -348,9 +426,16 @@ async def run_resolve_company_to_ror_stage(
     *,
     reconciled: "ReconciledEntities",
     provider: RorRagProvider | None = None,
+    github_provider: Any = None,
 ) -> CompanyAffiliationResult:
     """Stage entry. Materialises one Membership + (when new) one
     Organization per accepted ROR hit, idempotently.
+
+    When ``github_provider`` is supplied, `@handle` mentions in the person's
+    ``_company`` / ``_bio`` that GitHub confirms are *organizations* are linked
+    as github-org affiliations (and excluded from the free-text ROR search,
+    which is far less reliable for a handle); the github org then resolves to
+    ROR via the web-domain cascade in ``ownership_check``.
 
     Re-running the stage on a graph that already contains its earlier
     output is a no-op — both the org set and the membership composite
@@ -367,8 +452,9 @@ async def run_resolve_company_to_ror_stage(
 
     persons = reconciled.entities.get("persons") or []
     cache: dict[str, dict[str, Any] | None] = {}
+    gh_cache: dict[str, tuple[str, str] | None] = {}
     reasons: dict[str, int] = {}
-    resolved = 0
+    resolved_persons: set[str] = set()
     memberships_added = 0
     organizations_added = 0
 
@@ -381,6 +467,36 @@ async def run_resolve_company_to_ror_stage(
         person_id = _person_canonical_id(person)
         if not person_id:
             continue
+
+        # --- GitHub @handle -> org affiliation (from _company + _bio) -------
+        # A handle GitHub confirms is an organization is linked directly; record
+        # it so the free-text ROR search below skips that chunk (an @handle is a
+        # much weaker free-text ROR query than a confirmed github org).
+        github_handles: set[str] = set()
+        if github_provider is not None:
+            for handle in _extract_at_handles(person):
+                meta = _github_org_iri_and_name(github_provider, handle, gh_cache)
+                if meta is None:
+                    continue
+                iri, name = meta
+                github_handles.add(handle)
+                if iri not in existing_org_ids:
+                    reconciled.entities.setdefault("organizations", []).append(
+                        _build_github_org_stub(iri, name, STAGE_SOURCE_TAG),
+                    )
+                    existing_org_ids.add(iri)
+                    organizations_added += 1
+                composite = f"{person_id}__{iri}"
+                if composite not in existing_membership_keys:
+                    reconciled.entities.setdefault("memberships", []).append(
+                        _build_membership(
+                            person_id=person_id, org_id=iri, source=STAGE_SOURCE_TAG,
+                        ),
+                    )
+                    existing_membership_keys.add(composite)
+                    memberships_added += 1
+                    resolved_persons.add(person_id)
+
         raw_companies = _read_company(person)
         if not raw_companies:
             continue
@@ -394,6 +510,9 @@ async def run_resolve_company_to_ror_stage(
         candidate_hits: list[dict[str, Any]] = []
         for raw in raw_list:
             for part in _split_joint(raw):
+                # Skip a chunk already linked as a github org above.
+                if part.startswith("@") and _clean_query(part).lower() in github_handles:
+                    continue
                 hit, reason = await _resolve_one(provider, cache, part)
                 if hit is not None:
                     ror_id = hit.get("ror_id")
@@ -416,13 +535,13 @@ async def run_resolve_company_to_ror_stage(
             existing_membership_keys=existing_membership_keys,
         )
         if m_added > 0:
-            resolved += 1
+            resolved_persons.add(person_id)
             memberships_added += m_added
             organizations_added += o_added
 
     result = CompanyAffiliationResult(
         persons_examined=len(persons),
-        persons_resolved=resolved,
+        persons_resolved=len(resolved_persons),
         memberships_created=memberships_added,
         organizations_created=organizations_added,
         queries_attempted=len(cache),

--- a/tests/v2/test_company_github_mentions.py
+++ b/tests/v2/test_company_github_mentions.py
@@ -1,0 +1,105 @@
+"""@handle mentions in `_company` / `_bio` are linked as GitHub orgs.
+
+A person's free-text `_company` ("@google-deepmind") or `_bio` ("now at
+@huggingface") often names the affiliation by GitHub handle. A handle GitHub
+confirms is an *organization* is linked directly as a github-org affiliation
+(which then resolves to ROR via the web-domain cascade), instead of being
+fed to the weaker free-text ROR search.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from src.v2.pipeline.stages.models import ReconciledEntities
+from src.v2.pipeline.stages.resolve_company_to_ror import (
+    run_resolve_company_to_ror_stage,
+)
+
+
+class _StubGitHub:
+    def __init__(self, lookups: dict[str, dict[str, Any]]) -> None:
+        self._lookups = lookups
+        self.calls: list[str] = []
+
+    def get_user(self, login: str) -> dict[str, Any]:
+        self.calls.append(login)
+        return self._lookups.get(login.lower(), {})
+
+
+class _NoRor:
+    async def search(self, **_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+
+def _run(person: dict[str, Any], github: Any) -> ReconciledEntities:
+    rec = ReconciledEntities(
+        entities={"persons": [person], "organizations": [], "memberships": []},
+    )
+    asyncio.run(
+        run_resolve_company_to_ror_stage(
+            reconciled=rec, provider=_NoRor(), github_provider=github,
+        ),
+    )
+    return rec
+
+
+def test_company_and_bio_at_handles_become_github_orgs() -> None:
+    gh = _StubGitHub(
+        {
+            "google-deepmind": {"type": "Organization", "name": "Google DeepMind"},
+            "huggingface": {"type": "Organization", "name": "Hugging Face"},
+            "someuser": {"type": "User"},
+        },
+    )
+    person = {
+        "id": "https://github.com/alice",
+        "schema:name": "Alice",
+        "_company": "@google-deepmind",
+        "_bio": "PhD; now at @huggingface and @someuser",
+    }
+    rec = _run(person, gh)
+
+    orgs = {o["id"]: o for o in rec.entities["organizations"]}
+    assert set(orgs) == {
+        "https://github.com/google-deepmind",
+        "https://github.com/huggingface",
+    }
+    gd = orgs["https://github.com/google-deepmind"]
+    assert gd["idSource"] == "pulse:githubOrganizationHandle"
+    assert gd["pulse:githubOrganizationHandle"] == "https://github.com/google-deepmind"
+    assert gd["schema:name"] == "Google DeepMind"
+    # @someuser is a User, not an org -> no entity for it.
+    assert "https://github.com/someuser" not in orgs
+    member_orgs = {m["org:organization"] for m in rec.entities["memberships"]}
+    assert member_orgs == set(orgs)
+
+
+def test_non_org_handle_is_not_linked() -> None:
+    gh = _StubGitHub({"someuser": {"type": "User"}})
+    rec = _run({"id": "p", "_company": "@someuser"}, gh)
+    assert rec.entities["organizations"] == []
+    assert rec.entities["memberships"] == []
+
+
+def test_idempotent_across_reruns() -> None:
+    gh = _StubGitHub({"google-deepmind": {"type": "Organization", "name": "Google DeepMind"}})
+    person = {"id": "https://github.com/alice", "_company": "@google-deepmind"}
+    rec = ReconciledEntities(
+        entities={"persons": [person], "organizations": [], "memberships": []},
+    )
+    for _ in range(2):
+        asyncio.run(
+            run_resolve_company_to_ror_stage(
+                reconciled=rec, provider=_NoRor(), github_provider=gh,
+            ),
+        )
+    assert len(rec.entities["organizations"]) == 1
+    assert len(rec.entities["memberships"]) == 1
+
+
+def test_no_github_provider_is_a_noop_for_handles() -> None:
+    # Without a github provider, the @handle falls through to ROR (here: none).
+    rec = _run({"id": "p", "_company": "@google-deepmind"}, None)
+    assert rec.entities["organizations"] == []


### PR DESCRIPTION
Two related items.

## feat(v2 affiliation): @handle mentions → GitHub orgs
A person's free-text `_company` (`@google-deepmind`) or `_bio` (`now at @huggingface`) often names the affiliation by **GitHub handle**. An @handle is far more reliably an *organization* via a GitHub lookup than via free-text ROR search (which mis-resolves — cf. the Jøtul problem). `resolve_company_to_ror` now mines @handles from `_company` + `_bio`; each one GitHub confirms is an Organization (`get_user(...)['type']=='Organization'`) becomes a github-org `Organization` (`idSource=pulse:githubOrganizationHandle`) + `Membership`, idempotent, and is excluded from the free-text ROR search. The github org then anchors to ROR via the **web-domain cascade** in `ownership_check` (#104). `github_provider` threaded from `providers.github`; @Users / 404s fall through to existing behavior.

Verified: `@google-deepmind` (company) + `@huggingface` (bio) → both linked as github orgs; `@someuser` (User) ignored; idempotent; no-op without a github provider. 34 company-resolver tests green.

## feat(scripts): owner→ROR validation harness (shadow-mode)
`scripts/v2/validate_ror_resolution.py` replays github-org→ROR through the current cascade against the `gme7_ror_resolutions.txt` gold table and reports old→new + suspect-resolved-away / non-suspect-preserved rates. Never writes; fetches each org's GitHub homepage + name so the shadow run matches production signal. `--self-test` (embedded sample) → 4/4 suspect resolved away.

Part of the cascading owner→ROR redesign (A1 domain shipped in #104). Next increments: A2 external-id (Wikidata/GRID/ISNI), provenance/confidence, agent shadow-mode, backfill `refresh` flag.