### PR TITLE
feat(dockerhub index): repo_id is the canonical Docker Hub URL (v3.0.0 ids, step 3)

### DIFF
--- a/src/index/dockerhub/ingest/repos.py
+++ b/src/index/dockerhub/ingest/repos.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from src.index.dockerhub.models import DockerhubRepoRecord
+from src.v2.canonicalization.dockerhub import dockerhub_iri
 
 if TYPE_CHECKING:
     from src.index.dockerhub.config import DockerhubIndexConfig
@@ -68,7 +69,8 @@ def _record_from_payload(
     *, namespace: str, name: str, payload: dict[str, Any], tags: list[str],
 ) -> DockerhubRepoRecord:
     return DockerhubRepoRecord(
-        repo_id=f"{namespace}/{name}",
+        # v3.0.0: id is the canonical Docker Hub URL (namespace/name kept bare).
+        repo_id=dockerhub_iri(namespace, name) or f"{namespace}/{name}",
         namespace=namespace,
         name=name,
         description=payload.get("description") or None,

--- a/src/index/dockerhub/models.py
+++ b/src/index/dockerhub/models.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 
 
 class DockerhubRepoRecord(BaseModel):
-    repo_id: str  # "<namespace>/<name>" (official images are "library/<name>")
+    repo_id: str  # canonical URL: https://hub.docker.com/(r/<ns>/<name> | _/<name>)
     namespace: str
     name: str
     description: Optional[str] = None       # short tagline

--- a/src/index/dockerhub/storage/schema.sql
+++ b/src/index/dockerhub/storage/schema.sql
@@ -2,7 +2,7 @@
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 
 CREATE TABLE IF NOT EXISTS images (
-    repo_id           TEXT PRIMARY KEY,        -- "<namespace>/<name>"
+    repo_id           TEXT PRIMARY KEY,        -- canonical URL https://hub.docker.com/(r/<ns>/<name> | _/<name>)
     namespace         TEXT NOT NULL,
     name              TEXT NOT NULL,
     description       TEXT,                     -- short tagline

--- a/src/v2/canonicalization/dockerhub.py
+++ b/src/v2/canonicalization/dockerhub.py
@@ -1,0 +1,30 @@
+"""Canonical Docker Hub URL builder for index ids.
+
+Official images (the ``library`` namespace) live at ``/_/<name>``; everything
+else at ``/r/<namespace>/<name>``.
+"""
+
+from __future__ import annotations
+
+_BASE = "https://hub.docker.com/"
+
+
+def dockerhub_iri(namespace: str | None, name: str | None) -> str | None:
+    """Canonical Docker Hub repo URL from ``(namespace, name)``.
+
+    ``library/python`` -> https://hub.docker.com/_/python
+    ``grafana/grafana`` -> https://hub.docker.com/r/grafana/grafana
+    Returns None when ``name`` is missing.
+    """
+    if not isinstance(name, str) or not name.strip():
+        return None
+    n = name.strip().strip("/")
+    ns = (namespace or "library").strip().strip("/") or "library"
+    if not n:
+        return None
+    if ns == "library":
+        return f"{_BASE}_/{n}"
+    return f"{_BASE}r/{ns}/{n}"
+
+
+__all__ = ["dockerhub_iri"]

--- a/tests/index/dockerhub/test_repo_id_url.py
+++ b/tests/index/dockerhub/test_repo_id_url.py
@@ -1,0 +1,21 @@
+"""dockerhub repo_id is the canonical Docker Hub URL (v3.0.0 ids)."""
+from __future__ import annotations
+from src.index.dockerhub.ingest.repos import _record_from_payload
+from src.v2.canonicalization.dockerhub import dockerhub_iri
+
+
+def test_official_image_url() -> None:
+    rec = _record_from_payload(namespace="library", name="python", payload={}, tags=[])
+    assert rec.repo_id == "https://hub.docker.com/_/python"
+    assert rec.namespace == "library" and rec.name == "python"
+
+
+def test_user_image_url() -> None:
+    rec = _record_from_payload(namespace="grafana", name="grafana", payload={}, tags=[])
+    assert rec.repo_id == "https://hub.docker.com/r/grafana/grafana"
+
+
+def test_canonicalizer() -> None:
+    assert dockerhub_iri("library", "python") == "https://hub.docker.com/_/python"
+    assert dockerhub_iri("grafana", "grafana") == "https://hub.docker.com/r/grafana/grafana"
+    assert dockerhub_iri(None, None) is None

--- a/tests/v2/test_dockerhub_index.py
+++ b/tests/v2/test_dockerhub_index.py
@@ -164,7 +164,8 @@ def test_ingest_single_image_persists(tmp_path: Path) -> None:
             config=cfg, store=store, client=client, image_ref="grafana/grafana",
         )
     assert outcome == "ingested"
-    row = store.fetch_image("grafana/grafana")
+    # v3.0.0: stored under the canonical Docker Hub URL id.
+    row = store.fetch_image("https://hub.docker.com/r/grafana/grafana")
     assert row["tags"] == '["latest", "11.0.0"]' or row["tags"] == ["latest", "11.0.0"]
     assert row["pull_count"] == 1_000_000_000
     store.close()
@@ -192,7 +193,8 @@ def test_ingest_official_bare_name_maps_to_library(tmp_path: Path) -> None:
         _FakeResponse(status_code=200, payload={"results": []}),
     ):
         ingest_single_image(config=cfg, store=store, client=client, image_ref="redis")
-    row = store.fetch_image("library/redis")
+    # official bare name -> library namespace -> canonical /_/ URL id.
+    row = store.fetch_image("https://hub.docker.com/_/redis")
     assert row is not None
     assert row["is_official"] is True
     store.close()


### PR DESCRIPTION
**Step 3.** `dockerhub_iri(namespace, name)` → canonical URL, stored as `repo_id` (namespace/name kept bare):
- official (`library/*`) → `https://hub.docker.com/_/<name>`
- else → `https://hub.docker.com/r/<namespace>/<name>`

`chunks.entity_id` + Qdrant point + search-hit id follow. dockerhub has no monolith source → re-ingest (#109 `refresh`) / UPDATE to backfill. Round-trip tests fetch by URL; direct-record + payload-echo tests keep bare inputs. **Full tests/v2 suite green (1336).**

**Remaining:** orcid (multi-table `orcid_id` FK); the id-vs-value class (github orgs/users `login`, hf users/orgs `slug`, hf papers `arxiv_id` — the id column *is* the value); infoscience/ethz/snsf (URL patterns TBD). zenodo/openalex/ror already URL.