### PR TITLE
feat(github_repos index): repo_id is the canonical GitHub URL (v3.0.0 ids, step 1)

### DIFF
--- a/src/index/github_repos/ingest/repos.py
+++ b/src/index/github_repos/ingest/repos.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from src.index.github_repos.ingest.github_client import GitHubClient
 from src.index.github_repos.models import ContributorEntry, RepoRecord
+from src.v2.canonicalization.github import github_repo_iri
 
 if TYPE_CHECKING:
     from src.index.github_repos.config import GitHubIndexConfig
@@ -42,7 +43,10 @@ def _record_from_payload(
     owner = owner_block.get("login") or full_name.split("/", 1)[0]
     name = repo_payload.get("name") or full_name.split("/", 1)[1]
     return RepoRecord(
-        repo_id=full_name,
+        # v3.0.0: the id is the canonical GitHub URL (owner/name kept as their
+        # own bare fields). Consistent with zenodo/openalex/ror stores, the old
+        # HF monolith, and the extract pipeline's pulse:* github IRIs.
+        repo_id=github_repo_iri(full_name) or full_name,
         owner=str(owner),
         name=str(name),
         default_branch=repo_payload.get("default_branch"),

--- a/src/index/github_repos/models.py
+++ b/src/index/github_repos/models.py
@@ -19,7 +19,7 @@ class ContributorEntry(BaseModel):
 
 
 class RepoRecord(BaseModel):
-    repo_id: str  # "<owner>/<name>"
+    repo_id: str  # canonical URL: https://github.com/<owner>/<name>
     owner: str
     name: str
     default_branch: Optional[str] = None

--- a/src/index/github_repos/storage/schema.sql
+++ b/src/index/github_repos/storage/schema.sql
@@ -2,7 +2,7 @@
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 
 CREATE TABLE IF NOT EXISTS repos (
-    repo_id            TEXT PRIMARY KEY,             -- "<owner>/<name>"
+    repo_id            TEXT PRIMARY KEY,             -- canonical URL https://github.com/<owner>/<name>
     owner              TEXT NOT NULL,
     name               TEXT NOT NULL,
     default_branch     TEXT,

--- a/tests/index/github_repos/test_repo_id_canonical_url.py
+++ b/tests/index/github_repos/test_repo_id_canonical_url.py
@@ -1,0 +1,36 @@
+"""github_repos `repo_id` is the canonical GitHub URL (v3.0.0 index ids).
+
+All index ids that have a canonical URL are stored as that URL — consistent
+with the zenodo/openalex/ror stores and the extract pipeline's pulse:* github
+IRIs. `owner` / `name` stay bare (decomposed fields).
+"""
+
+from __future__ import annotations
+
+from src.index.github_repos.ingest.repos import _record_from_payload
+
+
+def test_repo_id_is_canonical_url() -> None:
+    rec = _record_from_payload(
+        full_name="pallets/click",
+        repo_payload={"owner": {"login": "pallets"}, "name": "click"},
+        languages={"Python": 100},
+        contributors=[],
+        readme_text=None,
+        readme_path=None,
+    )
+    assert rec.repo_id == "https://github.com/pallets/click"
+    assert rec.owner == "pallets"  # bare, unchanged
+    assert rec.name == "click"
+
+
+def test_repo_id_idempotent_if_already_url() -> None:
+    rec = _record_from_payload(
+        full_name="https://github.com/pallets/click",
+        repo_payload={"name": "click"},
+        languages={},
+        contributors=[],
+        readme_text=None,
+        readme_path=None,
+    )
+    assert rec.repo_id == "https://github.com/pallets/click"


### PR DESCRIPTION
**Step 1** of canonicalising all index ids to URLs (per the plan: all ids that have a canonical URL must *be* the URL).

The github_repos store keyed on bare `owner/name`; `zenodo_records`/`openalex`/`ror` already key on URLs, the old HF monolith did too, and the extract pipeline emits `pulse:*` GitHub URL IRIs — so the bare id was the odd one out.

`_record_from_payload` now sets `repo_id = github_repo_iri(full_name)` → `https://github.com/<owner>/<name>`. `owner`/`name` stay bare (separate fields) so scope/seed parsing and the GitHub API calls (which use `full_name`) are unaffected; `chunks.entity_id` + the Qdrant point + the search-hit `id` follow automatically. Idempotent if already a URL.

**Backfill:** re-ingest with the #109 `refresh` flag (the projector now emits URL ids), or `UPDATE repos SET repo_id='https://github.com/'||repo_id` + re-embed.

Tests: projector emits the URL; idempotent. 49 github/canonicalization tests green.

**Next increments:** github_organizations/users (need the id-vs-login split — `login` is currently both the PK and the value); huggingface_* (restores the old monolith's URL form); dockerhub; orcid. zenodo/openalex/ror already URL.