### PR TITLE
feat(ethz research collection index): entity ids are canonical URLs (v3.0.0 ids)

### DIFF
--- a/src/index/ethz_research_collection/extract_relations.py
+++ b/src/index/ethz_research_collection/extract_relations.py
@@ -24,6 +24,12 @@ import re
 from pathlib import Path
 from typing import Iterable, List, Optional, Set
 
+from src.v2.canonicalization.ethz import (
+    ethz_article_iri,
+    ethz_org_iri,
+    ethz_person_iri,
+)
+
 from .config import EthzResearchCollectionIndexConfig
 from .extract_matches import load_matches
 from .models import RelationRecord
@@ -35,6 +41,17 @@ from .paths import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _canon_relation(rec: RelationRecord) -> RelationRecord:
+    """v3.0.0: promote a RelationRecord's bare DSpace UUIDs to canonical
+    Research Collection URLs so the reverse-relation maps key on the same
+    ids as the Qdrant records. Idempotent."""
+    return RelationRecord(
+        article_uuid=ethz_article_iri(rec.article_uuid) or rec.article_uuid,
+        person_uuids=[ethz_person_iri(p) or p for p in rec.person_uuids],
+        org_uuids=[ethz_org_iri(o) or o for o in rec.org_uuids],
+    )
 
 # DSpace 7 ``relation.is*OfPublication`` fields carry the linked entity's
 # UUID in ``value`` (and a virtual slot id in ``authority``). For ETH RC
@@ -87,11 +104,11 @@ def extract_relations_single(uuid: str) -> Optional[RelationRecord]:
     org_uuids = _dedupe_preserve(_relation_values(metadata, _ORG_RELATION_FIELDS))
     if not person_uuids and not org_uuids:
         return None
-    return RelationRecord(
+    return _canon_relation(RelationRecord(
         article_uuid=uuid,
         person_uuids=person_uuids,
         org_uuids=org_uuids,
-    )
+    ))
 
 
 def _load_item(uuid: str) -> Optional[dict]:
@@ -138,13 +155,15 @@ def extract_relations(_cfg: EthzResearchCollectionIndexConfig) -> dict:
             )
             if not person_uuids and not org_uuids:
                 continue
-            record = RelationRecord(
+            record = _canon_relation(RelationRecord(
                 article_uuid=match.uuid,
                 person_uuids=person_uuids,
                 org_uuids=org_uuids,
-            )
+            ))
             out.write(record.model_dump_json() + "\n")
             written += 1
+            # The .txt sets stay bare UUIDs (the fetch-by-UUID worklist);
+            # only relations.jsonl carries the canonical URL ids.
             persons.update(person_uuids)
             orgs.update(org_uuids)
 
@@ -168,7 +187,9 @@ def load_relations() -> List[RelationRecord]:
     out: List[RelationRecord] = []
     for line in p.read_text(encoding="utf-8").splitlines():
         if line.strip():
-            out.append(RelationRecord(**json.loads(line)))
+            # Canonicalize on load so legacy relations.jsonl files (bare
+            # UUIDs) still key the reverse maps by the URL ids.
+            out.append(_canon_relation(RelationRecord(**json.loads(line))))
     return out
 
 

--- a/src/index/ethz_research_collection/fetch_related.py
+++ b/src/index/ethz_research_collection/fetch_related.py
@@ -16,6 +16,8 @@ from typing import Iterable, Optional
 
 import httpx
 
+from src.v2.canonicalization.ethz import parse_ethz_iri
+
 from .config import EthzResearchCollectionIndexConfig
 from .dspace import DSpaceClient
 from .extract_relations import load_set
@@ -59,6 +61,11 @@ async def _fetch_one(
     *,
     refresh: bool = False,
 ) -> str:
+    # Accept either a bare DSpace UUID or a canonical entity URL — the
+    # DSpace API and raw-file layout are keyed by the bare UUID.
+    parsed = parse_ethz_iri(uuid)
+    if parsed is not None:
+        uuid = parsed[1]
     out_path = out_dir / f"{uuid}.json"
     if out_path.exists() and not refresh:
         return "skipped-existing"

--- a/src/index/ethz_research_collection/parsers.py
+++ b/src/index/ethz_research_collection/parsers.py
@@ -11,9 +11,25 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List, Optional
 
+from src.v2.canonicalization.ethz import (
+    ethz_article_iri,
+    ethz_org_iri,
+    ethz_person_iri,
+)
+
 from .models import ArticleRecord, OrganizationRecord, PersonRecord
 
 _YEAR_RE = re.compile(r"\b(19|20)\d{2}\b")
+
+
+def _person_id(value: str | None) -> str | None:
+    """Canonical person URL, falling back to the bare value when it is not
+    a UUID4."""
+    return ethz_person_iri(value) or value
+
+
+def _org_id(value: str | None) -> str | None:
+    return ethz_org_iri(value) or value
 
 
 def first_value(metadata: dict, field: str) -> Optional[str]:
