### PR TITLE
feat(github orgs/users index): login id is the canonical URL (v3.0.0 ids, step 5)

### DIFF
--- a/src/index/github_organizations/ingest/organizations.py
+++ b/src/index/github_organizations/ingest/organizations.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from src.index.github_organizations.models import OrgRecord
+from src.v2.canonicalization.github import github_org_iri
 
 if TYPE_CHECKING:
     from src.index.github_repos.ingest.github_client import GitHubClient
@@ -31,7 +32,7 @@ def _parse_iso(value: Any) -> datetime | None:
 
 def _record_from_payload(login: str, payload: dict[str, Any]) -> OrgRecord:
     return OrgRecord(
-        login=login,
+        login=github_org_iri(login) or login,
         github_id=int(payload["id"]) if isinstance(payload.get("id"), int) else None,
         node_id=payload.get("node_id"),
         name=payload.get("name"),

--- a/src/index/github_organizations/storage/duckdb_store.py
+++ b/src/index/github_organizations/storage/duckdb_store.py
@@ -75,6 +75,8 @@ class GitHubOrganizationsStore:
     # ---- Upserts ---------------------------------------------------------
 
     def upsert_organization(self, record: OrgRecord) -> None:
+        from src.v2.canonicalization.github import github_org_iri  # noqa: PLC0415
+
         sql = (
             "INSERT INTO organizations "
             "(login, github_id, node_id, name, description, blog, location, "
@@ -108,7 +110,7 @@ class GitHubOrganizationsStore:
         self.connect().execute(
             sql,
             [
-                record.login,
+                github_org_iri(record.login) or record.login,  # v3.0.0: id is the URL
                 record.github_id,
                 record.node_id,
                 record.name,
@@ -163,11 +165,13 @@ class GitHubOrganizationsStore:
         return count_table(self.connect(), table)
 
     def fetch_organization(self, login: str) -> dict[str, Any] | None:
+        from src.v2.canonicalization.github import github_org_iri  # noqa: PLC0415
+
         return fetch_one(
             self.connect(),
             table="organizations",
             id_column=ID_COLUMN,
-            id_value=login,
+            id_value=github_org_iri(login) or login,  # accept bare or URL
         )
 
     def stream_rows_for_embedding(

--- a/src/index/github_organizations/storage/schema.sql
+++ b/src/index/github_organizations/storage/schema.sql
@@ -2,7 +2,7 @@
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 
 CREATE TABLE IF NOT EXISTS organizations (
-    login                       TEXT PRIMARY KEY,         -- GitHub org handle
+    login                       TEXT PRIMARY KEY,         -- canonical URL https://github.com/<login>
     github_id                   BIGINT,                   -- stable across renames
     node_id                     TEXT,
     name                        TEXT,

--- a/src/index/github_users/ingest/users.py
+++ b/src/index/github_users/ingest/users.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from src.index.github_users.models import UserRecord
+from src.v2.canonicalization.github import github_user_iri
 
 if TYPE_CHECKING:
     from src.index.github_repos.ingest.github_client import GitHubClient
@@ -27,7 +28,7 @@ def _parse_iso(value: Any) -> datetime | None:
 
 def _record_from_payload(login: str, payload: dict[str, Any]) -> UserRecord:
     return UserRecord(
-        login=login,
+        login=github_user_iri(login) or login,
         github_id=int(payload["id"]) if isinstance(payload.get("id"), int) else None,
         node_id=payload.get("node_id"),
         name=payload.get("name"),

--- a/src/index/github_users/storage/duckdb_store.py
+++ b/src/index/github_users/storage/duckdb_store.py
@@ -73,6 +73,8 @@ class GitHubUsersStore:
     # ---- Upserts ---------------------------------------------------------
 
     def upsert_user(self, record: UserRecord) -> None:
+        from src.v2.canonicalization.github import github_user_iri  # noqa: PLC0415
+
         sql = (
             "INSERT INTO users "
             "(login, github_id, node_id, name, bio, company, blog, location, "
@@ -102,7 +104,7 @@ class GitHubUsersStore:
         self.connect().execute(
             sql,
             [
-                record.login,
+                github_user_iri(record.login) or record.login,  # v3.0.0: id is the URL
                 record.github_id,
                 record.node_id,
                 record.name,
@@ -155,11 +157,13 @@ class GitHubUsersStore:
         return count_table(self.connect(), table)
 
     def fetch_user(self, login: str) -> dict[str, Any] | None:
+        from src.v2.canonicalization.github import github_user_iri  # noqa: PLC0415
+
         return fetch_one(
             self.connect(),
             table="users",
             id_column=ID_COLUMN,
-            id_value=login,
+            id_value=github_user_iri(login) or login,  # accept bare or URL
         )
 
     def stream_rows_for_embedding(

--- a/src/index/github_users/storage/schema.sql
+++ b/src/index/github_users/storage/schema.sql
@@ -2,7 +2,7 @@
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 
 CREATE TABLE IF NOT EXISTS users (
-    login              TEXT PRIMARY KEY,             -- GitHub login (natural key)
+    login              TEXT PRIMARY KEY,             -- canonical URL https://github.com/<login>
     github_id          BIGINT,                       -- stable across renames
     node_id            TEXT,
     name               TEXT,

--- a/tests/v2/test_index_github_organizations.py
+++ b/tests/v2/test_index_github_organizations.py
@@ -66,7 +66,7 @@ def test_record_from_payload_normalises_org_card() -> None:
 
     record = _record_from_payload("EPFL-ENAC", payload)
 
-    assert record.login == "EPFL-ENAC"
+    assert record.login == "https://github.com/EPFL-ENAC"
     assert record.github_id == 789
     assert record.description == "ENAC at EPFL"
     assert record.account_type == "Organization"
@@ -100,7 +100,7 @@ def test_ingest_single_organization_round_trips_through_duckdb(
     assert outcome == "ingested"
     row = orgs_store.fetch_organization("Imaging-Plaza")
     assert row is not None
-    assert row["login"] == "Imaging-Plaza"
+    assert row["login"] == "https://github.com/Imaging-Plaza"
     assert row["name"] == "Imaging Plaza"
     assert row["description"] == "Research imaging tools and pipelines"
     assert row["public_repos"] == 18

--- a/tests/v2/test_index_github_users.py
+++ b/tests/v2/test_index_github_users.py
@@ -69,7 +69,7 @@ def test_record_from_payload_normalises_user_card() -> None:
 
     record = _record_from_payload("alice", payload)
 
-    assert record.login == "alice"
+    assert record.login == "https://github.com/alice"
     assert record.github_id == 123
     assert record.bio == "Imaging at EPFL"
     assert record.company == "EPFL"
@@ -108,7 +108,7 @@ def test_ingest_single_user_round_trips_through_duckdb(
     assert outcome == "ingested"
     row = users_store.fetch_user("bob")
     assert row is not None
-    assert row["login"] == "bob"
+    assert row["login"] == "https://github.com/bob"
     assert row["bio"] == "Open-source pipelines"
     assert row["company"] == "@SomeOrg"
     assert row["public_repos"] == 12


### PR DESCRIPTION
**Step 5** — the id-vs-value class for GitHub accounts. `login` is the PK *and* the value used for the GitHub API, so (like orcid) the **store is the canonicalisation boundary**:
- `upsert_organization`/`upsert_user` write `login` as `github_org_iri`/`github_user_iri(login)` → `https://github.com/<login>`; `fetch_organization`/`fetch_user` accept **bare-or-URL**. So projector and direct-record upserts both persist the URL and lookups match.
- Ingest keeps the **bare login for the GitHub API** (`client.get_organization/get_user(login)` get the bare param).

`chunks.entity_id` + Qdrant point + search-hit id follow. Backfill via re-ingest (#109) / UPDATE. Record/round-trip assertions updated to URL; idempotent tests pass unchanged. **Full tests/v2 suite green (1336).**

**Remaining:** hf users/orgs (`slug`), hf papers (`arxiv_id`); infoscience/ethz/snsf (URL patterns TBD).