### PR TITLE
feat(v2 extract): per-request cache refresh (backfill flag)

### DIFF
--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -145,7 +145,12 @@ from src.v2.indices.zenodo_records import (
     run_zenodo_records_ingest_job,
     run_zenodo_records_search,
 )
-from src.v2.ingest.cache import ProviderCache
+from src.v2.ingest.cache import (
+    ProviderCache,
+    cache_refresh_active,
+    reset_cache_refresh,
+    set_cache_refresh,
+)
 from src.v2.ingest.detection import UnsupportedGitHubURL, classify_github_url
 from src.v2.jobs import JobStore
 from src.v2.observation.github_rate_limit import (
@@ -511,6 +516,7 @@ async def _run_extract_job(
         if payload.model_override is not None
         else None,
     )
+    refresh_token = set_cache_refresh(payload.refresh)
     try:
         existing = job_store.get(job_id)
         if existing is None:
@@ -598,6 +604,7 @@ async def _run_extract_job(
         job_store.set(record)
     finally:
         reset_request_model_override(override_token)
+        reset_cache_refresh(refresh_token)
         if heartbeat_task is not None:
             heartbeat_task.cancel()
             with contextlib.suppress(Exception):
@@ -805,7 +812,9 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
             include_context_summary=bool(include_context_summary),
             include_internal_fields=bool(include_internal_fields),
         )
-        cached_response = pipeline_cache.get(pipeline_cache_key)
+        # Backfill refresh: skip the read so the pipeline re-runs with current
+        # logic; the fresh result is still written back to `pipeline_cache_key`.
+        cached_response = None if cache_refresh_active() else pipeline_cache.get(pipeline_cache_key)
         if isinstance(cached_response, dict):
             try:
                 response_model = V2ExtractResponse.model_validate(cached_response)

--- a/src/v2/api_models/contracts.py
+++ b/src/v2/api_models/contracts.py
@@ -99,6 +99,15 @@ class V2ExtractRequest(BaseModel):
             "ignored otherwise. Target a different chat model/endpoint for a single run."
         ),
     )
+    refresh: bool = Field(
+        default=False,
+        description=(
+            "Bypass caches for this extraction (targeted backfill): skip the "
+            "pipeline-cache read and re-fetch providers, then overwrite the stale "
+            "entries — so a single re-extract picks up current pipeline logic "
+            "without clearing the whole cache. The result is still written back."
+        ),
+    )
 
 
 class V2ExtractResponse(BaseModel):

--- a/src/v2/ingest/cache.py
+++ b/src/v2/ingest/cache.py
@@ -11,6 +11,7 @@ import json
 import logging
 import sqlite3
 import time
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, Callable
 
@@ -18,6 +19,26 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CACHE_TTL_DAYS = 30
 SECONDS_PER_DAY = 86_400
+
+# Per-request cache-refresh ("backfill") toggle. When active, `get_or_set`
+# skips the read and always recomputes — so a single extraction re-fetches
+# providers and re-runs the pipeline with current code, then overwrites the
+# stale entries — WITHOUT clearing the whole cache. Carried in a ContextVar so
+# it scopes to one request's async task. Set it via `set_cache_refresh`.
+_refresh_active: ContextVar[bool] = ContextVar("v2_cache_refresh", default=False)
+
+
+def set_cache_refresh(enabled: bool) -> object:
+    """Enable/disable cache-refresh for the current task; returns a reset token."""
+    return _refresh_active.set(bool(enabled))
+
+
+def reset_cache_refresh(token: object) -> None:
+    _refresh_active.reset(token)  # type: ignore[arg-type]
+
+
+def cache_refresh_active() -> bool:
+    return _refresh_active.get()
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS responses (
@@ -98,11 +119,14 @@ class ProviderCache:
         ttl_seconds: float | None = None,
         label: str | None = None,
     ) -> Any:
-        cached = self.get(key)
-        if cached is not None:
-            if label:
-                logger.info("provider cache hit: %s", label)
-            return cached
+        if not _refresh_active.get():
+            cached = self.get(key)
+            if cached is not None:
+                if label:
+                    logger.info("provider cache hit: %s", label)
+                return cached
+        elif label:
+            logger.info("provider cache refresh (bypass read): %s", label)
         value = factory()
         if value is not None:
             self.set(key, value, ttl_seconds=ttl_seconds)
