### PR TITLE
feat(snsf index): grant id is the canonical SNSF grant URL (v3.0.0 ids)

### DIFF
--- a/src/index/snsf/embed_pipeline.py
+++ b/src/index/snsf/embed_pipeline.py
@@ -120,7 +120,9 @@ async def run(
     else:
         qstore.ensure_collection(active)
 
-    grant_numbers = [int(r["grant_number"]) for r in rows]
+    # v3.0.0: grant_number is the canonical grant URL (str); the Qdrant
+    # store derives the uuid5 point id from it.
+    grant_numbers = [r["grant_number"] for r in rows]
     payloads = [_payload(r, t) for r, t in zip(rows, texts)]
     qstore.upsert_records(
         active,

--- a/src/index/snsf/orcid_link.py
+++ b/src/index/snsf/orcid_link.py
@@ -118,7 +118,7 @@ def link_by_orcid(
                    g.main_discipline, g.start_date, g.amount_granted, g.state
             FROM persons p,
                  json_each(p.responsible_applicant_grants) AS j
-            JOIN grants g ON g.grant_number = CAST(j.value AS INTEGER)
+            JOIN grants g ON g.grant_number = json_extract_string(j.value, '$')
             {scope_join}
             WHERE p.orcid = ?
             ORDER BY g.start_date DESC NULLS LAST
@@ -180,7 +180,7 @@ def coverage_report(snsf_scope: Optional[str] = None) -> Dict[str, Any]:
     conn = open_joined(read_only=True)
     try:
         scope_join = (
-            "JOIN scope_records s ON s.grant_number = CAST(j.value AS INTEGER) "
+            "JOIN scope_records s ON s.grant_number = json_extract_string(j.value, '$') "
             "AND s.scope_mode = ?"
         ) if snsf_scope else ""
         params: List[Any] = [snsf_scope] if snsf_scope else []

--- a/src/index/snsf/qdrant_store.py
+++ b/src/index/snsf/qdrant_store.py
@@ -1,9 +1,13 @@
 """Qdrant client wrapper for the SNSF P3 index.
 
 One collection per scope mode (`snsf_epfl`, `snsf_ethz`, `snsf_eth_domain`,
-`snsf_switzerland`). Mirrors `src/index/ror/qdrant_store.py` shape — the
-only difference is point IDs use the integer `grant_number` directly
-instead of a UUIDv5 (Qdrant accepts int64 IDs natively).
+`snsf_switzerland`).
+
+v3.0.0: the grant id is the canonical grant URL
+(`https://data.snf.ch/grants/grant/<n>`). Qdrant point ids must be uint64 or
+UUID, so points are keyed by a deterministic `uuid5` of the grant URL (the
+infoscience / ethz scheme); the URL itself rides in the payload as
+`grant_number` and is what search returns.
 """
 
 from __future__ import annotations
@@ -12,6 +16,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from qdrant_client import QdrantClient, models
+
+from src.v2.canonicalization.snsf import snsf_grant_point_id
 
 if TYPE_CHECKING:
     from src.index.snsf.config import SnsfIndexConfig
@@ -65,7 +71,7 @@ class QdrantSnsfStore:
         self,
         scope_mode: str,
         *,
-        grant_numbers: List[int],
+        grant_numbers: List[str],
         vectors: List[List[float]],
         payloads: List[Dict[str, Any]],
         batch_size: int = 256,
@@ -79,7 +85,7 @@ class QdrantSnsfStore:
         for start in range(0, len(grant_numbers), batch_size):
             end = start + batch_size
             points = [
-                models.PointStruct(id=int(gn), vector=vec, payload=p)
+                models.PointStruct(id=snsf_grant_point_id(gn), vector=vec, payload=p)
                 for gn, vec, p in zip(
                     grant_numbers[start:end], vectors[start:end], payloads[start:end],
                 )
@@ -129,7 +135,9 @@ class QdrantSnsfStore:
         return [
             {
                 "score": float(p.score),
-                "grant_number": int(p.id),
+                # The point id is a uuid5(url); the canonical grant URL id
+                # rides in the payload.
+                "grant_number": (p.payload or {}).get("grant_number"),
                 "title": (p.payload or {}).get("title", ""),
                 "research_institution": (p.payload or {}).get("research_institution"),
                 "main_discipline": (p.payload or {}).get("main_discipline"),

--- a/src/index/snsf/resume_embed.py
+++ b/src/index/snsf/resume_embed.py
@@ -30,14 +30,16 @@ from src.index.snsf.embed import embed_passages
 from src.index.snsf.embed_pipeline import _payload, _scope_grant_rows
 from src.index.snsf.qdrant_store import QdrantSnsfStore
 from src.index.snsf.storage.duckdb_store import SnsfStore
+from src.v2.canonicalization.snsf import snsf_grant_point_id
 
 LOGGER = logging.getLogger(__name__)
 
 
-def _existing_point_ids(qstore: QdrantSnsfStore, collection: str) -> set[int]:
-    """Scroll the entire collection, collecting integer point ids."""
+def _existing_point_ids(qstore: QdrantSnsfStore, collection: str) -> set[str]:
+    """Scroll the entire collection, collecting point ids (uuid5 of the
+    grant URL)."""
     client = qstore.client
-    seen: set[int] = set()
+    seen: set[str] = set()
     offset = None
     while True:
         points, offset = client.scroll(
@@ -48,10 +50,7 @@ def _existing_point_ids(qstore: QdrantSnsfStore, collection: str) -> set[int]:
             with_vectors=False,
         )
         for p in points:
-            try:
-                seen.add(int(p.id))
-            except (TypeError, ValueError):
-                continue
+            seen.add(str(p.id))
         if offset is None:
             break
     return seen
@@ -78,7 +77,8 @@ async def run(scope_mode: str) -> Dict[str, Any]:
     LOGGER.info("Scope %s has %d grants in DuckDB", scope_mode, len(all_rows))
 
     missing: List[Dict[str, Any]] = [
-        r for r in all_rows if int(r["grant_number"]) not in existing
+        r for r in all_rows
+        if snsf_grant_point_id(r["grant_number"]) not in existing
     ]
     LOGGER.info("Missing %d grants → embedding", len(missing))
 
@@ -94,7 +94,7 @@ async def run(scope_mode: str) -> Dict[str, Any]:
     matrix = await embed_passages(cfg.rcp, texts, normalize=True)
     LOGGER.info("Embedded matrix shape=%s", matrix.shape)
 
-    grant_numbers = [int(r["grant_number"]) for r in missing]
+    grant_numbers = [r["grant_number"] for r in missing]
     payloads = [_payload(r, t) for r, t in zip(missing, texts)]
     qstore.upsert_records(
         scope_mode,

--- a/src/index/snsf/storage/duckdb_store.py
+++ b/src/index/snsf/storage/duckdb_store.py
@@ -19,6 +19,7 @@ import duckdb
 
 from src.index.snsf.models import IngestManifest
 from src.index.snsf.paths import duckdb_path
+from src.v2.canonicalization.snsf import snsf_grant_iri, snsf_grant_iri_sql
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -26,6 +27,35 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 SCHEMA_PATH = Path(__file__).parent / "schema.sql"
+
+# v3.0.0: the grant id is the canonical SNSF grant URL. This SQL fragment
+# URL-ifies the bare integer `GrantNumber` from the CSV (and is reused by the
+# bootstrap migration) so every `grant_number` PK/FK holds the URL.
+_GRANT_URL_SQL = snsf_grant_iri_sql("GrantNumber")
+_GRANT_BASE = "https://data.snf.ch/grants/grant/"
+
+# Output tables whose `grant_number` FK must be migrated alongside `grants`.
+_GRANT_FK_TABLES = (
+    "output_publications",
+    "output_academic_events",
+    "output_collaborations",
+    "output_datasets",
+    "output_knowledge_transfers",
+    "output_public_communications",
+    "output_use_inspired",
+    "scope_records",
+)
+
+# Per-role grant-number JSON-array columns in `persons` (lists of grant ids).
+_PERSON_GRANT_COLS = (
+    "responsible_applicant_grants",
+    "co_applicant_grants",
+    "project_partner_grants",
+    "practice_partner_grants",
+    "employee_grants",
+    "contact_person_grants",
+    "applicant_abroad_grants",
+)
 
 
 def _load_schema_sql() -> str:
@@ -63,6 +93,62 @@ class SnsfStore:
         )
 
         migrate_doi_column_to_url(conn, table="output_publications", column="doi")
+        self._migrate_grant_ids_to_url(conn)
+
+    @staticmethod
+    def _migrate_grant_ids_to_url(conn: duckdb.DuckDBPyConnection) -> None:
+        """v3.0.0: promote the integer `grant_number` PK/FKs (and the per-role
+        grant-number JSON arrays in `persons`) to the canonical grant URL.
+
+        Gated on the pre-v3 schema (`grants.grant_number` still INTEGER) so the
+        whole migration runs exactly once: after it, every `grant_number` is
+        VARCHAR and re-runs are no-ops. Fresh DBs (TEXT from schema.sql) skip.
+
+        DuckDB can't ``ALTER COLUMN ... TYPE`` a PRIMARY KEY column (``grants``,
+        ``scope_records``), so each affected table is rebuilt: snapshot into a
+        TEMP with the URL-transformed ``grant_number``, drop the original
+        (releasing its index names), recreate the fresh TEXT schema, then
+        re-insert ``BY NAME``. ``persons`` keeps its columns — only its JSON
+        grant-arrays are rewritten in place.
+        """
+        row = conn.execute(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_name = 'grants' AND column_name = 'grant_number'",
+        ).fetchone()
+        if row is None or "INT" not in str(row[0]).upper():
+            return  # already migrated (TEXT/VARCHAR) or table absent
+
+        existing = {
+            r[0]
+            for r in conn.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'main'",
+            ).fetchall()
+        }
+        url_sql = snsf_grant_iri_sql("grant_number")
+        tables = [t for t in ("grants", *_GRANT_FK_TABLES) if t in existing]
+        for table in tables:
+            conn.execute(
+                f"CREATE TEMP TABLE _mig_{table} AS "  # noqa: S608
+                f"SELECT * REPLACE ({url_sql} AS grant_number) FROM {table}",
+            )
+            conn.execute(f"DROP TABLE {table}")  # noqa: S608 — also drops its indexes
+        conn.execute(_load_schema_sql())  # recreate fresh TEXT tables + indexes
+        for table in tables:
+            conn.execute(
+                f"INSERT INTO {table} BY NAME SELECT * FROM _mig_{table}",  # noqa: S608
+            )
+            conn.execute(f"DROP TABLE _mig_{table}")  # noqa: S608
+        # persons keeps its schema; only its JSON arrays of bare integers
+        # become arrays of grant URLs.
+        if "persons" not in existing:
+            return
+        for col in _PERSON_GRANT_COLS:
+            conn.execute(
+                f"UPDATE persons SET {col} = TO_JSON(LIST_TRANSFORM("  # noqa: S608
+                f"CAST({col} AS BIGINT[]), n -> '{_GRANT_BASE}' || n)) "
+                f"WHERE {col} IS NOT NULL",
+            )
 
     def close(self) -> None:
         if self._conn is not None:
@@ -123,7 +209,7 @@ class SnsfStore:
                     state, call_full_title, call_end_date, call_decision_year
                 )
                 SELECT
-                    GrantNumber, GrantNumberString, Title, TitleEnglish,
+                    """ + _GRANT_URL_SQL + """, GrantNumberString, Title, TitleEnglish,
                     ResponsibleApplicantName,
                     FundingInstrumentPublished, FundingInstrumentReporting, FundingInstrumentLevel1,
                     Institute, InstituteCity, InstituteCountry,
@@ -162,13 +248,16 @@ class SnsfStore:
         # Some columns in persons.csv only ever contain a single grant_number per row,
         # so DuckDB auto-detects them as BIGINT — explicit CAST(... AS VARCHAR) is needed
         # before TRIM/STRING_SPLIT to keep the SQL valid for both BIGINT and VARCHAR types.
+        # v3.0.0: the per-role grant lists hold canonical grant URLs, not bare
+        # integers. Non-numeric tokens map to NULL (as the old TRY_CAST did).
         def _split(col: str) -> str:
             return (
                 f"CASE WHEN {col} IS NULL "
                 f"OR LENGTH(TRIM(CAST({col} AS VARCHAR))) = 0 THEN NULL "
                 f"ELSE TO_JSON(LIST_TRANSFORM("
                 f"STRING_SPLIT(CAST({col} AS VARCHAR), ';'), "
-                f"x -> TRY_CAST(TRIM(x) AS INTEGER))) END"
+                f"x -> CASE WHEN regexp_full_match(TRIM(x), '\\d+') "
+                f"THEN '{_GRANT_BASE}' || TRIM(x) ELSE NULL END)) END"
             )
 
         conn = self.connect()
@@ -390,6 +479,9 @@ class SnsfStore:
         if not csv_path.exists():
             msg = f"output CSV not found: {csv_path}"
             raise FileNotFoundError(msg)
+        # v3.0.0: the `grant_number` FK is the canonical grant URL. The output
+        # CSVs all carry a bare-integer `GrantNumber` column; URL-ify it.
+        select = select.replace("GrantNumber", _GRANT_URL_SQL, 1)
         conn = self.connect()
         with self.transaction():
             conn.execute(f"DELETE FROM {table}")  # noqa: S608 — table is a fixed string
@@ -473,9 +565,11 @@ class SnsfStore:
         ).fetchone()
         return int(result[0]) if result else 0
 
-    def fetch_grant(self, grant_number: int) -> Optional[dict[str, Any]]:
+    def fetch_grant(self, grant_number: object) -> Optional[dict[str, Any]]:
+        # Accept a bare int / numeric string or the canonical grant URL.
         cur = self.connect().execute(
-            "SELECT * FROM grants WHERE grant_number = ?", [int(grant_number)],
+            "SELECT * FROM grants WHERE grant_number = ?",
+            [snsf_grant_iri(grant_number) or grant_number],
         )
         row = cur.fetchone()
         if row is None:

--- a/src/index/snsf/storage/schema.sql
+++ b/src/index/snsf/storage/schema.sql
@@ -5,7 +5,10 @@
 -- One row per SNSF P3 grant (Application). Loaded from the bulk CSV
 -- `grants_with_abstracts.csv`. 90,448 grants total, 1975-2027.
 CREATE TABLE IF NOT EXISTS grants (
-    grant_number             INTEGER PRIMARY KEY,
+    -- v3.0.0: the id is the canonical SNSF grant URL
+    -- (`https://data.snf.ch/grants/grant/<n>`), not the bare integer.
+    -- `SnsfStore.bootstrap()` migrates legacy INTEGER rows in place.
+    grant_number             TEXT PRIMARY KEY,
     grant_number_string      TEXT,
     title                    TEXT,
     title_english            TEXT,
@@ -107,7 +110,7 @@ CREATE TABLE IF NOT EXISTS discipline_taxonomy (
 -- Per-scope grant membership. (scope_mode, grant_number).
 CREATE TABLE IF NOT EXISTS scope_records (
     scope_mode   TEXT NOT NULL,
-    grant_number INTEGER NOT NULL,
+    grant_number TEXT NOT NULL,
     PRIMARY KEY (scope_mode, grant_number)
 );
 
@@ -133,7 +136,7 @@ CREATE TABLE IF NOT EXISTS manifests (
 -- output_data_scientific_publications.csv — 23 cols including DOI + Abstract.
 CREATE TABLE IF NOT EXISTS output_publications (
     publication_id           TEXT PRIMARY KEY,
-    grant_number             INTEGER,
+    grant_number             TEXT,
     peer_review_status       TEXT,
     type                     TEXT,
     title                    TEXT,
@@ -165,7 +168,7 @@ CREATE INDEX IF NOT EXISTS output_pubs_year_idx  ON output_publications(year);
 -- output_data_academicevents.csv — talks, posters, conferences.
 CREATE TABLE IF NOT EXISTS output_academic_events (
     event_id                 TEXT PRIMARY KEY,
-    grant_number             INTEGER,
+    grant_number             TEXT,
     type                     TEXT,
     event                    TEXT,
     contribution_title       TEXT,
@@ -182,7 +185,7 @@ CREATE INDEX IF NOT EXISTS output_events_date_idx  ON output_academic_events(dat
 -- output_data_collaborations.csv — partner research groups + country.
 CREATE TABLE IF NOT EXISTS output_collaborations (
     collaboration_id         TEXT PRIMARY KEY,
-    grant_number             INTEGER,
+    grant_number             TEXT,
     research_group           TEXT,
     type                     TEXT,
     country                  TEXT,
@@ -197,7 +200,7 @@ CREATE INDEX IF NOT EXISTS output_collab_country_idx ON output_collaborations(co
 -- output_data_datasets.csv — research data outputs (with PID like Zenodo DOI).
 CREATE TABLE IF NOT EXISTS output_datasets (
     dataset_id               TEXT PRIMARY KEY,
-    grant_number             INTEGER,
+    grant_number             TEXT,
     title                    TEXT,
     author                   TEXT,
     persistent_identifier    TEXT,                -- DOI / Handle / etc.
@@ -214,7 +217,7 @@ CREATE INDEX IF NOT EXISTS output_ds_pid_idx   ON output_datasets(persistent_ide
 -- output_data_knowledgetransfer.csv — tech transfer events.
 CREATE TABLE IF NOT EXISTS output_knowledge_transfers (
     event_id                 TEXT PRIMARY KEY,
-    grant_number             INTEGER,
+    grant_number             TEXT,
     type                     TEXT,
     event                    TEXT,
     date                     TIMESTAMP,
@@ -230,7 +233,7 @@ CREATE INDEX IF NOT EXISTS output_kt_grant_idx ON output_knowledge_transfers(gra
 -- output_data_publiccommunications.csv — outreach + lay press.
 CREATE TABLE IF NOT EXISTS output_public_communications (
     communication_id         TEXT PRIMARY KEY,
-    grant_number             INTEGER,
+    grant_number             TEXT,
     type                     TEXT,
     title                    TEXT,
     description              TEXT,
@@ -245,7 +248,7 @@ CREATE INDEX IF NOT EXISTS output_pc_grant_idx ON output_public_communications(g
 -- output_data_useinspired.csv — patents, startups, licenses.
 CREATE TABLE IF NOT EXISTS output_use_inspired (
     use_inspired_id          TEXT PRIMARY KEY,
-    grant_number             INTEGER,
+    grant_number             TEXT,
     type                     TEXT,
     title                    TEXT,
     url                      TEXT,

--- a/src/v2/canonicalization/snsf.py
+++ b/src/v2/canonicalization/snsf.py
@@ -1,0 +1,104 @@
+"""Canonical SNSF grant URL builder for index ids.
+
+SNSF's native grant id is a bare integer ``GrantNumber`` (from the P3 bulk
+CSV). v3.0.0 stores the canonical grant URL as the id — consistent with the
+github / huggingface / dockerhub / orcid / infoscience / ethz index ids:
+
+  grant -> https://data.snf.ch/grants/grant/<grant_number>
+
+Qdrant point ids must be uint64 or UUID (never an arbitrary string), so the
+search layer derives a deterministic ``uuid5`` of the grant URL — exactly the
+scheme the infoscience / ethz indices use. The URL remains the id everywhere a
+consumer sees it (DuckDB PK, Qdrant payload, search-hit id).
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+_BASE = "https://data.snf.ch/grants/grant/"
+
+# Shared namespace for deriving Qdrant point ids from grant URLs.
+_POINT_NAMESPACE = uuid.UUID("b3d1f4a2-7c6e-4d58-9f0a-2e5c8b1d6a47")
+
+_INT_RE = re.compile(r"^\d+$")
+
+
+def snsf_grant_iri(value: object) -> str | None:
+    """Canonical SNSF grant URL for a bare grant number (int or str) or an
+    already-canonical URL.
+
+    Returns None on empty/invalid input. Idempotent: a value already under
+    ``https://data.snf.ch/grants/grant/`` is returned unchanged (trailing
+    slash trimmed); an ``http://`` form is upgraded to ``https://``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return f"{_BASE}{value}"
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not s:
+        return None
+    if s.lower().startswith(_BASE):
+        return s.rstrip("/")
+    if s.lower().startswith("http://data.snf.ch/grants/grant/"):
+        return ("https://" + s.split("://", 1)[1]).rstrip("/")
+    if _INT_RE.fullmatch(s):
+        return f"{_BASE}{s}"
+    return None
+
+
+def parse_snsf_grant(value: object) -> int | None:
+    """Inverse of :func:`snsf_grant_iri`: extract the bare integer grant
+    number. Accepts a canonical URL, a bare numeric string, or an int.
+    Returns None on anything else."""
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        return None
+    s = value.strip().rstrip("/")
+    if not s:
+        return None
+    if s.lower().startswith(_BASE) or s.lower().startswith(
+        "http://data.snf.ch/grants/grant/",
+    ):
+        tail = s.rsplit("/", 1)[-1]
+        return int(tail) if _INT_RE.fullmatch(tail) else None
+    return int(s) if _INT_RE.fullmatch(s) else None
+
+
+def snsf_grant_point_id(value: object) -> str:
+    """Deterministic Qdrant point id (uuid5) for a grant, keyed by its
+    canonical URL. Accepts a URL or a bare grant number."""
+    url = snsf_grant_iri(value) or str(value)
+    return str(uuid.uuid5(_POINT_NAMESPACE, url))
+
+
+def snsf_grant_iri_sql(expr: str) -> str:
+    """Return a DuckDB scalar SQL expression that URL-ifies a bare integer
+    grant number column ``expr`` to the canonical grant URL.
+
+    NULL passes through; an already-canonical URL passes through; a bare
+    integer (cast to text) is prefixed. Shared by the bulk-CSV load path and
+    the bootstrap migration so they agree with :func:`snsf_grant_iri`.
+    """
+    return (
+        f"CASE "
+        f"WHEN {expr} IS NULL THEN NULL "
+        f"WHEN starts_with(lower(CAST({expr} AS VARCHAR)), '{_BASE}') "
+        f"THEN CAST({expr} AS VARCHAR) "
+        f"WHEN regexp_full_match(CAST({expr} AS VARCHAR), '\\d+') "
+        f"THEN '{_BASE}' || CAST({expr} AS VARCHAR) "
+        f"ELSE CAST({expr} AS VARCHAR) END"
+    )
+
+
+__all__ = [
+    "parse_snsf_grant",
+    "snsf_grant_iri",
+    "snsf_grant_iri_sql",
+    "snsf_grant_point_id",
+]

--- a/tests/index/snsf/test_grant_id_canonical_url.py
+++ b/tests/index/snsf/test_grant_id_canonical_url.py
@@ -1,0 +1,121 @@
+"""v3.0.0: SNSF grant ids (PK + FKs + persons JSON arrays) are canonical URLs.
+
+Covers the riskiest pieces: the bulk-CSV load SQL fragments, `fetch_grant`
+accepting any input shape, and the in-place INTEGER→URL bootstrap migration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from src.index.snsf.storage.duckdb_store import (
+    _GRANT_URL_SQL,
+    SnsfStore,
+)
+
+_URL = "https://data.snf.ch/grants/grant/241892"
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SnsfStore:
+    s = SnsfStore.open(tmp_path / "snsf.duckdb")
+    yield s
+    s.close()
+
+
+def test_schema_grant_number_is_text(store: SnsfStore) -> None:
+    row = store.connect().execute(
+        "SELECT data_type FROM information_schema.columns "
+        "WHERE table_name = 'grants' AND column_name = 'grant_number'",
+    ).fetchone()
+    assert "INT" not in str(row[0]).upper()
+
+
+def test_fetch_grant_accepts_int_str_and_url(store: SnsfStore) -> None:
+    store.connect().execute(
+        "INSERT INTO grants (grant_number, title) VALUES (?, ?)",
+        [_URL, "A grant"],
+    )
+    for key in (241892, "241892", _URL):
+        row = store.fetch_grant(key)
+        assert row is not None, key
+        assert row["grant_number"] == _URL
+
+
+def test_grant_url_sql_fragment_behaviour() -> None:
+    """The shared SQL fragment URL-ifies a bare integer, passes URLs/NULL."""
+    c = duckdb.connect()
+    c.execute("CREATE TABLE t (id INTEGER, GrantNumber VARCHAR)")
+    c.execute(
+        "INSERT INTO t VALUES (1, '241892'), (2, ?), (3, NULL)", [_URL],
+    )
+    got = [
+        r[0]
+        for r in c.execute(f"SELECT {_GRANT_URL_SQL} FROM t ORDER BY id").fetchall()
+    ]
+    assert got == [_URL, _URL, None]
+
+
+def test_split_fragment_builds_url_arrays() -> None:
+    """The persons `_split` lambda turns ';'-joined grant numbers into a JSON
+    array of grant URLs (non-numeric tokens -> NULL)."""
+    base = "https://data.snf.ch/grants/grant/"
+    c = duckdb.connect()
+    expr = (
+        "TO_JSON(LIST_TRANSFORM(STRING_SPLIT(CAST(col AS VARCHAR), ';'), "
+        f"x -> CASE WHEN regexp_full_match(TRIM(x), '\\d+') "
+        f"THEN '{base}' || TRIM(x) ELSE NULL END))"
+    )
+    c.execute("CREATE TABLE p (col VARCHAR)")
+    c.execute("INSERT INTO p VALUES ('108806;125710')")
+    out = c.execute(f"SELECT {expr} FROM p").fetchone()[0]
+    assert f"{base}108806" in out
+    assert f"{base}125710" in out
+
+
+def test_migration_promotes_legacy_integer_ids(tmp_path: Path) -> None:
+    """A pre-v3 DB (grant_number INTEGER, JSON int arrays) is migrated in
+    place to URLs, idempotently. Exercises `_migrate_grant_ids_to_url`
+    directly on the columns it touches (the full schema's indexes are
+    covered elsewhere)."""
+    conn = duckdb.connect(str(tmp_path / "legacy.duckdb"))
+    conn.execute("CREATE TABLE grants (grant_number INTEGER PRIMARY KEY, title TEXT)")
+    conn.execute("INSERT INTO grants VALUES (241892, 'A'), (999, 'B')")
+    conn.execute("CREATE TABLE output_publications (publication_id TEXT, grant_number INTEGER)")
+    conn.execute("INSERT INTO output_publications VALUES ('p1', 241892)")
+    conn.execute("CREATE TABLE scope_records (scope_mode TEXT, grant_number INTEGER)")
+    conn.execute("INSERT INTO scope_records VALUES ('epfl', 241892)")
+    # Include the columns schema.sql indexes (orcid, research_institution) so
+    # the migration's schema re-run can (re)create the persons indexes.
+    conn.execute(
+        "CREATE TABLE persons (person_number INTEGER, orcid TEXT, "
+        "research_institution TEXT, "
+        "responsible_applicant_grants JSON, co_applicant_grants JSON, "
+        "project_partner_grants JSON, practice_partner_grants JSON, "
+        "employee_grants JSON, contact_person_grants JSON, "
+        "applicant_abroad_grants JSON)",
+    )
+    conn.execute(
+        "INSERT INTO persons VALUES (1, NULL, NULL, TO_JSON([241892, 999]), "
+        "NULL, NULL, NULL, NULL, NULL, NULL)",
+    )
+
+    SnsfStore._migrate_grant_ids_to_url(conn)
+
+    assert conn.execute("SELECT grant_number FROM grants ORDER BY title").fetchall() == [
+        ("https://data.snf.ch/grants/grant/241892",),
+        ("https://data.snf.ch/grants/grant/999",),
+    ]
+    assert conn.execute("SELECT grant_number FROM output_publications").fetchone()[0] == _URL
+    assert conn.execute("SELECT grant_number FROM scope_records").fetchone()[0] == _URL
+    arr = conn.execute("SELECT responsible_applicant_grants FROM persons").fetchone()[0]
+    assert _URL in arr and "https://data.snf.ch/grants/grant/999" in arr
+
+    # Idempotent: re-running detects the already-migrated (VARCHAR) schema
+    # and changes nothing.
+    SnsfStore._migrate_grant_ids_to_url(conn)
+    assert conn.execute("SELECT grant_number FROM grants WHERE title = 'A'").fetchone()[0] == _URL
+    conn.close()

--- a/tests/v2/test_snsf_canonicalization.py
+++ b/tests/v2/test_snsf_canonicalization.py
@@ -1,0 +1,52 @@
+"""Tests for the SNSF grant canonical-URL helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.v2.canonicalization.snsf import (
+    parse_snsf_grant,
+    snsf_grant_iri,
+    snsf_grant_point_id,
+)
+
+_URL = "https://data.snf.ch/grants/grant/241892"
+
+
+def test_iri_from_int_and_str():
+    assert snsf_grant_iri(241892) == _URL
+    assert snsf_grant_iri("241892") == _URL
+    assert snsf_grant_iri("  241892  ") == _URL
+
+
+def test_iri_idempotent_on_url():
+    assert snsf_grant_iri(_URL) == _URL
+    assert snsf_grant_iri(_URL + "/") == _URL
+    assert snsf_grant_iri("http://data.snf.ch/grants/grant/241892") == _URL
+
+
+@pytest.mark.parametrize("bad", [None, "", "   ", "abc", "12a", [], {}, "https://example.com/1"])
+def test_iri_rejects_garbage(bad):
+    assert snsf_grant_iri(bad) is None
+
+
+def test_parse_inverts():
+    assert parse_snsf_grant(_URL) == 241892
+    assert parse_snsf_grant("241892") == 241892
+    assert parse_snsf_grant(241892) == 241892
+    assert parse_snsf_grant(_URL + "/") == 241892
+
+
+@pytest.mark.parametrize("bad", [None, "", "abc", "https://example.com/x"])
+def test_parse_rejects_garbage(bad):
+    assert parse_snsf_grant(bad) is None
+
+
+def test_point_id_is_stable_uuid_keyed_on_url():
+    # Same grant via int / str / URL → same point id (keyed on the URL).
+    pid = snsf_grant_point_id(241892)
+    assert pid == snsf_grant_point_id("241892")
+    assert pid == snsf_grant_point_id(_URL)
+    # uuid5 shape
+    assert len(pid) == 36 and pid.count("-") == 4
+    assert snsf_grant_point_id(999) != pid


### PR DESCRIPTION
Final v3.0.0 index-id increment. Re-PKs the SNSF grant id from the bare integer `GrantNumber` to the canonical grant URL — e.g. grant `241892` → **`https://data.snf.ch/grants/grant/241892`** — across every reference.

### Bigger than the DSpace increments (#116/#117) — two reasons
1. **Column type change**: `grant_number` INTEGER → TEXT across the `grants` PK, the **7 `output_*` FK tables**, `scope_records`, and the **per-role grant-number JSON arrays** in `persons`.
2. **Qdrant point-id scheme change**: Qdrant point ids must be uint64/UUID, so points can't be keyed by a URL string. They're now keyed by a deterministic `uuid5(grant_url)` (the infoscience/ethz scheme); the URL rides in the payload and is what search returns. Previously the raw integer `grant_number` was the point id.

### What changed
- **schema**: `grant_number` INTEGER→TEXT everywhere.
- **store**: URL-ified at CSV-load (grants + all outputs via `_replace_output_table` + persons JSON arrays); `fetch_grant` accepts int / numeric-string / URL.
- **migration** (`bootstrap()`): rebuild-based — DuckDB can't `ALTER` a PRIMARY KEY column's type, so each affected table is snapshotted → dropped → recreated fresh (TEXT) from `schema.sql` → reinserted `BY NAME`; persons JSON arrays rewritten in place. Gated on the pre-v3 INTEGER schema, so it runs once and re-runs are no-ops.
- **search/embed**: `qdrant_store` uuid5 point ids; `embed_pipeline`/`resume_embed` drop `int()` casts and dedup on the point id; `orcid_link` JSON joins compare `json_extract_string(j.value,'$')` against the URL.

### ⚠️ Deploy note
The Qdrant point-id scheme changes, so this needs a **re-embed** of the snsf collections. The DuckDB store + in-place migration are code-complete.

### Tests
- New `test_snsf_canonicalization` + `test_grant_id_canonical_url` (load SQL fragments, `fetch_grant`, legacy-INTEGER→URL migration + idempotency + JSON-array rewrite).
- Full `tests/v2/` gate: **1370 passed, 1 skipped**.

Left open for review rather than auto-merged, given the schema-type change + re-embed requirement.