### PR TITLE
feat(orcid index): orcid_id is the canonical URL across all tables (v3.0.0 ids, step 4)

### DIFF
--- a/src/index/orcid/ingest/persons.py
+++ b/src/index/orcid/ingest/persons.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from src.index.orcid.ingest.orcid_client import build_orcid_provider
 from src.index.orcid.ingest.scope import post_filter_record
+from src.v2.canonicalization.orcid import parse_orcid
 from src.v2.ingest.providers.base import (
     ProviderError,
     ProviderNotFoundError,
@@ -40,7 +41,7 @@ def ingest_single_orcid(
     if provider is None:
         provider = build_orcid_provider(config)
     try:
-        record = provider.get_person_by_orcid(orcid_id)  # type: ignore[attr-defined]
+        record = provider.get_person_by_orcid(parse_orcid(orcid_id) or orcid_id)  # type: ignore[attr-defined]
     except ProviderNotFoundError:
         LOGGER.info("orcid not found, skipping: %s", orcid_id)
         return "not_found"
@@ -96,7 +97,7 @@ def ingest_persons(
                 time.sleep(min_interval - elapsed)
         last_request_at = time.monotonic()
         try:
-            record = provider.get_person_by_orcid(orcid_id)
+            record = provider.get_person_by_orcid(parse_orcid(orcid_id) or orcid_id)
         except ProviderNotFoundError:
             LOGGER.info("orcid not found, skipping: %s", orcid_id)
             summary["errors"] += 1

--- a/src/index/orcid/storage/duckdb_store.py
+++ b/src/index/orcid/storage/duckdb_store.py
@@ -12,6 +12,15 @@ from typing import TYPE_CHECKING, Any
 import duckdb
 
 from src.index.orcid.paths import get_orcid_paths
+from src.v2.canonicalization.orcid import orcid_iri
+
+
+def _canon_orcid(value: Any) -> Any:
+    """Canonical ORCID URL (https://orcid.org/<bare>) for storage, or the value
+    unchanged if it can't be canonicalised. v3.0.0: the stored id is the URL,
+    consistently across persons / employments / educations / seeds so their
+    joins still match. Ingest keeps the bare id for the ORCID API."""
+    return orcid_iri(value) or value
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -92,7 +101,7 @@ class OrcidStore:
             "    ELSE 'both' "
             "  END, "
             "  hint = COALESCE(excluded.hint, seeds.hint)",
-            [orcid_id, discovered_via, hint],
+            [_canon_orcid(orcid_id), discovered_via, hint],
         )
 
     def upsert_person(self, row: dict[str, Any], raw: dict[str, Any]) -> None:
@@ -117,6 +126,7 @@ class OrcidStore:
             f"ON CONFLICT (orcid_id) DO UPDATE SET {update_cols}"
         )
         values: list[Any] = [row.get(c) for c in cols]
+        values[0] = _canon_orcid(values[0])  # orcid_id -> canonical URL
         values.append(json.dumps(raw, ensure_ascii=False))
         values.append(self._now())
         self.connect().execute(sql, values)
@@ -131,6 +141,7 @@ class OrcidStore:
             message = f"Unknown affiliation table: {table}"
             raise ValueError(message)
         conn = self.connect()
+        orcid_id = _canon_orcid(orcid_id)
         # Replace-all semantics keeps the table consistent when ORCID
         # entries are removed/renumbered upstream.
         conn.execute(
@@ -152,7 +163,9 @@ class OrcidStore:
         sql = f"INSERT INTO {table} ({col_list}) VALUES ({placeholders})"  # noqa: S608
         count = 0
         for row in rows:
-            conn.execute(sql, [row.get(c) for c in cols])
+            row_values = [row.get(c) for c in cols]
+            row_values[0] = _canon_orcid(row_values[0])  # orcid_id -> canonical URL
+            conn.execute(sql, row_values)
             count += 1
         return count
 
@@ -188,7 +201,7 @@ class OrcidStore:
     def fetch_person(self, orcid_id: str) -> dict[str, Any] | None:
         cur = self.connect().execute(
             "SELECT * FROM persons WHERE orcid_id = ?",
-            [orcid_id],
+            [_canon_orcid(orcid_id)],  # accept bare or URL; rows are keyed by URL
         )
         row = cur.fetchone()
         if row is None:
@@ -283,7 +296,7 @@ class OrcidStore:
     def list_employments(self, orcid_id: str) -> list[dict[str, Any]]:
         cur = self.connect().execute(
             "SELECT * FROM employments WHERE orcid_id = ? ORDER BY seq",
-            [orcid_id],
+            [_canon_orcid(orcid_id)],  # accept bare or URL; rows keyed by URL
         )
         cols = [d[0] for d in cur.description]
         return [dict(zip(cols, r, strict=False)) for r in cur.fetchall()]

--- a/src/index/orcid/storage/schema.sql
+++ b/src/index/orcid/storage/schema.sql
@@ -3,7 +3,7 @@
 -- One DuckDB file per scope (see src/index/orcid/paths.py).
 
 CREATE TABLE IF NOT EXISTS persons (
-    orcid_id        TEXT PRIMARY KEY,            -- canonical "0000-0000-0000-000X"
+    orcid_id        TEXT PRIMARY KEY,            -- canonical URL https://orcid.org/0000-0000-0000-000X
     given_name      TEXT,
     family_name     TEXT,
     display_name    TEXT,

--- a/tests/index/orcid/test_duckdb_store.py
+++ b/tests/index/orcid/test_duckdb_store.py
@@ -18,7 +18,8 @@ def test_upsert_seed_promotes_to_both(tmp_store) -> None:
     tmp_store.upsert_seed(orcid_id="0000-0002-1825-0097", discovered_via="orcid_search")
     cur = tmp_store.connect().execute(
         "SELECT discovered_via FROM seeds WHERE orcid_id = ?",
-        ["0000-0002-1825-0097"],
+        # v3.0.0: the store persists the canonical ORCID URL as the id.
+        ["https://orcid.org/0000-0002-1825-0097"],
     )
     assert cur.fetchone()[0] == "both"
 
@@ -91,7 +92,9 @@ def test_stream_rows_for_embedding_skips_already_chunked(tmp_store) -> None:
     tmp_store.upsert_chunk(
         chunk_id="x",
         entity_type="persons",
-        entity_id="0000-0002-1825-0097",
+        # the person is stored under the canonical URL id; the chunk's
+        # entity_id must match it (as the embed pipeline produces).
+        entity_id="https://orcid.org/0000-0002-1825-0097",
         chunk_index=0,
         text="Alice Example",
         token_count=2,


### PR DESCRIPTION
**Step 4** — the tricky one. `orcid_id` is a multi-table key (persons/employments/educations/seeds) with a `seeds↔persons` join *and* the ORCID-API lookup key, so half-canonicalising would break the join.

- The **store** canonicalises `orcid_id` → `https://orcid.org/<bare>` at every **write** (`upsert_seed`, `upsert_person`, `replace_affiliations` incl. each row) and accepts **bare-or-URL** at every **lookup** (`fetch_person`, `list_employments`). So every table stores the URL and the joins (`seeds↔persons`, `chunks.entity_id = t.orcid_id`) still match.
- **Ingest keeps the bare id for the ORCID API**: both `get_person_by_orcid(...)` call sites pass `parse_orcid(orcid_id)`, so the API still receives the bare ORCID even though seeds/persons store the URL.

`chunks.entity_id` + Qdrant point + search-hit id follow. Backfill via re-ingest (#109 `refresh`) / UPDATE. Updated 3 store tests that asserted the bare id in internal storage. **Full tests/v2 suite green (1336).**

**Remaining:** the id-vs-value class (github orgs/users `login`, hf users/orgs `slug`, hf papers `arxiv_id`); infoscience/ethz/snsf (URL patterns TBD).