@@ -126,4 +150,7 @@ __all__ = [
     "DEFAULT_CACHE_TTL_DAYS",
     "SECONDS_PER_DAY",
     "ProviderCache",
+    "cache_refresh_active",
+    "reset_cache_refresh",
+    "set_cache_refresh",
 ]

--- a/tests/v2/test_cache_refresh.py
+++ b/tests/v2/test_cache_refresh.py
@@ -1,0 +1,70 @@
+"""Backfill cache-refresh toggle on ProviderCache.
+
+When the per-request refresh flag is active, `get_or_set` must bypass the read
+(recompute every time) and overwrite the stored value — so a single re-extract
+picks up current logic without clearing the whole cache.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.v2.ingest.cache import (
+    ProviderCache,
+    cache_refresh_active,
+    reset_cache_refresh,
+    set_cache_refresh,
+)
+
+
+def _cache(tmp_path: Path) -> ProviderCache:
+    return ProviderCache(tmp_path / "c.db")
+
+
+def test_get_or_set_caches_by_default(tmp_path: Path) -> None:
+    cache = _cache(tmp_path)
+    calls = {"n": 0}
+
+    def factory() -> str:
+        calls["n"] += 1
+        return f"v{calls['n']}"
+
+    assert cache.get_or_set("k", factory) == "v1"
+    assert cache.get_or_set("k", factory) == "v1"  # served from cache
+    assert calls["n"] == 1
+
+
+def test_refresh_bypasses_read_and_overwrites(tmp_path: Path) -> None:
+    cache = _cache(tmp_path)
+    calls = {"n": 0}
+
+    def factory() -> str:
+        calls["n"] += 1
+        return f"v{calls['n']}"
+
+    assert cache.get_or_set("k", factory) == "v1"  # populate
+
+    token = set_cache_refresh(True)
+    try:
+        assert cache_refresh_active() is True
+        assert cache.get_or_set("k", factory) == "v2"  # recomputed, not served
+    finally:
+        reset_cache_refresh(token)
+
+    assert calls["n"] == 2
+    assert cache_refresh_active() is False
+    # the refreshed value was written back
+    assert cache.get_or_set("k", factory) == "v2"
+    assert calls["n"] == 2  # served from cache again, no recompute
+
+
+def test_refresh_default_is_off() -> None:
+    assert cache_refresh_active() is False
+
+
+def test_extract_request_has_refresh_field() -> None:
+    from src.v2.api_models.contracts import V2ExtractRequest
+
+    req = V2ExtractRequest(source_url="https://github.com/x/y", refresh=True)
+    assert req.refresh is True
+    assert V2ExtractRequest(source_url="https://github.com/x/y").refresh is False


### PR DESCRIPTION
Lands the index/RAG improvements (the owner→ROR cascade #104-#108) on **already-extracted** repos without nuking the whole cache.

**Problem:** re-extracting an affected repo returns the stale result — the pipeline cache replays the old `V2ExtractResponse` (e.g. the old Jøtul mapping), and the ProviderCache replays old provider responses (pre-#104 ROR records with no `links`). The only lever was `POST /v2/cache/clear` (global wipe → re-fetches everything).

**Fix:** `V2ExtractRequest.refresh: bool` (default false). When set, for that extraction only:
- `ProviderCache.get_or_set` bypasses the read and recomputes (a ContextVar set by the job runner, reset in `finally` — same pattern as the model override);
- the pipeline-cache read is skipped so the pipeline re-runs with current code;
- the fresh result is still **written back**, overwriting the stale entries.

So an operator re-extracts just the ~138 affected repos (targeted cache-bust) and picks up the improvements, instead of clearing everything.

Tests: `get_or_set` caches by default; refresh bypasses read + overwrites + persists; default off; `refresh` field present. 158 cache/extract/job/api tests green.

This is the **last item of the owner→ROR redesign plan** — it's how all of #104-#108 reaches production.