### PR TITLE
feat(hf index): models/datasets/spaces repo_id is the canonical URL (v3.0.0 ids, step 2)

### DIFF
--- a/src/index/huggingface_datasets/ingest/datasets.py
+++ b/src/index/huggingface_datasets/ingest/datasets.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from src.index.huggingface_datasets.models import DatasetRecord
+from src.v2.canonicalization.huggingface import huggingface_iri
 
 if TYPE_CHECKING:
     from src.index._huggingface_base.client import HFClient
@@ -106,7 +107,7 @@ def _record_from_info(repo_id: str, info: Any) -> DatasetRecord:
         dataset_info = {}
 
     return DatasetRecord(
-        repo_id=repo_id,
+        repo_id=huggingface_iri(repo_id, "dataset") or repo_id,
         author=getattr(info, "author", None),
         sha=getattr(info, "sha", None),
         license=card_data_dict.get("license") if isinstance(card_data_dict, dict) else None,

--- a/src/index/huggingface_models/ingest/models.py
+++ b/src/index/huggingface_models/ingest/models.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from src.index.huggingface_models.models import ModelRecord
+from src.v2.canonicalization.huggingface import huggingface_iri
 
 if TYPE_CHECKING:
     from src.index._huggingface_base.client import HFClient
@@ -85,7 +86,7 @@ def _record_from_info(repo_id: str, info: Any) -> ModelRecord:
     else:
         base_models = []
     return ModelRecord(
-        repo_id=repo_id,
+        repo_id=huggingface_iri(repo_id, "model") or repo_id,
         author=getattr(info, "author", None),
         sha=getattr(info, "sha", None),
         pipeline_tag=getattr(info, "pipeline_tag", None),

--- a/src/index/huggingface_models/models.py
+++ b/src/index/huggingface_models/models.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 class ModelRecord(BaseModel):
     """Structured view of an HF model persisted to DuckDB.
 
-    ``repo_id`` is the natural primary key (``<namespace>/<name>``).
+    ``repo_id`` is the canonical URL (https://huggingface.co/<repo_id>).
     Mirrors the schema columns in ``storage/schema.sql``.
     """
 

--- a/src/index/huggingface_models/storage/schema.sql
+++ b/src/index/huggingface_models/storage/schema.sql
@@ -2,7 +2,7 @@
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 
 CREATE TABLE IF NOT EXISTS models (
-    repo_id              TEXT PRIMARY KEY,             -- "<namespace>/<name>"
+    repo_id              TEXT PRIMARY KEY,             -- canonical URL https://huggingface.co/<repo_id>
     author               TEXT,
     sha                  TEXT,
     pipeline_tag         TEXT,

--- a/src/index/huggingface_spaces/ingest/spaces.py
+++ b/src/index/huggingface_spaces/ingest/spaces.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from src.index.huggingface_spaces.models import SpaceRecord
+from src.v2.canonicalization.huggingface import huggingface_iri
 
 if TYPE_CHECKING:
     from src.index._huggingface_base.client import HFClient
@@ -79,7 +80,7 @@ def _record_from_info(repo_id: str, info: Any) -> SpaceRecord:
     stage, hardware = _runtime_fields(info)
 
     return SpaceRecord(
-        repo_id=repo_id,
+        repo_id=huggingface_iri(repo_id, "space") or repo_id,
         author=getattr(info, "author", None),
         sha=getattr(info, "sha", None),
         sdk=getattr(info, "sdk", None),

--- a/src/v2/canonicalization/huggingface.py
+++ b/src/v2/canonicalization/huggingface.py
@@ -1,0 +1,55 @@
+"""Canonical HuggingFace URL builder for index ids.
+
+HuggingFace's native ids are bare (`<namespace>/<name>` for repos, a bare
+`<slug>` for users/orgs, an arXiv id for papers). v3.0.0 stores the canonical
+URL as the id — consistent with the github/zenodo/openalex/ror index ids and
+the extract pipeline's URL identifiers.
+
+The per-surface URL prefix differs:
+  model    -> https://huggingface.co/<repo_id>
+  dataset  -> https://huggingface.co/datasets/<repo_id>
+  space    -> https://huggingface.co/spaces/<repo_id>
+  user/org -> https://huggingface.co/<slug>
+  paper    -> https://huggingface.co/papers/<arxiv_id>
+"""
+
+from __future__ import annotations
+
+_BASE = "https://huggingface.co/"
+_PREFIX: dict[str, str] = {
+    "model": "",
+    "models": "",
+    "dataset": "datasets/",
+    "datasets": "datasets/",
+    "space": "spaces/",
+    "spaces": "spaces/",
+    "user": "",
+    "users": "",
+    "org": "",
+    "organization": "",
+    "organizations": "",
+    "paper": "papers/",
+    "papers": "papers/",
+}
+
+
+def huggingface_iri(value: str | None, kind: str = "model") -> str | None:
+    """Canonical HuggingFace URL for a bare id (or an already-canonical URL).
+
+    Returns None on empty/invalid input. Idempotent: a value already under
+    ``https://huggingface.co/`` is returned unchanged (trailing slash trimmed).
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    s = value.strip()
+    if s.lower().startswith(_BASE):
+        return s.rstrip("/")
+    if s.lower().startswith("http://huggingface.co/"):
+        return ("https://" + s.split("://", 1)[1]).rstrip("/")
+    prefix = _PREFIX.get(kind.lower().strip())
+    if prefix is None:
+        return None
+    return f"{_BASE}{prefix}{s.strip('/')}"
+
+
+__all__ = ["huggingface_iri"]

--- a/tests/index/huggingface_canonical/test_hf_repo_id_url.py
+++ b/tests/index/huggingface_canonical/test_hf_repo_id_url.py
@@ -1,0 +1,37 @@
+"""HuggingFace models/datasets/spaces `repo_id` is the canonical URL (v3.0.0)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.index.huggingface_datasets.ingest.datasets import (
+    _record_from_info as dataset_record,
+)
+from src.index.huggingface_models.ingest.models import _record_from_info as model_record
+from src.index.huggingface_spaces.ingest.spaces import _record_from_info as space_record
+from src.v2.canonicalization.huggingface import huggingface_iri
+
+
+@pytest.mark.parametrize(
+    ("builder", "expected"),
+    [
+        (model_record, "https://huggingface.co/ZurichNLP/swissbert"),
+        (dataset_record, "https://huggingface.co/datasets/ZurichNLP/swissbert"),
+        (space_record, "https://huggingface.co/spaces/ZurichNLP/swissbert"),
+    ],
+)
+def test_repo_id_is_canonical_url(builder, expected) -> None:
+    rec = builder("ZurichNLP/swissbert", SimpleNamespace())
+    assert rec.repo_id == expected
+
+
+def test_canonicalizer_idempotent_and_kinds() -> None:
+    assert huggingface_iri("a/b", "model") == "https://huggingface.co/a/b"
+    assert huggingface_iri("a/b", "dataset") == "https://huggingface.co/datasets/a/b"
+    assert huggingface_iri("x", "user") == "https://huggingface.co/x"
+    assert huggingface_iri("2310.01234", "paper") == "https://huggingface.co/papers/2310.01234"
+    # idempotent
+    assert huggingface_iri("https://huggingface.co/datasets/a/b", "dataset") == "https://huggingface.co/datasets/a/b"
+    assert huggingface_iri("", "model") is None

--- a/tests/v2/test_index_huggingface_datasets.py
+++ b/tests/v2/test_index_huggingface_datasets.py
@@ -98,7 +98,7 @@ def test_record_from_info_populates_dataset_specific_fields() -> None:
         paperswithcode_id="my-dataset",
     )
     record = _record_from_info("user/my-dataset", info)
-    assert record.repo_id == "user/my-dataset"
+    assert record.repo_id == "https://huggingface.co/datasets/user/my-dataset"
     assert record.license == "cc-by-4.0"
     assert record.downloads == 42
     assert record.likes == 10
@@ -126,7 +126,7 @@ def test_ingest_single_dataset_round_trips(
         config=object(), store=datasets_store, client=client, repo_id="alice/x",
     )
     assert outcome == "ingested"
-    row = datasets_store.fetch_dataset("alice/x")
+    row = datasets_store.fetch_dataset("https://huggingface.co/datasets/alice/x")
     assert row is not None
     assert row["license"] == "mit"
 

--- a/tests/v2/test_index_huggingface_models.py
+++ b/tests/v2/test_index_huggingface_models.py
@@ -94,7 +94,8 @@ def test_record_from_info_populates_all_fields() -> None:
         card_data={"license": "mit", "base_model": "google/flan-t5-base"},
     )
     record = _record_from_info("hf-org/my-model", info)
-    assert record.repo_id == "hf-org/my-model"
+    # v3.0.0: repo_id is the canonical HuggingFace URL.
+    assert record.repo_id == "https://huggingface.co/hf-org/my-model"
     assert record.pipeline_tag == "text-classification"
     assert record.library_name == "transformers"
     assert record.license == "mit"
@@ -141,9 +142,10 @@ def test_ingest_single_model_round_trips(models_store: HuggingFaceModelsStore) -
         config=object(), store=models_store, client=client, repo_id="hf-org/my-model",
     )
     assert outcome == "ingested"
-    row = models_store.fetch_model("hf-org/my-model")
+    # stored under the canonical URL id (the ingest input handle stays bare).
+    row = models_store.fetch_model("https://huggingface.co/hf-org/my-model")
     assert row is not None
-    assert row["repo_id"] == "hf-org/my-model"
+    assert row["repo_id"] == "https://huggingface.co/hf-org/my-model"
     assert row["pipeline_tag"] == "text-classification"
     assert row["license"] == "mit"
 

--- a/tests/v2/test_index_huggingface_spaces.py
+++ b/tests/v2/test_index_huggingface_spaces.py
@@ -75,7 +75,7 @@ def test_record_from_info_populates_space_specific_fields() -> None:
         runtime={"stage": "RUNNING", "hardware": "cpu-basic"},
     )
     record = _record_from_info("alice/audio-demo", info)