@@ -64,12 +80,13 @@ def parse_article(item: Dict[str, Any], matched_urls: Optional[List[str]] = None
     # (see `extract_relations.py`); `dc.contributor.author.authority` is a
     # virtual slot id (`virtual::N`), not a UUID.
     author_uuids = [
-        entry.get("value")
+        _person_id(entry.get("value"))
         for entry in (md.get("relation.isAuthorOfPublication") or [])
         if isinstance(entry, dict) and entry.get("value")
     ]
     return ArticleRecord(
-        article_uuid=uuid,
+        # v3.0.0: id + UUID cross-refs are canonical Research Collection URLs.
+        article_uuid=ethz_article_iri(uuid) or uuid,
         title=first_value(md, "dc.title"),
         abstract=first_value(md, "dc.description.abstract"),
         keywords=all_values(md, "dc.subject"),
@@ -98,9 +115,9 @@ def parse_article(item: Dict[str, Any], matched_urls: Optional[List[str]] = None
         issn=first_value(md, "dc.identifier.issn"),
         handle_uri=first_value(md, "dc.identifier.uri"),
         lab=first_value(md, "cris.virtual.department"),
-        lab_uuid=first_authority(md, "cris.virtual.department"),
+        lab_uuid=_org_id(first_authority(md, "cris.virtual.department")),
         org_uuids=sorted({
-            entry.get("authority")
+            _org_id(entry.get("authority"))
             for field in ("cris.virtual.department",
                           "cris.virtual.parent-organization",
                           "oairecerif.author.affiliation")
@@ -135,7 +152,7 @@ def parse_person(item: Dict[str, Any]) -> PersonRecord:
 
     edu_affiliation = first_value(md, "person.edu.affiliation")  # e.g. "faculty"
     return PersonRecord(
-        person_uuid=uuid,
+        person_uuid=ethz_person_iri(uuid) or uuid,
         name=name,
         given_name=given,
         family_name=family,
@@ -143,9 +160,9 @@ def parse_person(item: Dict[str, Any]) -> PersonRecord:
         sciper_id=first_value(md, "epfl.sciperId") or first_value(md, "cris.virtual.sciperId"),
         scopus_id=first_value(md, "person.identifier.scopus-author-id"),
         primary_affiliation=primary_affiliation,
-        primary_affiliation_uuid=first_authority(md, "person.affiliation.name"),
+        primary_affiliation_uuid=_org_id(first_authority(md, "person.affiliation.name")),
         affiliation_uuids=sorted({
-            entry.get("authority")
+            _org_id(entry.get("authority"))
             for entry in (md.get("person.affiliation.name") or [])
             if isinstance(entry, dict) and entry.get("authority")
         }),
@@ -160,13 +177,13 @@ def parse_organization(item: Dict[str, Any]) -> OrganizationRecord:
     md = item.get("metadata", {}) or {}
     uuid = item.get("uuid") or ""
     parent_chain_authorities = [
-        entry.get("authority")
+        _org_id(entry.get("authority"))
         for entry in (md.get("cris.virtual.parent-organization") or [])
         if isinstance(entry, dict) and entry.get("authority")
     ]
     parent_chain_names = all_values(md, "cris.virtual.parent-organization")
     return OrganizationRecord(
-        org_uuid=uuid,
+        org_uuid=ethz_org_iri(uuid) or uuid,
         name=first_value(md, "dc.title") or first_value(md, "organization.legalName"),
         acronym=first_value(md, "organization.identifier.acronym"),
         aliases=all_values(md, "organization.alternateName"),
@@ -177,7 +194,7 @@ def parse_organization(item: Dict[str, Any]) -> OrganizationRecord:
         or first_value(md, "dc.description.abstract"),
         sciper_unit_id=first_value(md, "cris.virtual.unitId")
         or first_value(md, "epfl.unitId"),
-        unit_manager_uuid=first_authority(md, "cris.virtual.unitManager"),
+        unit_manager_uuid=_person_id(first_authority(md, "cris.virtual.unitManager")),
         unit_manager_name=first_value(md, "cris.virtual.unitManager"),
         research_collection_url=_research_collection_url(uuid, "orgunit"),
     )

--- a/src/index/ethz_research_collection/storage/duckdb_store.py
+++ b/src/index/ethz_research_collection/storage/duckdb_store.py
@@ -19,6 +19,12 @@ from typing import TYPE_CHECKING, Any, Iterable, Iterator
 import duckdb
 
 from src.index.ethz_research_collection.paths import duckdb_path
+from src.v2.canonicalization.ethz import (
+    ethz_article_iri,
+    ethz_iri_sql,
+    ethz_org_iri,
+    ethz_person_iri,
+)
 
 if TYPE_CHECKING:
     pass
@@ -60,6 +66,33 @@ class EthzResearchCollectionStore:
     def bootstrap(self) -> None:
         conn = self.connect()
         conn.execute(_load_schema_sql())
+        self._migrate_ids_to_url(conn)
+
+    @staticmethod
+    def _migrate_ids_to_url(conn: duckdb.DuckDBPyConnection) -> None:
+        """v3.0.0: promote bare DSpace UUID ids (and the junction FKs that
+        reference them) to canonical Research Collection entity URLs.
+        Idempotent — the guarded CASE only rewrites bare UUID4s, so
+        already-canonical rows and re-runs are no-ops."""
+
+        def col(name: str, kind: str) -> str:
+            return ethz_iri_sql(name, kind)
+
+        updates = (
+            f"UPDATE articles SET article_uuid = {col('article_uuid', 'publication')}, "
+            f"research_collection_url = {col('research_collection_url', 'publication')}",
+            f"UPDATE persons SET person_uuid = {col('person_uuid', 'person')}, "
+            f"primary_affiliation_uuid = {col('primary_affiliation_uuid', 'orgunit')}",
+            f"UPDATE organizations SET org_uuid = {col('org_uuid', 'orgunit')}, "
+            f"parent_org_uuid = {col('parent_org_uuid', 'orgunit')}",
+            f"UPDATE article_persons SET article_uuid = {col('article_uuid', 'publication')}, "
+            f"person_uuid = {col('person_uuid', 'person')}",
+            f"UPDATE article_orgs SET article_uuid = {col('article_uuid', 'publication')}, "
+            f"org_uuid = {col('org_uuid', 'orgunit')}",
+            f"UPDATE article_links SET article_uuid = {col('article_uuid', 'publication')}",
+        )
+        for stmt in updates:
+            conn.execute(stmt)
 
     def close(self) -> None:
         if self._conn is not None:
@@ -96,6 +129,11 @@ class EthzResearchCollectionStore:
     # ---- Upserts ---------------------------------------------------------
 
     def upsert_article(self, row: dict[str, Any], raw: dict[str, Any]) -> None:
+        # v3.0.0: the id is the canonical Research Collection publication URL.
+        uid = row.get("article_uuid")
+        row = {**row, "article_uuid": ethz_article_iri(uid) or uid}
+        if row.get("research_collection_url") is None and row.get("article_uuid"):
+            row = {**row, "research_collection_url": row["article_uuid"]}
         self._upsert(
             table="articles",
             cols=(
@@ -114,6 +152,13 @@ class EthzResearchCollectionStore:
         )
 
     def upsert_person(self, row: dict[str, Any], raw: dict[str, Any]) -> None:
+        pid = row.get("person_uuid")
+        aff = row.get("primary_affiliation_uuid")
+        row = {
+            **row,
+            "person_uuid": ethz_person_iri(pid) or pid,
+            "primary_affiliation_uuid": ethz_org_iri(aff) or aff,
+        }
         self._upsert(
             table="persons",
             cols=(
@@ -131,6 +176,13 @@ class EthzResearchCollectionStore:
         )
 
     def upsert_organization(self, row: dict[str, Any], raw: dict[str, Any]) -> None:
+        oid = row.get("org_uuid")
+        pid = row.get("parent_org_uuid")
+        row = {
+            **row,
+            "org_uuid": ethz_org_iri(oid) or oid,
+            "parent_org_uuid": ethz_org_iri(pid) or pid,
+        }
         self._upsert(
             table="organizations",
             cols=(
@@ -174,14 +226,16 @@ class EthzResearchCollectionStore:
         person_positions: Iterable[tuple[str, int | None]],
     ) -> None:
         conn = self.connect()
+        art_id = ethz_article_iri(article_uuid) or article_uuid
         for person_uuid, position in person_positions:
+            person_id = ethz_person_iri(person_uuid) or person_uuid
             conn.execute(
                 "INSERT INTO article_persons (article_uuid, person_uuid, position) "
                 "VALUES (?, ?, ?) "
                 "ON CONFLICT (article_uuid, person_uuid) DO UPDATE SET position = "
                 "COALESCE(LEAST(article_persons.position, excluded.position), "
                 "         excluded.position, article_persons.position)",
-                [article_uuid, person_uuid, position],
+                [art_id, person_id, position],
             )
 
     def upsert_article_orgs(
@@ -190,11 +244,13 @@ class EthzResearchCollectionStore:
         org_field_pairs: Iterable[tuple[str, str]],
     ) -> None:
         conn = self.connect()
+        art_id = ethz_article_iri(article_uuid) or article_uuid
         for org_uuid, field in org_field_pairs:
+            org_id = ethz_org_iri(org_uuid) or org_uuid
             conn.execute(
                 "INSERT INTO article_orgs (article_uuid, org_uuid, field) "
                 "VALUES (?, ?, ?) ON CONFLICT DO NOTHING",
-                [article_uuid, org_uuid, field],
+                [art_id, org_id, field],
             )
 
     def upsert_article_links(
@@ -204,9 +260,10 @@ class EthzResearchCollectionStore:
     ) -> None:
         """rows: iterable of (host_label, url, source)."""
         conn = self.connect()
+        art_id = ethz_article_iri(article_uuid) or article_uuid
         for host_label, url, source in rows:
             conn.execute(
                 "INSERT INTO article_links (article_uuid, host_label, url, source) "
                 "VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING",
-                [article_uuid, host_label, url, source],
+                [art_id, host_label, url, source],
             )

--- a/src/index/ethz_research_collection/storage/ingest_raw.py
+++ b/src/index/ethz_research_collection/storage/ingest_raw.py
@@ -28,10 +28,19 @@ from src.index.ethz_research_collection.paths import (
     raw_organizations_dir,
     raw_persons_dir,
 )
+from src.v2.canonicalization.ethz import ethz_article_iri, ethz_iri_sql
 
 from .duckdb_store import EthzResearchCollectionStore
 
 logger = logging.getLogger(__name__)
+
+# v3.0.0: ids are canonical Research Collection entity URLs. These SQL
+# fragments URL-ify a bare UUID4 extracted from the DSpace JSON, guarded so
+# non-UUID and already-canonical values pass through unchanged. They agree
+# with the per-row Python helpers and the bootstrap migration.
+_ART_UUID = ethz_iri_sql("json_extract_string(json, '$.uuid')", "publication")
+_PERSON_UUID = ethz_iri_sql("json_extract_string(json, '$.uuid')", "person")
+_ORG_UUID = ethz_iri_sql("json_extract_string(json, '$.uuid')", "orgunit")
 
 
 # ---------------------------------------------------------------------------
@@ -41,7 +50,7 @@ logger = logging.getLogger(__name__)
 # Note: DSpace metadata field names contain dots, so the JSON path needs them
 # quoted. Path templates are reused for both the article columns and the
 # child unnest queries.
-_ARTICLE_UPSERT_SQL = """
+_ARTICLE_UPSERT_SQL = f"""
 CREATE OR REPLACE TEMP TABLE _items AS
   SELECT json FROM read_json_objects(?);
 
@@ -49,7 +58,7 @@ INSERT INTO articles
   (article_uuid, title, abstract, doi, publication_year, publication_type,
    journal, language, research_collection_url, raw, ingested_at)
 SELECT
-  json_extract_string(json, '$.uuid') AS article_uuid,
+  {_ART_UUID} AS article_uuid,
   json_extract_string(json, '$.metadata."dc.title"[0].value') AS title,
   json_extract_string(json, '$.metadata."dc.description.abstract"[0].value') AS abstract,
   json_extract_string(json, '$.metadata."dc.identifier.doi"[0].value') AS doi,
@@ -60,7 +69,7 @@ SELECT
   json_extract_string(json, '$.metadata."dc.type"[0].value') AS publication_type,
   json_extract_string(json, '$.metadata."dc.relation.journal"[0].value') AS journal,
   json_extract_string(json, '$.metadata."dc.language.iso"[0].value') AS language,
-  'https://www.research-collection.ethz.ch/entities/publication/' || json_extract_string(json, '$.uuid') AS research_collection_url,
+  {_ART_UUID} AS research_collection_url,
   json AS raw,
   CURRENT_TIMESTAMP AS ingested_at
 FROM _items
@@ -85,11 +94,11 @@ ON CONFLICT (article_uuid) DO UPDATE SET
 # the Person UUID via the parallel `relation.isAuthorOfPublication` array.
 # We read from the relation array directly — its `place` matches the
 # corresponding `dc.contributor.author.place`.
-_ARTICLE_PERSONS_SQL = """
+_ARTICLE_PERSONS_SQL = f"""
 INSERT INTO article_persons (article_uuid, person_uuid, position)
 SELECT
-  json_extract_string(i.json, '$.uuid') AS article_uuid,
-  json_extract_string(t.rel, '$.value') AS person_uuid,
+  {ethz_iri_sql("json_extract_string(i.json, '$.uuid')", "publication")} AS article_uuid,
+  {ethz_iri_sql("json_extract_string(t.rel, '$.value')", "person")} AS person_uuid,
   TRY_CAST(json_extract_string(t.rel, '$.place') AS INTEGER) AS position
 FROM _items i,
      UNNEST(
@@ -131,8 +140,8 @@ def _orgs_union_sql() -> str:
         parts.append(
             f"""
             SELECT
-              json_extract_string(i.json, '$.uuid') AS article_uuid,
-              json_extract_string(t.org, '$.authority') AS org_uuid,
+              {ethz_iri_sql("json_extract_string(i.json, '$.uuid')", "publication")} AS article_uuid,
+              {ethz_iri_sql("json_extract_string(t.org, '$.authority')", "orgunit")} AS org_uuid,
               '{field}' AS field
             FROM _items i,
                  UNNEST(
@@ -149,7 +158,7 @@ def _orgs_union_sql() -> str:
 # Persons
 # ---------------------------------------------------------------------------
 
-_PERSON_UPSERT_SQL = """
+_PERSON_UPSERT_SQL = f"""
 CREATE OR REPLACE TEMP TABLE _persons AS
   SELECT json FROM read_json_objects(?);
 
@@ -157,7 +166,7 @@ INSERT INTO persons
   (person_uuid, display_name, given_name, family_name, orcid, sciper_id,
    primary_affiliation, primary_affiliation_uuid, raw, ingested_at)
 SELECT
-  json_extract_string(json, '$.uuid') AS person_uuid,
+  {_PERSON_UUID} AS person_uuid,
   COALESCE(
     json_extract_string(json, '$.metadata."dc.title"[0].value'),
     TRIM(
@@ -180,7 +189,7 @@ SELECT
     json_extract_string(json, '$.metadata."cris.virtual.sciperId"[0].value')
   ) AS sciper_id,
   json_extract_string(json, '$.metadata."person.affiliation.name"[0].value') AS primary_affiliation,
-  json_extract_string(json, '$.metadata."person.affiliation.name"[0].authority') AS primary_affiliation_uuid,
+  {ethz_iri_sql('''json_extract_string(json, '$.metadata."person.affiliation.name"[0].authority')''', "orgunit")} AS primary_affiliation_uuid,
   json AS raw,
   CURRENT_TIMESTAMP AS ingested_at
 FROM _persons
@@ -202,20 +211,20 @@ ON CONFLICT (person_uuid) DO UPDATE SET
 # Organizations
 # ---------------------------------------------------------------------------
 
-_ORG_UPSERT_SQL = """
+_ORG_UPSERT_SQL = f"""
 CREATE OR REPLACE TEMP TABLE _orgs AS
   SELECT json FROM read_json_objects(?);
 
 INSERT INTO organizations
   (org_uuid, name, acronym, parent_org_uuid, sciper_unit_id, ror_id, raw, ingested_at)
 SELECT
-  json_extract_string(json, '$.uuid') AS org_uuid,
+  {_ORG_UUID} AS org_uuid,
   COALESCE(
     json_extract_string(json, '$.metadata."dc.title"[0].value'),
     json_extract_string(json, '$.metadata."organization.legalName"[0].value')
   ) AS name,
   json_extract_string(json, '$.metadata."organization.identifier.acronym"[0].value') AS acronym,
-  json_extract_string(json, '$.metadata."cris.virtual.parent-organization"[0].authority') AS parent_org_uuid,
+  {ethz_iri_sql('''json_extract_string(json, '$.metadata."cris.virtual.parent-organization"[0].authority')''', "orgunit")} AS parent_org_uuid,
   COALESCE(
     json_extract_string(json, '$.metadata."cris.virtual.unitId"[0].value'),
     json_extract_string(json, '$.metadata."epfl.unitId"[0].value')
@@ -353,12 +362,14 @@ def ingest_links_dump(store: EthzResearchCollectionStore, dump_path: Path) -> in
         uuid = art.get("uuid")
         if not uuid:
             continue
+        # v3.0.0: article_links.article_uuid FK is the canonical URL id.
+        article_id = ethz_article_iri(uuid) or uuid
         for label in art.get("matched_phrases", []) or []:
             phrase = queries.get(label, "")
-            rows.append((uuid, label, phrase, "phrase_match"))
+            rows.append((article_id, label, phrase, "phrase_match"))
         for label, urls in (art.get("body_urls") or {}).items():
             for url in urls or []:
-                rows.append((uuid, label, url, "body_text"))
+                rows.append((article_id, label, url, "body_text"))
 
     if not rows:
         return 0

--- a/src/index/ethz_research_collection/storage/schema.sql
+++ b/src/index/ethz_research_collection/storage/schema.sql
@@ -1,6 +1,12 @@
 -- Canonical DuckDB schema for the infoscience index module.
 -- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
 -- Mirrors the openalex / huggingface sister-index pattern.
+--
+-- v3.0.0: the `*_uuid` id columns (and the junction FKs that reference
+-- them) hold the canonical Research Collection entity URL, not the bare
+-- DSpace UUID —
+-- `https://www.research-collection.ethz.ch/entities/{publication|person|orgunit}/<uuid>`.
+-- `EthzResearchCollectionStore.bootstrap()` migrates legacy rows in place.
 
 -- One-shot cleanup of the dead `chunks` table: chunks live exclusively
 -- in Qdrant (`ethz_research_collection_chunks` collection) and the

--- a/src/v2/canonicalization/ethz.py
+++ b/src/v2/canonicalization/ethz.py
@@ -1,0 +1,127 @@
+"""Shared ETH Zürich Research Collection canonical-URL helpers.
+
+The Research Collection (ETH Zürich's DSpace institutional repository)
+identifies persons, organisations (org-units), and publications via UUID4
+in its REST API. The canonical web-facing URL for each entity is:
+
+  - person:     ``https://www.research-collection.ethz.ch/entities/person/<uuid>``
+  - org-unit:   ``https://www.research-collection.ethz.ch/entities/orgunit/<uuid>``
+  - publication:``https://www.research-collection.ethz.ch/entities/publication/<uuid>``
+
+(Note ``orgunit`` not ``organization`` in the org URL — that's DSpace's own
+URL convention, not ours to change.)
+
+Mirrors the Infoscience helpers: every helper accepts any reasonable input
+shape (bare UUID4 or already-canonical URL), returns the canonical URL form,
+and is idempotent on canonical input. Bogus shapes return ``None``.
+"""
+
+from __future__ import annotations
+
+import re
+
+_BASE = "https://www.research-collection.ethz.ch/entities/"
+
+# Strict UUID4. Per RFC 4122 UUIDs are case-insensitive; we lowercase first.
+_UUID4_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+)
+
+
+def _build(kind: str, value: str | None) -> str | None:
+    """Build a Research Collection entity URL for ``kind`` (``person``,
+    ``orgunit``, ``publication``) given a bare UUID4 OR an already-canonical
+    URL. Returns ``None`` when ``value`` is malformed or the kind in an input
+    URL doesn't match the requested ``kind``."""
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not s:
+        return None
+    if s.endswith("/"):
+        s = s.rstrip("/")
+    if s.lower().startswith(_BASE):
+        path = s[len(_BASE):]
+        parts = path.split("/", 1)
+        if len(parts) != 2:
+            return None
+        url_kind, uuid = parts
+        url_kind = url_kind.lower()
+        uuid = uuid.lower()
+        if url_kind != kind:
+            return None
+        if not _UUID4_RE.fullmatch(uuid):
+            return None
+        return f"{_BASE}{kind}/{uuid}"
+    s_lower = s.lower()
+    if not _UUID4_RE.fullmatch(s_lower):
+        return None
+    return f"{_BASE}{kind}/{s_lower}"
+
+
+def ethz_person_iri(value: str | None) -> str | None:
+    """Canonical Research Collection person URL."""
+    return _build("person", value)
+
+
+def ethz_org_iri(value: str | None) -> str | None:
+    """Canonical Research Collection org-unit URL."""
+    return _build("orgunit", value)
+
+
+def ethz_article_iri(value: str | None) -> str | None:
+    """Canonical Research Collection publication URL."""
+    return _build("publication", value)
+
+
+def ethz_iri_sql(expr: str, kind: str) -> str:
+    """Return a DuckDB scalar SQL expression that URL-ifies a bare UUID4
+    column ``expr`` to the canonical Research Collection ``kind`` URL.
+
+    Mirrors :func:`_build`: NULL and already-canonical values pass through,
+    non-UUID4 strings are left as-is, and a bare UUID4 is lowercased and
+    prefixed. Shared by the bulk-SQL ingest path and the bootstrap migration.
+    """
+    if kind not in ("person", "orgunit", "publication"):
+        msg = f"Unknown ethz kind: {kind!r}"
+        raise ValueError(msg)
+    uuid4 = r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+    return (
+        f"CASE "
+        f"WHEN {expr} IS NULL THEN NULL "
+        f"WHEN starts_with(lower({expr}), '{_BASE}') THEN {expr} "
+        f"WHEN regexp_full_match(lower({expr}), '{uuid4}') "
+        f"THEN '{_BASE}{kind}/' || lower({expr}) "
+        f"ELSE {expr} END"
+    )
+
+
+def parse_ethz_iri(iri: str | None) -> tuple[str, str] | None:
+    """Inverse — return ``(kind, uuid)`` for a canonical Research Collection
+    URL, or ``None`` on anything else."""
+    if not isinstance(iri, str):
+        return None
+    s = iri.strip().rstrip("/")
+    if not s.lower().startswith(_BASE):
+        return None
+    rest = s[len(_BASE):]
+    parts = rest.split("/", 1)
+    if len(parts) != 2:
+        return None
+    kind, uuid = parts
+    kind = kind.lower()
+    uuid = uuid.lower()
+    if kind not in ("person", "orgunit", "publication"):
+        return None
+    if not _UUID4_RE.fullmatch(uuid):
+        return None
+    return kind, uuid
+
+
+__all__ = [
+    "ethz_article_iri",
+    "ethz_iri_sql",
+    "ethz_org_iri",
+    "ethz_person_iri",
+    "parse_ethz_iri",
+]

--- a/tests/index/ethz_research_collection/test_duckdb_store_canonical_url.py
+++ b/tests/index/ethz_research_collection/test_duckdb_store_canonical_url.py
@@ -1,0 +1,110 @@
+"""v3.0.0: ethz Research Collection ids (and junction FKs) are canonical URLs.
+
+Covers the per-row Python upserts, the bulk-SQL `ingest_raw` path, and the
+in-place bootstrap migration of legacy bare-UUID rows.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.index.ethz_research_collection.storage.duckdb_store import (
+    EthzResearchCollectionStore,
+)
+from src.index.ethz_research_collection.storage.ingest_raw import ingest_articles
+
+_ART = "8f486100-04da-40e6-9c00-0411efbfd978"
+_PERSON = "a7bc3696-16f4-49a8-a0d1-fabc1d9ad261"
+_ORG = "372d8be7-b45f-47ce-8689-2f7872fd4c2f"
+
+_BASE = "https://www.research-collection.ethz.ch/entities"
+_PUB_URL = f"{_BASE}/publication/{_ART}"
+_PERSON_URL = f"{_BASE}/person/{_PERSON}"
+_ORG_URL = f"{_BASE}/orgunit/{_ORG}"
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> EthzResearchCollectionStore:
+    s = EthzResearchCollectionStore.open(tmp_path / "ethz.duckdb")
+    yield s
+    s.close()
+
+
+def _one(store: EthzResearchCollectionStore, sql: str):
+    return store.connect().execute(sql).fetchone()
+
+
+def test_python_upserts_store_url_ids(store: EthzResearchCollectionStore) -> None:
+    store.upsert_article({"article_uuid": _ART, "title": "T"}, raw={})
+    store.upsert_person({"person_uuid": _PERSON, "primary_affiliation_uuid": _ORG}, raw={})
+    store.upsert_organization({"org_uuid": _ORG, "parent_org_uuid": _ORG}, raw={})
+    store.upsert_article_persons(_ART, [(_PERSON, 0)])
+    store.upsert_article_orgs(_ART, [(_ORG, "cris.virtual.department")])
+    store.upsert_article_links(_ART, [("github", "https://github.com/x/y", "body_text")])
+
+    assert _one(store, "SELECT article_uuid, research_collection_url FROM articles") == (
+        _PUB_URL, _PUB_URL,
+    )
+    assert _one(store, "SELECT person_uuid, primary_affiliation_uuid FROM persons") == (
+        _PERSON_URL, _ORG_URL,
+    )
+    assert _one(store, "SELECT org_uuid FROM organizations")[0] == _ORG_URL
+    assert _one(store, "SELECT article_uuid, person_uuid FROM article_persons") == (
+        _PUB_URL, _PERSON_URL,
+    )
+    assert _one(store, "SELECT article_uuid, org_uuid FROM article_orgs") == (_PUB_URL, _ORG_URL)
+    assert _one(store, "SELECT article_uuid FROM article_links")[0] == _PUB_URL
+
+
+def test_bulk_ingest_raw_stores_url_ids(
+    store: EthzResearchCollectionStore, tmp_path: Path,
+) -> None:
+    items_dir = tmp_path / "items"
+    items_dir.mkdir()
+    item = {
+        "uuid": _ART,
+        "metadata": {
+            "dc.title": [{"value": "Bulk title"}],
+            # ETH RC author UUIDs live in relation.isAuthorOfPublication[*].value
+            "relation.isAuthorOfPublication": [{"value": _PERSON, "place": "0"}],
+            "cris.virtual.department": [{"value": "Lab", "authority": _ORG}],
+        },
+    }
+    (items_dir / f"{_ART}.json").write_text(json.dumps(item), encoding="utf-8")
+
+    ingest_articles(store, items_dir=items_dir)
+
+    assert _one(store, "SELECT article_uuid, research_collection_url FROM articles") == (
+        _PUB_URL, _PUB_URL,
+    )
+    assert _one(store, "SELECT article_uuid, person_uuid FROM article_persons") == (
+        _PUB_URL, _PERSON_URL,
+    )
+    assert _one(store, "SELECT article_uuid, org_uuid FROM article_orgs") == (_PUB_URL, _ORG_URL)
+
+
+def test_bootstrap_migrates_legacy_bare_uuid_rows(tmp_path: Path) -> None:
+    db = tmp_path / "legacy.duckdb"
+    store = EthzResearchCollectionStore.open(db)
+    conn = store.connect()
+    conn.execute(
+        "INSERT INTO articles (article_uuid, title, research_collection_url) VALUES (?, ?, ?)",
+        [_ART, "Legacy", f"{_BASE}/publication/{_ART}"],
+    )
+    conn.execute(
+        "INSERT INTO article_persons (article_uuid, person_uuid, position) VALUES (?, ?, ?)",
+        [_ART, _PERSON, 0],
+    )
+    store.close()
+
+    store2 = EthzResearchCollectionStore.open(db)
+    assert _one(store2, "SELECT article_uuid FROM articles")[0] == _PUB_URL
+    assert _one(store2, "SELECT article_uuid, person_uuid FROM article_persons") == (
+        _PUB_URL, _PERSON_URL,
+    )
+    store2.bootstrap()  # idempotent
+    assert _one(store2, "SELECT article_uuid FROM articles")[0] == _PUB_URL
+    store2.close()

--- a/tests/v2/test_ethz_canonicalization.py
+++ b/tests/v2/test_ethz_canonicalization.py
@@ -1,0 +1,75 @@
+"""Tests for the shared ETH Research Collection canonical-URL helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.v2.canonicalization.ethz import (
+    ethz_article_iri,
+    ethz_org_iri,
+    ethz_person_iri,
+    parse_ethz_iri,
+)
+
+_UUID = "f97b60da-bcab-4f2e-ba12-0ee0c4d0d6eb"
+_BASE = "https://www.research-collection.ethz.ch/entities"
+_PERSON_URL = f"{_BASE}/person/{_UUID}"
+_ORG_URL = f"{_BASE}/orgunit/{_UUID}"
+_ARTICLE_URL = f"{_BASE}/publication/{_UUID}"
+
+
+def test_person_iri_from_bare_uuid():
+    assert ethz_person_iri(_UUID) == _PERSON_URL
+
+
+def test_iri_idempotent_and_trailing_slash():
+    assert ethz_person_iri(_PERSON_URL) == _PERSON_URL
+    assert ethz_person_iri(_PERSON_URL + "/") == _PERSON_URL
+    assert ethz_person_iri(f"  {_UUID}  ") == _PERSON_URL
+
+
+def test_org_iri_builds_orgunit_url():
+    assert ethz_org_iri(_UUID) == _ORG_URL
+    assert "/entities/orgunit/" in ethz_org_iri(_UUID)
+
+
+def test_article_iri_builds_publication_url():
+    assert ethz_article_iri(_UUID) == _ARTICLE_URL
+
+
+def test_iri_rejects_wrong_kind_url():
+    assert ethz_person_iri(_ORG_URL) is None
+    assert ethz_org_iri(_PERSON_URL) is None
+    assert ethz_article_iri(_ORG_URL) is None
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        "",
+        "   ",
+        "not-a-uuid",
+        "f97b60da",
+        "https://example.com/" + _UUID,
+        f"{_BASE}/{_UUID}",  # missing /<kind>/
+        "f97b60da-bcab-1f2e-ba12-0ee0c4d0d6eb",  # UUID1-shaped
+    ],
+)
+def test_helpers_return_none_for_malformed_input(raw):
+    assert ethz_person_iri(raw) is None
+    assert ethz_org_iri(raw) is None
+    assert ethz_article_iri(raw) is None
+
+
+def test_parse_returns_kind_and_uuid():
+    assert parse_ethz_iri(_PERSON_URL) == ("person", _UUID)
+    assert parse_ethz_iri(_ORG_URL) == ("orgunit", _UUID)
+    assert parse_ethz_iri(_ARTICLE_URL) == ("publication", _UUID)
+    assert parse_ethz_iri(_ARTICLE_URL + "/") == ("publication", _UUID)
+
+
+def test_parse_returns_none_on_non_canonical():
+    assert parse_ethz_iri(None) is None
+    assert parse_ethz_iri(_UUID) is None
+    assert parse_ethz_iri(f"{_BASE}/spaceship/{_UUID}") is None


### PR DESCRIPTION
Full relational re-PK of the ETH Research Collection index — the direct mirror of the infoscience increment (#116). The `article_uuid` / `person_uuid` / `org_uuid` ids **and every junction FK** now hold the canonical Research Collection entity URL instead of the bare DSpace UUID:

`https://www.research-collection.ethz.ch/entities/{publication|person|orgunit}/<uuid>`

### Both id paths covered (identical output)
- **Bulk-SQL ingest** (`ingest_raw.py`): shared UUID4-guarded `ethz_iri_sql()`. ETH RC author UUIDs come from `relation.isAuthorOfPublication[*].value`.
- **Qdrant build path** (`parsers.py` + `extract_relations.py`): record ids + kind-aware UUID cross-refs.

### Migration
`EthzResearchCollectionStore.bootstrap()` promotes legacy bare-UUID rows in place across all 6 tables — idempotent.

### Notes
- `.txt` person/org worklists stay **bare UUIDs** (fetch-by-UUID input); `fetch_related` is URL-tolerant.
- `journal_uuid` left bare (unsupported URL kind).
- **Operational follow-up:** re-embed the Qdrant collections.

### Tests
- New `test_ethz_canonicalization` + `test_duckdb_store_canonical_url` (upserts + bulk ingest + legacy migration + idempotency).
- Full `tests/v2/` gate: **1354 passed, 1 skipped**.