### PR TITLE
feat(infoscience index): entity ids are canonical URLs (v3.0.0 ids)

### DIFF
--- a/src/index/infoscience/extract_relations.py
+++ b/src/index/infoscience/extract_relations.py
@@ -17,9 +17,26 @@ import re
 from pathlib import Path
 from typing import Iterable, List, Optional, Set
 
+from src.v2.canonicalization.infoscience import (
+    infoscience_article_iri,
+    infoscience_org_iri,
+    infoscience_person_iri,
+)
+
 from .config import InfoscienceIndexConfig
 from .extract_matches import load_matches
 from .models import RelationRecord
+
+
+def _canon_relation(rec: RelationRecord) -> RelationRecord:
+    """v3.0.0: promote a RelationRecord's bare DSpace UUIDs to canonical
+    Infoscience URLs so the reverse-relation maps key on the same ids as
+    the Qdrant person/org records. Idempotent."""
+    return RelationRecord(
+        article_uuid=infoscience_article_iri(rec.article_uuid) or rec.article_uuid,
+        person_uuids=[infoscience_person_iri(p) or p for p in rec.person_uuids],
+        org_uuids=[infoscience_org_iri(o) or o for o in rec.org_uuids],
+    )
 from .paths import (
     organizations_set_path,
     persons_set_path,
@@ -111,13 +128,16 @@ def extract_relations(_cfg: InfoscienceIndexConfig) -> dict:
             org_uuids = _dedupe_preserve(_authorities(md, _ORG_ONLY_FIELDS))
             if not person_uuids and not org_uuids:
                 continue
-            record = RelationRecord(
+            record = _canon_relation(RelationRecord(
                 article_uuid=match.uuid,
                 person_uuids=person_uuids,
                 org_uuids=org_uuids,
-            )
+            ))
             out.write(record.model_dump_json() + "\n")
             written += 1
+            # The .txt sets are the fetch-by-UUID worklist for
+            # `fetch_related` — keep them as bare DSpace UUIDs. Only the
+            # relations.jsonl (above) carries the canonical URL ids.
             persons.update(person_uuids)
             orgs.update(org_uuids)
 
@@ -141,7 +161,9 @@ def load_relations() -> List[RelationRecord]:
     out: List[RelationRecord] = []
     for line in p.read_text(encoding="utf-8").splitlines():
         if line.strip():
-            out.append(RelationRecord(**json.loads(line)))
+            # Canonicalize on load so legacy relations.jsonl files (bare
+            # UUIDs) still key the reverse maps by the URL ids.
+            out.append(_canon_relation(RelationRecord(**json.loads(line))))
     return out
 
 

--- a/src/index/infoscience/fetch_related.py
+++ b/src/index/infoscience/fetch_related.py
@@ -16,6 +16,8 @@ from typing import Iterable, Optional
 
 import httpx
 
+from src.v2.canonicalization.infoscience import parse_infoscience_iri
+
 from .config import InfoscienceIndexConfig
 from .dspace import DSpaceClient
 from .extract_relations import load_set
@@ -36,6 +38,11 @@ async def _fetch_one(
     *,
     refresh: bool = False,
 ) -> str:
+    # Accept either a bare DSpace UUID or a canonical entity URL — the
+    # DSpace API and raw-file layout are keyed by the bare UUID.
+    parsed = parse_infoscience_iri(uuid)
+    if parsed is not None:
+        uuid = parsed[1]
     out_path = out_dir / f"{uuid}.json"
     if out_path.exists() and not refresh:
         return "skipped-existing"

--- a/src/index/infoscience/parsers.py
+++ b/src/index/infoscience/parsers.py
@@ -11,9 +11,25 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List, Optional
 
+from src.v2.canonicalization.infoscience import (
+    infoscience_article_iri,
+    infoscience_org_iri,
+    infoscience_person_iri,
+)
+
 from .models import ArticleRecord, OrganizationRecord, PersonRecord
 
 _YEAR_RE = re.compile(r"\b(19|20)\d{2}\b")
+
+
+def _person_id(value: str | None) -> str | None:
+    """Canonical person URL, falling back to the bare authority when it is
+    not a UUID4 (DSpace sometimes emits non-UUID authority placeholders)."""
+    return infoscience_person_iri(value) or value
+
+
+def _org_id(value: str | None) -> str | None:
+    return infoscience_org_iri(value) or value
 
 
 def first_value(metadata: dict, field: str) -> Optional[str]:
@@ -61,14 +77,17 @@ def parse_article(item: Dict[str, Any], matched_urls: Optional[List[str]] = None
     uuid = item.get("uuid") or ""
     publication_date = first_value(md, "dc.date.issued")
     return ArticleRecord(
-        article_uuid=uuid,
+        # v3.0.0: ids are canonical Infoscience entity URLs. The article id
+        # and every UUID cross-ref (authors -> person, orgs -> orgunit) are
+        # URL-ified so the Qdrant ids match the DuckDB relational keys.
+        article_uuid=infoscience_article_iri(uuid) or uuid,
         title=first_value(md, "dc.title"),
         abstract=first_value(md, "dc.description.abstract"),
         keywords=all_values(md, "dc.subject"),
         subjects=all_values(md, "dc.subject"),
         authors=all_values(md, "dc.contributor.author"),
         author_uuids=[
-            entry.get("authority")
+            _person_id(entry.get("authority"))
             for entry in (md.get("dc.contributor.author") or [])
             if isinstance(entry, dict) and entry.get("authority")
         ],
@@ -78,11 +97,13 @@ def parse_article(item: Dict[str, Any], matched_urls: Optional[List[str]] = None
         publication_type=first_value(md, "dc.type"),
         language=first_value(md, "dc.language.iso"),
         journal=first_value(md, "dc.relation.journal"),
+        # journal_uuid points at a DSpace journal entity (unsupported URL
+        # kind) — left as the bare authority.
         journal_uuid=first_authority(md, "dc.relation.journal"),
         lab=first_value(md, "cris.virtual.department"),
-        lab_uuid=first_authority(md, "cris.virtual.department"),
+        lab_uuid=_org_id(first_authority(md, "cris.virtual.department")),
         org_uuids=sorted({
-            entry.get("authority")
+            _org_id(entry.get("authority"))
             for field in ("cris.virtual.department",
                           "cris.virtual.parent-organization",
                           "oairecerif.author.affiliation")
@@ -103,7 +124,7 @@ def parse_person(item: Dict[str, Any]) -> PersonRecord:
     if not name and (given or family):
         name = " ".join(p for p in (given, family) if p)
     return PersonRecord(
-        person_uuid=uuid,
+        person_uuid=infoscience_person_iri(uuid) or uuid,
         name=name,
         given_name=given,
         family_name=family,
@@ -111,9 +132,9 @@ def parse_person(item: Dict[str, Any]) -> PersonRecord:
         sciper_id=first_value(md, "epfl.sciperId") or first_value(md, "cris.virtual.sciperId"),
         scopus_id=first_value(md, "person.identifier.scopus-author-id"),
         primary_affiliation=first_value(md, "person.affiliation.name"),
-        primary_affiliation_uuid=first_authority(md, "person.affiliation.name"),
+        primary_affiliation_uuid=_org_id(first_authority(md, "person.affiliation.name")),
         affiliation_uuids=sorted({
-            entry.get("authority")
+            _org_id(entry.get("authority"))
             for entry in (md.get("person.affiliation.name") or [])
             if isinstance(entry, dict) and entry.get("authority")
         }),
@@ -128,13 +149,13 @@ def parse_organization(item: Dict[str, Any]) -> OrganizationRecord:
     md = item.get("metadata", {}) or {}
     uuid = item.get("uuid") or ""
     parent_chain_authorities = [
-        entry.get("authority")
+        _org_id(entry.get("authority"))
         for entry in (md.get("cris.virtual.parent-organization") or [])
         if isinstance(entry, dict) and entry.get("authority")
     ]
     parent_chain_names = all_values(md, "cris.virtual.parent-organization")
     return OrganizationRecord(
-        org_uuid=uuid,
+        org_uuid=infoscience_org_iri(uuid) or uuid,
         name=first_value(md, "dc.title") or first_value(md, "organization.legalName"),
         # The real Infoscience/DSpace key for the unit acronym is
         # `oairecerif.acronym` (e.g. `UPMWMATHIS`, `UPAMATHIS`,
@@ -174,7 +195,7 @@ def parse_organization(item: Dict[str, Any]) -> OrganizationRecord:
             or first_value(md, "epfl.unitId")
             or first_value(md, "epfl.unit.code")
         ),
-        unit_manager_uuid=first_authority(md, "cris.virtual.unitManager"),
+        unit_manager_uuid=_person_id(first_authority(md, "cris.virtual.unitManager")),
         unit_manager_name=first_value(md, "cris.virtual.unitManager"),
         infoscience_url=_infoscience_url(uuid, "orgunit"),
     )

--- a/src/index/infoscience/storage/duckdb_store.py
+++ b/src/index/infoscience/storage/duckdb_store.py
@@ -19,6 +19,12 @@ from typing import TYPE_CHECKING, Any, Iterable, Iterator
 import duckdb
 
 from src.index.infoscience.paths import duckdb_path
+from src.v2.canonicalization.infoscience import (
+    infoscience_article_iri,
+    infoscience_iri_sql,
+    infoscience_org_iri,
+    infoscience_person_iri,
+)
 
 if TYPE_CHECKING:
     pass
@@ -66,6 +72,36 @@ class InfoscienceStore:
         )
 
         migrate_doi_column_to_url(conn, table="articles", column="doi")
+        self._migrate_ids_to_url(conn)
+
+    @staticmethod
+    def _migrate_ids_to_url(conn: duckdb.DuckDBPyConnection) -> None:
+        """v3.0.0: promote bare DSpace UUID ids (and the junction FKs that
+        reference them) to canonical Infoscience entity URLs. Idempotent —
+        the guarded CASE only rewrites bare UUID4s, so already-canonical
+        rows and re-runs are no-ops. Existing on-disk DBs converge on the
+        next ``bootstrap()``.
+        """
+
+        def col(name: str, kind: str) -> str:
+            return infoscience_iri_sql(name, kind)
+
+        updates = (
+            f"UPDATE articles SET article_uuid = {col('article_uuid', 'publication')}, "
+            f"infoscience_url = {col('infoscience_url', 'publication')}",
+            f"UPDATE persons SET person_uuid = {col('person_uuid', 'person')}, "
+            f"primary_affiliation_uuid = {col('primary_affiliation_uuid', 'orgunit')}",
+            f"UPDATE organizations SET org_uuid = {col('org_uuid', 'orgunit')}, "
+            f"parent_org_uuid = {col('parent_org_uuid', 'orgunit')}, "
+            f"infoscience_url = {col('infoscience_url', 'orgunit')}",
+            f"UPDATE article_persons SET article_uuid = {col('article_uuid', 'publication')}, "
+            f"person_uuid = {col('person_uuid', 'person')}",
+            f"UPDATE article_orgs SET article_uuid = {col('article_uuid', 'publication')}, "
+            f"org_uuid = {col('org_uuid', 'orgunit')}",
+            f"UPDATE article_links SET article_uuid = {col('article_uuid', 'publication')}",
+        )
+        for stmt in updates:
+            conn.execute(stmt)
 
     def close(self) -> None:
         if self._conn is not None:
@@ -106,6 +142,11 @@ class InfoscienceStore:
 
         if row.get("doi"):
             row = {**row, "doi": doi_iri(row["doi"])}
+        # v3.0.0: the id is the canonical Infoscience publication URL.
+        uid = row.get("article_uuid")
+        row = {**row, "article_uuid": infoscience_article_iri(uid) or uid}
+        if row.get("infoscience_url") is None and row.get("article_uuid"):
+            row = {**row, "infoscience_url": row["article_uuid"]}
         self._upsert(
             table="articles",
             cols=(
@@ -124,6 +165,15 @@ class InfoscienceStore:
         )
 
     def upsert_person(self, row: dict[str, Any], raw: dict[str, Any]) -> None:
+        # v3.0.0: person_uuid is the canonical person URL; the affiliation
+        # FK is the canonical orgunit URL.
+        pid = row.get("person_uuid")
+        aff = row.get("primary_affiliation_uuid")
+        row = {
+            **row,
+            "person_uuid": infoscience_person_iri(pid) or pid,
+            "primary_affiliation_uuid": infoscience_org_iri(aff) or aff,
+        }
         self._upsert(
             table="persons",
             cols=(
@@ -141,6 +191,16 @@ class InfoscienceStore:
         )
 
     def upsert_organization(self, row: dict[str, Any], raw: dict[str, Any]) -> None:
+        # v3.0.0: org_uuid + parent_org_uuid are canonical orgunit URLs.
+        oid = row.get("org_uuid")
+        pid = row.get("parent_org_uuid")
+        row = {
+            **row,
+            "org_uuid": infoscience_org_iri(oid) or oid,
+            "parent_org_uuid": infoscience_org_iri(pid) or pid,
+        }
+        if row.get("infoscience_url") is None and row.get("org_uuid"):
+            row = {**row, "infoscience_url": row["org_uuid"]}
         self._upsert(
             table="organizations",
             cols=(
@@ -190,14 +250,16 @@ class InfoscienceStore:
         person_positions: Iterable[tuple[str, int | None]],
     ) -> None:
         conn = self.connect()
+        art_id = infoscience_article_iri(article_uuid) or article_uuid
         for person_uuid, position in person_positions:
+            person_id = infoscience_person_iri(person_uuid) or person_uuid
             conn.execute(
                 "INSERT INTO article_persons (article_uuid, person_uuid, position) "
                 "VALUES (?, ?, ?) "
                 "ON CONFLICT (article_uuid, person_uuid) DO UPDATE SET position = "
                 "COALESCE(LEAST(article_persons.position, excluded.position), "
                 "         excluded.position, article_persons.position)",
-                [article_uuid, person_uuid, position],
+                [art_id, person_id, position],
             )
 
     def upsert_article_orgs(
@@ -206,11 +268,13 @@ class InfoscienceStore:
         org_field_pairs: Iterable[tuple[str, str]],
     ) -> None:
         conn = self.connect()
+        art_id = infoscience_article_iri(article_uuid) or article_uuid
         for org_uuid, field in org_field_pairs:
+            org_id = infoscience_org_iri(org_uuid) or org_uuid
             conn.execute(
                 "INSERT INTO article_orgs (article_uuid, org_uuid, field) "
                 "VALUES (?, ?, ?) ON CONFLICT DO NOTHING",
-                [article_uuid, org_uuid, field],
+                [art_id, org_id, field],
             )
 
     def upsert_article_links(
@@ -220,9 +284,10 @@ class InfoscienceStore:
     ) -> None:
         """rows: iterable of (host_label, url, source)."""
         conn = self.connect()
+        art_id = infoscience_article_iri(article_uuid) or article_uuid
         for host_label, url, source in rows:
             conn.execute(
                 "INSERT INTO article_links (article_uuid, host_label, url, source) "
                 "VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING",
-                [article_uuid, host_label, url, source],
+                [art_id, host_label, url, source],
             )

--- a/src/index/infoscience/storage/ingest_raw.py
+++ b/src/index/infoscience/storage/ingest_raw.py
@@ -28,10 +28,25 @@ from src.index.infoscience.paths import (
     raw_organizations_dir,
     raw_persons_dir,
 )
+from src.v2.canonicalization.infoscience import (
+    infoscience_article_iri,
+    infoscience_iri_sql,
+)
 
 from .duckdb_store import InfoscienceStore
 
 logger = logging.getLogger(__name__)
+
+# v3.0.0: ids are canonical Infoscience entity URLs. These SQL fragments
+# URL-ify a bare UUID4 extracted from the DSpace JSON to the matching
+# entity URL (publication / person / orgunit), guarded so non-UUID and
+# already-canonical values pass through unchanged. They agree with the
+# per-row Python helpers (`infoscience_article_iri`, ...) and the bootstrap
+# migration so the two write paths (bulk SQL here, the Qdrant build path)
+# produce identical ids.
+_ART_UUID = infoscience_iri_sql("json_extract_string(json, '$.uuid')", "publication")
+_PERSON_UUID = infoscience_iri_sql("json_extract_string(json, '$.uuid')", "person")
+_ORG_UUID = infoscience_iri_sql("json_extract_string(json, '$.uuid')", "orgunit")
 
 
 # ---------------------------------------------------------------------------
@@ -41,7 +56,7 @@ logger = logging.getLogger(__name__)
 # Note: DSpace metadata field names contain dots, so the JSON path needs them
 # quoted. Path templates are reused for both the article columns and the
 # child unnest queries.
-_ARTICLE_UPSERT_SQL = """
+_ARTICLE_UPSERT_SQL = f"""
 CREATE OR REPLACE TEMP TABLE _items AS
   SELECT json FROM read_json_objects(?);
 
@@ -49,7 +64,7 @@ INSERT INTO articles
   (article_uuid, title, abstract, doi, publication_year, publication_type,
    journal, language, infoscience_url, raw, ingested_at)
 SELECT
-  json_extract_string(json, '$.uuid') AS article_uuid,
+  {_ART_UUID} AS article_uuid,
   json_extract_string(json, '$.metadata."dc.title"[0].value') AS title,
   json_extract_string(json, '$.metadata."dc.description.abstract"[0].value') AS abstract,
   json_extract_string(json, '$.metadata."dc.identifier.doi"[0].value') AS doi,
@@ -60,7 +75,7 @@ SELECT
   json_extract_string(json, '$.metadata."dc.type"[0].value') AS publication_type,
   json_extract_string(json, '$.metadata."dc.relation.journal"[0].value') AS journal,
   json_extract_string(json, '$.metadata."dc.language.iso"[0].value') AS language,
-  'https://infoscience.epfl.ch/entities/publication/' || json_extract_string(json, '$.uuid') AS infoscience_url,
+  {_ART_UUID} AS infoscience_url,
   json AS raw,
   CURRENT_TIMESTAMP AS ingested_at
 FROM _items
@@ -78,11 +93,11 @@ ON CONFLICT (article_uuid) DO UPDATE SET
   ingested_at      = excluded.ingested_at;
 """
 
-_ARTICLE_PERSONS_SQL = """
+_ARTICLE_PERSONS_SQL = f"""
 INSERT INTO article_persons (article_uuid, person_uuid, position)
 SELECT
-  json_extract_string(i.json, '$.uuid') AS article_uuid,
-  json_extract_string(t.author, '$.authority') AS person_uuid,
+  {infoscience_iri_sql("json_extract_string(i.json, '$.uuid')", "publication")} AS article_uuid,
+  {infoscience_iri_sql("json_extract_string(t.author, '$.authority')", "person")} AS person_uuid,
   TRY_CAST(json_extract_string(t.author, '$.place') AS INTEGER) AS position
 FROM _items i,
      UNNEST(
@@ -123,8 +138,8 @@ def _orgs_union_sql() -> str:
         parts.append(
             f"""
             SELECT
-              json_extract_string(i.json, '$.uuid') AS article_uuid,
-              json_extract_string(t.org, '$.authority') AS org_uuid,
+              {infoscience_iri_sql("json_extract_string(i.json, '$.uuid')", "publication")} AS article_uuid,
+              {infoscience_iri_sql("json_extract_string(t.org, '$.authority')", "orgunit")} AS org_uuid,
               '{field}' AS field
             FROM _items i,
                  UNNEST(
@@ -141,7 +156,7 @@ def _orgs_union_sql() -> str:
 # Persons
 # ---------------------------------------------------------------------------
 
-_PERSON_UPSERT_SQL = """
+_PERSON_UPSERT_SQL = f"""
 CREATE OR REPLACE TEMP TABLE _persons AS
   SELECT json FROM read_json_objects(?);
 
@@ -149,7 +164,7 @@ INSERT INTO persons
   (person_uuid, display_name, given_name, family_name, orcid, sciper_id,
    primary_affiliation, primary_affiliation_uuid, raw, ingested_at)
 SELECT
-  json_extract_string(json, '$.uuid') AS person_uuid,
+  {_PERSON_UUID} AS person_uuid,
   COALESCE(
     json_extract_string(json, '$.metadata."dc.title"[0].value'),
     TRIM(
@@ -172,7 +187,7 @@ SELECT
     json_extract_string(json, '$.metadata."cris.virtual.sciperId"[0].value')
   ) AS sciper_id,
   json_extract_string(json, '$.metadata."person.affiliation.name"[0].value') AS primary_affiliation,
-  json_extract_string(json, '$.metadata."person.affiliation.name"[0].authority') AS primary_affiliation_uuid,
+  {infoscience_iri_sql('''json_extract_string(json, '$.metadata."person.affiliation.name"[0].authority')''', "orgunit")} AS primary_affiliation_uuid,
   json AS raw,
   CURRENT_TIMESTAMP AS ingested_at
 FROM _persons
@@ -194,20 +209,20 @@ ON CONFLICT (person_uuid) DO UPDATE SET
 # Organizations
 # ---------------------------------------------------------------------------
 
-_ORG_UPSERT_SQL = """
+_ORG_UPSERT_SQL = f"""
 CREATE OR REPLACE TEMP TABLE _orgs AS
   SELECT json FROM read_json_objects(?);
 
 INSERT INTO organizations
   (org_uuid, name, acronym, parent_org_uuid, sciper_unit_id, ror_id, raw, ingested_at)
 SELECT
-  json_extract_string(json, '$.uuid') AS org_uuid,
+  {_ORG_UUID} AS org_uuid,
   COALESCE(
     json_extract_string(json, '$.metadata."dc.title"[0].value'),
     json_extract_string(json, '$.metadata."organization.legalName"[0].value')
   ) AS name,
   json_extract_string(json, '$.metadata."organization.identifier.acronym"[0].value') AS acronym,
-  json_extract_string(json, '$.metadata."cris.virtual.parent-organization"[0].authority') AS parent_org_uuid,
+  {infoscience_iri_sql('''json_extract_string(json, '$.metadata."cris.virtual.parent-organization"[0].authority')''', "orgunit")} AS parent_org_uuid,
   COALESCE(
     json_extract_string(json, '$.metadata."cris.virtual.unitId"[0].value'),
     json_extract_string(json, '$.metadata."epfl.unitId"[0].value')
@@ -330,12 +345,14 @@ def ingest_links_dump(store: InfoscienceStore, dump_path: Path) -> int:
         uuid = art.get("uuid")
         if not uuid:
             continue
+        # v3.0.0: article_links.article_uuid FK is the canonical URL id.
+        article_id = infoscience_article_iri(uuid) or uuid
         for label in art.get("matched_phrases", []) or []:
             phrase = queries.get(label, "")
-            rows.append((uuid, label, phrase, "phrase_match"))
+            rows.append((article_id, label, phrase, "phrase_match"))
         for label, urls in (art.get("body_urls") or {}).items():
             for url in urls or []:
-                rows.append((uuid, label, url, "body_text"))
+                rows.append((article_id, label, url, "body_text"))
 
     if not rows:
         return 0

--- a/src/index/infoscience/storage/schema.sql
+++ b/src/index/infoscience/storage/schema.sql
@@ -1,6 +1,11 @@
 -- Canonical DuckDB schema for the infoscience index module.
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 -- Mirrors the openalex / huggingface sister-index pattern.
+--
+-- v3.0.0: the `*_uuid` id columns (and the junction FKs that reference
+-- them) hold the canonical Infoscience entity URL, not the bare DSpace
+-- UUID — `https://infoscience.epfl.ch/entities/{publication|person|orgunit}/<uuid>`.
+-- `InfoscienceStore.bootstrap()` migrates legacy bare-UUID rows in place.
 
 -- One-shot cleanup of the dead `chunks` table: chunks live exclusively
 -- in Qdrant (`infoscience_chunks` collection) and the DuckDB table

--- a/src/v2/canonicalization/infoscience.py
+++ b/src/v2/canonicalization/infoscience.py
@@ -81,6 +81,32 @@ def infoscience_article_iri(value: str | None) -> str | None:
     return _build("publication", value)
 
 
+def infoscience_iri_sql(expr: str, kind: str) -> str:
+    """Return a DuckDB scalar SQL expression that URL-ifies a bare UUID4
+    column ``expr`` to the canonical Infoscience ``kind`` URL.
+
+    ``kind`` is the URL path segment (``person`` / ``orgunit`` /
+    ``publication``). Mirrors :func:`_build` semantics exactly: NULL and
+    already-canonical values pass through unchanged, non-UUID4 strings are
+    left as-is, and a bare UUID4 is lowercased and prefixed. Used by the
+    bulk-SQL ingest path and the bootstrap migration so both agree with the
+    per-row Python helpers.
+    """
+    if kind not in ("person", "orgunit", "publication"):
+        msg = f"Unknown infoscience kind: {kind!r}"
+        raise ValueError(msg)
+    # UUID4 pattern matching `_UUID4_RE` (lowercased input).
+    uuid4 = r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+    return (
+        f"CASE "
+        f"WHEN {expr} IS NULL THEN NULL "
+        f"WHEN starts_with(lower({expr}), '{_BASE}') THEN {expr} "
+        f"WHEN regexp_full_match(lower({expr}), '{uuid4}') "
+        f"THEN '{_BASE}{kind}/' || lower({expr}) "
+        f"ELSE {expr} END"
+    )
+
+
 def parse_infoscience_iri(iri: str | None) -> tuple[str, str] | None:
     """Inverse — return ``(kind, uuid)`` for a canonical Infoscience
     URL, or ``None`` on anything else. ``kind`` is one of
@@ -107,6 +133,7 @@ def parse_infoscience_iri(iri: str | None) -> tuple[str, str] | None:
 
 __all__ = [
     "infoscience_article_iri",
+    "infoscience_iri_sql",
     "infoscience_org_iri",
     "infoscience_person_iri",
     "parse_infoscience_iri",

--- a/tests/index/infoscience/test_duckdb_store_canonical_url.py
+++ b/tests/index/infoscience/test_duckdb_store_canonical_url.py
@@ -1,0 +1,119 @@
+"""v3.0.0: infoscience DuckDB ids (and junction FKs) are canonical URLs.
+
+Covers all three write surfaces that must agree on the id form:
+  * the per-row Python upserts on `InfoscienceStore`,
+  * the bulk-SQL `ingest_raw` path,
+  * the in-place bootstrap migration of legacy bare-UUID rows.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.index.infoscience.storage.duckdb_store import InfoscienceStore
+from src.index.infoscience.storage.ingest_raw import ingest_articles
+
+# Valid UUID4s (version nibble 4, variant 8/9/a/b).
+_ART = "8f486100-04da-40e6-9c00-0411efbfd978"
+_PERSON = "a7bc3696-16f4-49a8-a0d1-fabc1d9ad261"
+_ORG = "372d8be7-b45f-47ce-8689-2f7872fd4c2f"
+
+_PUB_URL = f"https://infoscience.epfl.ch/entities/publication/{_ART}"
+_PERSON_URL = f"https://infoscience.epfl.ch/entities/person/{_PERSON}"
+_ORG_URL = f"https://infoscience.epfl.ch/entities/orgunit/{_ORG}"
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> InfoscienceStore:
+    s = InfoscienceStore.open(tmp_path / "infoscience.duckdb")
+    yield s
+    s.close()
+
+
+def _one(store: InfoscienceStore, sql: str):
+    return store.connect().execute(sql).fetchone()
+
+
+def test_python_upserts_store_url_ids(store: InfoscienceStore) -> None:
+    store.upsert_article({"article_uuid": _ART, "title": "T"}, raw={})
+    store.upsert_person({"person_uuid": _PERSON, "primary_affiliation_uuid": _ORG}, raw={})
+    store.upsert_organization({"org_uuid": _ORG, "parent_org_uuid": _ORG}, raw={})
+    store.upsert_article_persons(_ART, [(_PERSON, 0)])
+    store.upsert_article_orgs(_ART, [(_ORG, "cris.virtual.department")])
+    store.upsert_article_links(_ART, [("github", "https://github.com/x/y", "body_text")])
+
+    assert _one(store, "SELECT article_uuid, infoscience_url FROM articles")[0] == _PUB_URL
+    assert _one(store, "SELECT article_uuid FROM articles")[0] == _PUB_URL
+    assert _one(store, "SELECT infoscience_url FROM articles")[0] == _PUB_URL
+    assert _one(store, "SELECT person_uuid, primary_affiliation_uuid FROM persons") == (
+        _PERSON_URL, _ORG_URL,
+    )
+    assert _one(store, "SELECT org_uuid FROM organizations")[0] == _ORG_URL
+    # Junction FKs are URL-ified on both sides.
+    assert _one(store, "SELECT article_uuid, person_uuid FROM article_persons") == (
+        _PUB_URL, _PERSON_URL,
+    )
+    assert _one(store, "SELECT article_uuid, org_uuid FROM article_orgs") == (_PUB_URL, _ORG_URL)
+    assert _one(store, "SELECT article_uuid FROM article_links")[0] == _PUB_URL
+
+
+def test_python_upserts_are_idempotent_on_url(store: InfoscienceStore) -> None:
+    # Upserting an already-canonical id must not double-wrap.
+    store.upsert_article({"article_uuid": _PUB_URL, "title": "T"}, raw={})
+    assert _one(store, "SELECT count(*) FROM articles")[0] == 1
+    assert _one(store, "SELECT article_uuid FROM articles")[0] == _PUB_URL
+
+
+def test_bulk_ingest_raw_stores_url_ids(store: InfoscienceStore, tmp_path: Path) -> None:
+    items_dir = tmp_path / "items"
+    items_dir.mkdir()
+    item = {
+        "uuid": _ART,
+        "metadata": {
+            "dc.title": [{"value": "Bulk title"}],
+            "dc.contributor.author": [
+                {"value": "Alice", "authority": _PERSON, "place": "0"},
+            ],
+            "cris.virtual.department": [{"value": "Lab", "authority": _ORG}],
+        },
+    }
+    (items_dir / f"{_ART}.json").write_text(json.dumps(item), encoding="utf-8")
+
+    ingest_articles(store, items_dir=items_dir)
+
+    assert _one(store, "SELECT article_uuid, infoscience_url FROM articles") == (_PUB_URL, _PUB_URL)
+    assert _one(store, "SELECT article_uuid, person_uuid FROM article_persons") == (
+        _PUB_URL, _PERSON_URL,
+    )
+    assert _one(store, "SELECT article_uuid, org_uuid FROM article_orgs") == (_PUB_URL, _ORG_URL)
+
+
+def test_bootstrap_migrates_legacy_bare_uuid_rows(tmp_path: Path) -> None:
+    db = tmp_path / "legacy.duckdb"
+    store = InfoscienceStore.open(db)
+    conn = store.connect()
+    # Simulate a pre-v3 DB: insert rows with bare UUID ids, bypassing the
+    # canonicalizing upserts.
+    conn.execute(
+        "INSERT INTO articles (article_uuid, title, infoscience_url) VALUES (?, ?, ?)",
+        [_ART, "Legacy", f"https://infoscience.epfl.ch/entities/publication/{_ART}"],
+    )
+    conn.execute(
+        "INSERT INTO article_persons (article_uuid, person_uuid, position) VALUES (?, ?, ?)",
+        [_ART, _PERSON, 0],
+    )
+    store.close()
+
+    # Re-open → bootstrap runs the migration.
+    store2 = InfoscienceStore.open(db)
+    assert _one(store2, "SELECT article_uuid FROM articles")[0] == _PUB_URL
+    assert _one(store2, "SELECT article_uuid, person_uuid FROM article_persons") == (
+        _PUB_URL, _PERSON_URL,
+    )
+    # Idempotent: a second bootstrap leaves the URLs untouched.
+    store2.bootstrap()
+    assert _one(store2, "SELECT article_uuid FROM articles")[0] == _PUB_URL
+    store2.close()

--- a/tests/index/infoscience/test_extract_relations.py
+++ b/tests/index/infoscience/test_extract_relations.py
@@ -51,10 +51,21 @@ def test_extract_relations_pulls_authority_uuids(article_json: dict) -> None:
     assert summary["organizations"] >= 1
 
     relation = json.loads(relations_path().read_text(encoding="utf-8").strip())
-    assert relation["article_uuid"] == uuid
-    assert all(len(p) == 36 for p in relation["person_uuids"])
-    assert all(len(o) == 36 for o in relation["org_uuids"])
+    # v3.0.0: relations.jsonl carries the canonical entity URLs (so the
+    # reverse maps key on the same ids as the Qdrant records)...
+    assert relation["article_uuid"] == f"https://infoscience.epfl.ch/entities/publication/{uuid}"
+    assert all(
+        p.startswith("https://infoscience.epfl.ch/entities/person/")
+        for p in relation["person_uuids"]
+    )
+    assert all(
+        o.startswith("https://infoscience.epfl.ch/entities/orgunit/")
+        for o in relation["org_uuids"]
+    )
+    # ...but the .txt sets stay bare UUIDs (the fetch-by-UUID worklist).
     persons_listing = persons_set_path().read_text(encoding="utf-8").splitlines()
     orgs_listing = organizations_set_path().read_text(encoding="utf-8").splitlines()
-    assert relation["person_uuids"][0] in persons_listing
-    assert relation["org_uuids"][0] in orgs_listing
+    assert all(len(p) == 36 for p in persons_listing)
+    assert all(len(o) == 36 for o in orgs_listing)
+    assert relation["person_uuids"][0].rsplit("/", 1)[-1] in persons_listing
+    assert relation["org_uuids"][0].rsplit("/", 1)[-1] in orgs_listing

--- a/tests/index/infoscience/test_parsers.py
+++ b/tests/index/infoscience/test_parsers.py
@@ -9,26 +9,35 @@ from src.index.infoscience.parsers import (
 )
 
 
+_PUB = "https://infoscience.epfl.ch/entities/publication/"
+_PERSON = "https://infoscience.epfl.ch/entities/person/"
+_ORGUNIT = "https://infoscience.epfl.ch/entities/orgunit/"
+
+
 def test_parse_article(article_json: dict) -> None:
     rec = parse_article(article_json, matched_urls=["https://github.com/x/y"])
-    assert rec.article_uuid
+    # v3.0.0: the id is the canonical publication URL, and UUID cross-refs
+    # (authors -> person, orgs -> orgunit) are URL-ified too.
+    assert rec.article_uuid.startswith(_PUB)
+    assert rec.article_uuid == rec.infoscience_url
     assert rec.title
     assert rec.authors, "expected at least one author name"
-    # The fixture has at least one author with an authority — UUIDs flow through.
     assert any(rec.author_uuids)
+    assert all(u.startswith(_PERSON) for u in rec.author_uuids)
+    assert all(u.startswith(_ORGUNIT) for u in rec.org_uuids)
     assert rec.matched_urls == ["https://github.com/x/y"]
-    assert rec.infoscience_url.startswith("https://infoscience.epfl.ch/entities/publication/")
+    assert rec.infoscience_url.startswith(_PUB)
 
 
 def test_parse_person(person_json: dict) -> None:
     rec = parse_person(person_json)
-    assert rec.person_uuid
+    assert rec.person_uuid.startswith(_PERSON)
     assert rec.name
-    assert rec.profile_url.startswith("https://infoscience.epfl.ch/entities/person/")
+    assert rec.profile_url.startswith(_PERSON)
 
 
 def test_parse_organization(organization_json: dict) -> None:
     rec = parse_organization(organization_json)
-    assert rec.org_uuid
+    assert rec.org_uuid.startswith(_ORGUNIT)
     assert rec.name
-    assert rec.infoscience_url.startswith("https://infoscience.epfl.ch/entities/orgunit/")
+    assert rec.infoscience_url.startswith(_ORGUNIT)


### PR DESCRIPTION
Full relational re-PK of the infoscience index: the `article_uuid` / `person_uuid` / `org_uuid` ids — **and every junction FK** (`article_persons`, `article_orgs`, `article_links`, `parent_org_uuid`, `primary_affiliation_uuid`) — now hold the canonical Infoscience entity URL instead of the bare DSpace UUID:

`https://infoscience.epfl.ch/entities/{publication|person|orgunit}/<uuid>`

Consistent with the github / huggingface / dockerhub / orcid / zenodo / openalex / ror index ids.

### Both id paths covered (identical output)
- **Bulk-SQL ingest** (`ingest_raw.py`): a shared, UUID4-guarded SQL builder `infoscience_iri_sql()` URL-ifies the PKs + junction FKs.
- **Qdrant build path** (`parsers.py` + `extract_relations.py`): the record ids + kind-aware UUID cross-refs (authors→person, orgs→orgunit).

### Migration
`InfoscienceStore.bootstrap()` promotes legacy bare-UUID rows in place across all 6 tables — idempotent (only rewrites bare UUID4s; URLs/re-runs are no-ops).

### Notes
- The `.txt` person/org worklists stay **bare UUIDs** (the fetch-by-UUID input); `fetch_related` is now URL-tolerant.
- `journal_uuid` left bare (DSpace journal is an unsupported URL kind).
- **Operational follow-up:** re-embed the Qdrant collections so search-hit ids carry the URL form (the DuckDB store + migration are code-complete here).

### Tests
- Updated `test_parsers`, `test_extract_relations`; new `test_duckdb_store_canonical_url` (Python upserts + bulk ingest + legacy-row migration + idempotency).
- Full `tests/v2/` gate: **1339 passed, 1 skipped**.