-    assert record.repo_id == "alice/audio-demo"
+    assert record.repo_id == "https://huggingface.co/spaces/alice/audio-demo"
     assert record.sdk == "gradio"
     assert record.runtime_stage == "RUNNING"
     assert record.hardware == "cpu-basic"
@@ -104,7 +104,7 @@ def test_ingest_single_space_round_trips(
         config=object(), store=spaces_store, client=client, repo_id="alice/x",
     )
     assert outcome == "ingested"
-    row = spaces_store.fetch_space("alice/x")
+    row = spaces_store.fetch_space("https://huggingface.co/spaces/alice/x")
     assert row is not None
     assert row["sdk"] == "streamlit"
     assert row["hardware"] == "t4-small"

--- a/tests/v2/test_indices_reset_api.py
+++ b/tests/v2/test_indices_reset_api.py
@@ -258,10 +258,11 @@ def test_full_lifecycle_ingest_reset_reingest(tmp_path, monkeypatch) -> None:
     store_2 = HuggingFaceModelsStore.open(db_path)
     store_2.upsert_model(_record_from_info("org/m2", info_2))
     rows = store_2.count("models")
-    row = store_2.fetch_model("org/m2")
+    # v3.0.0: stored under the canonical URL id (projector canonicalises).
+    row = store_2.fetch_model("https://huggingface.co/org/m2")
     # Critically, the old org/m1 row from round 1 is GONE — the reset
     # truly wiped the file, not just the rows.
-    old_row = store_2.fetch_model("org/m1")
+    old_row = store_2.fetch_model("https://huggingface.co/org/m1")
     store_2.close()
 
     assert rows == 1


### PR DESCRIPTION
**Step 2** of canonicalising index ids to URLs. Adds `huggingface_iri(value, kind)` and applies it in the models/datasets/spaces projectors:
- model → `https://huggingface.co/<repo_id>`
- dataset → `https://huggingface.co/datasets/<repo_id>`
- space → `https://huggingface.co/spaces/<repo_id>`

Idempotent if already a URL. This **restores the form the old HF monolith stored** — the H1-H8 split had regressed `repo_id` to bare, so migrated rows (URL) and fresh ingests (bare) disagreed; now both are URL. `chunks.entity_id` + Qdrant point + search-hit id follow.

Updated the record/round-trip tests to the URL form. **Backfill** the live split stores via re-ingest (#109 `refresh`) or `UPDATE … SET repo_id=…` + re-embed. 121 HF tests green.

**Next:** huggingface_users/organizations + papers (slug / arxiv_id), dockerhub, orcid; github_organizations/users (id-vs-login split).