### PR TITLE
fix(v2 ownership): disambiguate A1 web-domain collisions (parent-domain residual)

### DIFF
--- a/src/v2/pipeline/stages/ownership_check.py
+++ b/src/v2/pipeline/stages/ownership_check.py
@@ -1047,6 +1047,41 @@ def _ror_acronyms(record: dict[str, Any]) -> set[str]:
     }
 
 
+def _has_country_qualifier(name: Any) -> bool:
+    """A trailing `(...)` — ROR's per-country record suffix, e.g. 'Google (Canada)'."""
+    return isinstance(name, str) and bool(re.search(r"\([^)]*\)\s*$", name))
+
+
+def _disambiguate_domain_matches(
+    matches: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Pick the right ROR record among shortlist candidates that all share the
+    org's web domain, or None to abstain.
+
+    A shared institutional/parent domain spans many records: NIH (`nih.gov` ->
+    NLM / NHLBI / NCI), a university campus (`nyu.edu`), or a multinational's
+    per-country records (`google.com` -> 'Google (Canada)' / '(United States)').
+    The bare first-match would pick an arbitrary sub-entity/region (the residual
+    'parent-domain collision'). Instead:
+
+      * 1 match           -> accept it.
+      * N regional variants of ONE org (same country-stripped name) -> accept the
+        single unqualified 'global' record if present; else abstain.
+      * N distinct sub-entities (different names) -> abstain (the domain is an
+        umbrella; let name-token matching / the selector decide).
+    """
+    if not matches:
+        return None
+    if len(matches) == 1:
+        return matches[0]
+    base_names = {_despace(_PAREN_RE.sub("", str(m.get("name") or ""))) for m in matches}
+    if len(base_names) == 1:
+        unqualified = [m for m in matches if not _has_country_qualifier(m.get("name"))]
+        if len(unqualified) == 1:
+            return unqualified[0]
+    return None
+
+
 def _stamp_match(
     hit: dict[str, Any], tier: str, confidence: float, handle: str, warnings: list[str],
 ) -> dict[str, Any]:
@@ -1283,9 +1318,19 @@ async def _select_ror_parent(
     #   A2 external id  (shared grid/isni/wikidata/fundref)
     #   A3 exact name / acronym (normalised equality)
     if org_label:
-        for _score, hit in shortlist:
-            if org_label in _ror_domain_labels(hit):
-                return _stamp_match(hit, "A1_domain", 0.98, handle, warnings)
+        domain_matches = [
+            hit for _score, hit in shortlist if org_label in _ror_domain_labels(hit)
+        ]
+        chosen = _disambiguate_domain_matches(domain_matches)
+        if chosen is not None:
+            return _stamp_match(chosen, "A1_domain", 0.98, handle, warnings)
+        if len(domain_matches) > 1:
+            warnings.append(
+                f"github_handle_parents: A1 web-domain ambiguous for handle "
+                f"'{handle}' ('{org_label}' shared by {len(domain_matches)} records: "
+                f"{[m.get('name') for m in domain_matches][:4]}) — deferring to "
+                f"name/selector.",
+            )
     if org_ext:
         for _score, hit in shortlist:
             if org_ext & _ror_external_ids(hit):

--- a/tests/v2/test_ror_domain_cascade.py
+++ b/tests/v2/test_ror_domain_cascade.py
@@ -153,3 +153,58 @@ def test_a1_domain_wins_over_a3_exact_name() -> None:
     )
     assert pick is not None and pick["id"] == "ror:right"
     assert pick["_ror_match_tier"] == "A1_domain"
+
+
+# --- A1 parent-domain-collision disambiguation ------------------------------
+def _hd(ror_id: str, name: str, domain: str):
+    return _hit_ext(ror_id, name, links=[f"https://{domain}"])
+
+
+def test_a1_regional_variants_prefers_global_record() -> None:
+    shortlist = [
+        (1, _hd("g:ca", "Google (Canada)", "google.com")),
+        (1, _hd("g:global", "Google", "google.com")),
+        (1, _hd("g:us", "Google (United States)", "google.com")),
+    ]
+    pick = asyncio.run(
+        _select_ror_parent(
+            handle="GoogleCloudPlatform", org_name="Google Cloud Platform",
+            shortlist=shortlist, parent_selector=None,
+            org_context={"homepage": "https://cloud.google.com"}, warnings=[],
+        ),
+    )
+    assert pick is not None and pick["id"] == "g:global"
+    assert pick["_ror_match_tier"] == "A1_domain"
+
+
+def test_a1_all_regional_no_global_abstains() -> None:
+    # No unqualified 'Google' record -> A1 abstains; rule-based token<2 -> None.
+    shortlist = [
+        (1, _hd("g:ca", "Google (Canada)", "google.com")),
+        (1, _hd("g:us", "Google (United States)", "google.com")),
+    ]
+    pick = asyncio.run(
+        _select_ror_parent(
+            handle="GoogleCloudPlatform", org_name="Google Cloud Platform",
+            shortlist=shortlist, parent_selector=None,
+            org_context={"homepage": "https://cloud.google.com"}, warnings=[],
+        ),
+    )
+    assert pick is None  # no arbitrary region picked
+
+
+def test_a1_umbrella_domain_defers_to_name_match() -> None:
+    # NLM and NHLBI both nih.gov (distinct sub-entities) -> A1 abstains; the
+    # exact-name / token tier then picks the RIGHT one (NLM, not NHLBI).
+    shortlist = [
+        (2, _hd("nhlbi", "National Heart, Lung, and Blood Institute", "nih.gov")),
+        (2, _hd("nlm", "National Library of Medicine", "nih.gov")),
+    ]
+    pick = asyncio.run(
+        _select_ror_parent(
+            handle="NLM-DIR", org_name="National Library of Medicine",
+            shortlist=shortlist, parent_selector=None,
+            org_context={"homepage": "https://www.nlm.nih.gov"}, warnings=[],
+        ),
+    )
+    assert pick is not None and pick["id"] == "nlm"


### PR DESCRIPTION
Closes the residual class the **full gold-set validation** surfaced: a shared institutional / parent domain spans many ROR records, and A1's bare first-match picked an arbitrary sub-entity/region.

- NIH (`nih.gov` → NLM / NHLBI / NCI) → `NLM-DIR` resolved to NHLBI
- university (`nyu.edu`) → `VIDA-NYU` to the Florence campus
- multinational per-country (`google.com` → 'Google (Canada)'/'(United States)') → `GoogleCloudPlatform` to Google Canada; `microsoft` to a region

`_disambiguate_domain_matches`:
- **1 match** → accept.
- **N regional variants of one org** (same country-stripped name) → accept the single unqualified *global* record if present; else **abstain** (never guess a region).
- **N distinct sub-entities** (different names) → **abstain**; A3/name-token/selector then picks the right one.

Validated: `GoogleCloudPlatform` → global 'Google' (or abstains); `NLM-DIR` → **National Library of Medicine** (not NHLBI); `broadinstitute`/`huggingface` single-domain matches unchanged. 17 cascade tests + ownership suite green.

## Full gold-set validation summary (213 pairs)
- Coincidental wrong matches (the field-report bug) — **all fixed** (Jøtul/Ai Corporation/Planet/NAVER/Accenture/Celagix/Barrick/META → standalone).
- Correct concatenated/acronym matches — **preserved** (broadinstitute/huggingface/NIST/PNNL/SSI/VTT…).
- Parent-domain collisions — **this PR**.
- (Harness 'preserved 26%' is a rule_based artifact — production's LLM selector + the A-tiers resolve token-only cases the shadow run abstains on.)