### PR TITLE
feat(hf users/orgs/papers index): id is the canonical URL (v3.0.0 ids, step 6)

### DIFF
--- a/src/index/huggingface_organizations/storage/duckdb_store.py
+++ b/src/index/huggingface_organizations/storage/duckdb_store.py
@@ -22,6 +22,8 @@ from src.index.huggingface_organizations.paths import (
     get_huggingface_organizations_paths,
 )
 
+from src.v2.canonicalization.huggingface import huggingface_iri
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -90,7 +92,7 @@ class HuggingFaceOrganizationsStore:
         self.connect().execute(
             sql,
             [
-                record.slug,
+                huggingface_iri(record.slug, "org") or record.slug,
                 record.fullname,
                 record.details,
                 record.avatar_url,
@@ -133,7 +135,7 @@ class HuggingFaceOrganizationsStore:
             self.connect(),
             table="organizations",
             id_column=ID_COLUMN,
-            id_value=slug,
+            id_value=huggingface_iri(slug, "org") or slug,
         )
 
     def stream_rows_for_embedding(

--- a/src/index/huggingface_organizations/storage/schema.sql
+++ b/src/index/huggingface_organizations/storage/schema.sql
@@ -2,7 +2,7 @@
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 
 CREATE TABLE IF NOT EXISTS organizations (
-    slug             TEXT PRIMARY KEY,             -- HF namespace handle
+    slug             TEXT PRIMARY KEY,             -- canonical URL https://huggingface.co/<slug>
     fullname         TEXT,
     details          TEXT,
     avatar_url       TEXT,

--- a/src/index/huggingface_papers/storage/duckdb_store.py
+++ b/src/index/huggingface_papers/storage/duckdb_store.py
@@ -22,6 +22,8 @@ from src.index.huggingface_papers.paths import (
     get_huggingface_papers_paths,
 )
 
+from src.v2.canonicalization.huggingface import huggingface_iri
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -100,7 +102,7 @@ class HuggingFacePapersStore:
         self.connect().execute(
             sql,
             [
-                record.arxiv_id,
+                huggingface_iri(record.arxiv_id, "paper") or record.arxiv_id,
                 record.title,
                 record.summary,
                 record.doi,
@@ -155,7 +157,7 @@ class HuggingFacePapersStore:
             self.connect(),
             table="papers",
             id_column=ID_COLUMN,
-            id_value=arxiv_id,
+            id_value=huggingface_iri(arxiv_id, "paper") or arxiv_id,
         )
 
     def stream_rows_for_embedding(

--- a/src/index/huggingface_papers/storage/schema.sql
+++ b/src/index/huggingface_papers/storage/schema.sql
@@ -2,7 +2,7 @@
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 
 CREATE TABLE IF NOT EXISTS papers (
-    arxiv_id                  TEXT PRIMARY KEY,         -- "YYMM.NNNNN" (no v-suffix)
+    arxiv_id                  TEXT PRIMARY KEY,         -- canonical URL https://huggingface.co/papers/<arxiv_id>
     title                     TEXT NOT NULL,
     summary                   TEXT,                     -- abstract
     doi                       TEXT,                     -- "10.48550/arXiv.<id>"

--- a/src/index/huggingface_users/storage/duckdb_store.py
+++ b/src/index/huggingface_users/storage/duckdb_store.py
@@ -22,6 +22,8 @@ from src.index.huggingface_users.paths import (
     get_huggingface_users_paths,
 )
 
+from src.v2.canonicalization.huggingface import huggingface_iri
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -90,7 +92,7 @@ class HuggingFaceUsersStore:
         self.connect().execute(
             sql,
             [
-                record.slug,
+                huggingface_iri(record.slug, "user") or record.slug,
                 record.fullname,
                 record.details,
                 record.avatar_url,
@@ -133,7 +135,7 @@ class HuggingFaceUsersStore:
             self.connect(),
             table="users",
             id_column=ID_COLUMN,
-            id_value=slug,
+            id_value=huggingface_iri(slug, "user") or slug,
         )
 
     def stream_rows_for_embedding(

--- a/src/index/huggingface_users/storage/schema.sql
+++ b/src/index/huggingface_users/storage/schema.sql
@@ -2,7 +2,7 @@
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 
 CREATE TABLE IF NOT EXISTS users (
-    slug             TEXT PRIMARY KEY,             -- HF namespace handle
+    slug             TEXT PRIMARY KEY,             -- canonical URL https://huggingface.co/<slug>
     fullname         TEXT,                         -- display name
     details          TEXT,                         -- HF user bio
     avatar_url       TEXT,

--- a/tests/v2/test_index_huggingface_papers.py
+++ b/tests/v2/test_index_huggingface_papers.py
@@ -188,7 +188,8 @@ def test_ingest_single_paper_round_trips_through_duckdb(
     assert outcome == "ingested"
     row = papers_store.fetch_paper("2405.00001")
     assert row is not None
-    assert row["arxiv_id"] == "2405.00001"
+    # v3.0.0: stored under the canonical HF papers URL id.
+    assert row["arxiv_id"] == "https://huggingface.co/papers/2405.00001"
     assert row["title"].startswith("Graph Neural")
     assert row["upvotes"] == 23
     assert row["doi"] == "10.48550/arXiv.2405.00001"


### PR DESCRIPTION
**Step 6** — completes the HuggingFace index ids. The id-vs-value stores (`slug` for users/orgs, `arxiv_id` for papers) canonicalise at the store boundary:
- user/org → `https://huggingface.co/<slug>`
- paper → `https://huggingface.co/papers/<arxiv_id>`

`upsert_*` write `huggingface_iri(record.<id>, kind)`; `fetch_*` accept bare-or-URL. The papers projector still computes the arXiv DOI from the bare param, so `doi` is unaffected; only the stored id becomes the URL. `chunks.entity_id` + Qdrant + search-hit id follow. Backfill via re-ingest (#109) / UPDATE.

Papers round-trip assertion updated. **Full tests/v2 suite green (1336).**

**Only remaining index ids:** infoscience / ethz / snsf (URL patterns TBD). zenodo/openalex/ror already URL; github (repos/orgs/users), hf (all), dockerhub, orcid done.