### PR TITLE
feat(federated): machine-readable store manifest + naming contract

### DIFF
--- a/docs/architecture/index-store-naming.md
+++ b/docs/architecture/index-store-naming.md
@@ -1,0 +1,81 @@
+# Index store naming & the federated manifest
+
+This is the contract consumers (the Hub's "Sources" tiles, federated search,
+any external reader) should build against. **Do not infer a store's shape from
+its name or filename** — read the manifest.
+
+## The one invariant
+
+For every store:
+
+```
+store name  ==  <store name>.duckdb  ==  the key in src/index/_federated/registry.py
+```
+
+The DuckDB file is always `<store-name>.duckdb` (e.g. `zenodo_communities.duckdb`,
+`openalex.duckdb`). The registry (`load_adapters()`) is the source of truth for
+which stores exist.
+
+## Two naming patterns (both valid — don't "fix" them)
+
+A store name is **opaque**. Two patterns coexist by design:
+
+| Pattern | Shape | When | Examples |
+|---|---|---|---|
+| **A — split** | `<source>_<entity>` | a source is split into several independently-useful entity stores | `github_repos`, `github_users`, `huggingface_models`, `zenodo_records`, `zenodo_communities` |
+| **B — unified** | `<source>` | a source is one store holding many tables in one DuckDB | `openalex` (10 tables), `snsf` (17), `infoscience` (6), `orcid`, `ror`, `dockerhub` |
+
+You **cannot** put "the table" in the name of a Pattern-B store — `openalex.duckdb`
+has works, authors, institutions, … . So `<source>_<table>` is *not* a universal
+rule, and trying to enforce it everywhere would misrepresent multi-table stores.
+
+A single DuckDB legitimately holds **many tables** (entity + junction/satellite +
+chunk bookkeeping). The file boundary is the *store*, not the table.
+
+## The manifest
+
+`python -m src.index._federated.manifest` emits the structured truth so consumers
+never parse names:
+
+```json
+{
+  "name": "zenodo_communities",
+  "duckdb": "zenodo_communities.duckdb",
+  "entity_types": ["community"],
+  "backend": "duckdb",          // "vector" = own Qdrant collection; "duckdb" = SQL only
+  "surface_as_source": true,    // show as a Hub "Sources" tile
+  "id_shape": "url"             // v3.0.0: every id is a canonical URL
+}
+```
+
+`--sources` filters to the stores the Hub should tile: **vector-backed stores
+plus DuckDB-only stores explicitly allowlisted** via `surface_as_source`. This is
+the curated allowlist — DuckDB-only stores stay off the grid unless they opt in
+(so dead/legacy stores don't resurrect), and it's declared in the index, not
+hardcoded in the Hub.
+
+### Declaring the hints
+
+The three manifest fields are optional class attributes on the adapter (read via
+`getattr`, so they are **not** part of the `IndexAdapter` `isinstance` contract —
+existing adapters need no change):
+
+```python
+class ZenodoCommunitiesAdapter:
+    name = "zenodo_communities"
+    entity_types = ["community"]
+    backend = "duckdb"
+    surface_as_source = True
+    id_shape = "url"
+```
+
+Defaults when unset: `backend="vector"`, `surface_as_source=False`, `id_shape="url"`.
+
+## Consumer guidance (Hub)
+
+1. Iterate `python -m src.index._federated.manifest --sources` (or the registry).
+2. Treat each store as opaque: name = filename, possibly multi-table.
+3. Render one tile per entry; use the entity's canonical URL id (`community_id`,
+   etc.) as the tile id and click-through target.
+4. New stores (e.g. a future `github_communities`) appear automatically once
+   registered + allowlisted — no Hub change.

--- a/src/index/_federated/adapters/zenodo_communities.py
+++ b/src/index/_federated/adapters/zenodo_communities.py
@@ -46,6 +46,11 @@ def _row_to_hit(row: dict[str, Any], score: float) -> Hit:
 class ZenodoCommunitiesAdapter:
     name = "zenodo_communities"
     entity_types = ["community"]
+    # Manifest hints (see IndexAdapter docstring). DuckDB-only store, but it
+    # should still show as a "Sources" tile — the curated allowlist opt-in.
+    backend = "duckdb"
+    surface_as_source = True
+    id_shape = "url"  # community_id is https://zenodo.org/communities/<slug>
 
     def search(
         self,

--- a/src/index/_federated/manifest.py
+++ b/src/index/_federated/manifest.py
@@ -1,0 +1,85 @@
+"""Machine-readable manifest of the federated index stores.
+
+The single contract the Hub (and any other consumer) builds against, so it
+never has to infer a store's shape from its name or filename. For every
+registered adapter it emits:
+
+    name              the registry key == the DuckDB filename stem
+    duckdb            "<name>.duckdb" — the on-disk store file
+    entity_types      the entity types the store serves
+    backend           "vector" (own Qdrant collection) | "duckdb" (SQL only)
+    surface_as_source whether the Hub should show it as a "Sources" tile
+    id_shape          shape of the canonical id ("url" in v3.0.0)
+
+Naming is intentionally NOT parsed: some stores are `<source>_<entity>`
+(`github_repos`, `zenodo_communities`) and some are bare `<source>` holding
+many tables (`openalex`, `snsf`). The store name is opaque; the manifest
+carries the structured truth instead.
+
+Usage:
+    python -m src.index._federated.manifest            # JSON to stdout
+    python -m src.index._federated.manifest --sources  # only Source tiles
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from src.index._federated.registry import IndexAdapter, load_adapters
+
+# Defaults for the optional, declarative adapter attributes (see
+# `IndexAdapter` docstring). Read via getattr so adapters opt in only where
+# they differ from the default.
+_DEFAULT_BACKEND = "vector"
+_DEFAULT_SURFACE = False
+_DEFAULT_ID_SHAPE = "url"
+
+
+def manifest_entry(adapter: IndexAdapter) -> dict[str, Any]:
+    """Build one manifest entry from a registered adapter."""
+    name = adapter.name
+    return {
+        "name": name,
+        "duckdb": f"{name}.duckdb",
+        "entity_types": list(adapter.entity_types),
+        "backend": getattr(adapter, "backend", _DEFAULT_BACKEND),
+        "surface_as_source": bool(
+            getattr(adapter, "surface_as_source", _DEFAULT_SURFACE),
+        ),
+        "id_shape": getattr(adapter, "id_shape", _DEFAULT_ID_SHAPE),
+    }
+
+
+def build_manifest(*, sources_only: bool = False) -> list[dict[str, Any]]:
+    """Return the manifest for all registered stores, sorted by name.
+
+    ``sources_only`` keeps just the stores the Hub should tile under
+    "Sources" — i.e. vector-backed stores plus DuckDB-only stores explicitly
+    allowlisted via ``surface_as_source``.
+    """
+    entries = [manifest_entry(a) for a in load_adapters()]
+    if sources_only:
+        entries = [
+            e for e in entries
+            if e["surface_as_source"] or e["backend"] == "vector"
+        ]
+    entries.sort(key=lambda e: e["name"])
+    return entries
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sources",
+        action="store_true",
+        help="emit only stores that should appear as Hub 'Sources' tiles",
+    )
+    args = parser.parse_args(argv)
+    print(json.dumps(build_manifest(sources_only=args.sources), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/index/_federated/registry.py
+++ b/src/index/_federated/registry.py
@@ -42,6 +42,22 @@ class IndexAdapter(Protocol):
     Adapters live under `src/index/_federated/adapters/<name>.py` and are
     expected to be cheap to import. Heavy imports (RCP clients, qdrant,
     duckdb) should happen inside the methods, not at module top-level.
+
+    Optional, declarative class attributes (read by the manifest export via
+    `getattr`, so they are NOT part of this Protocol's `isinstance` contract —
+    existing adapters need no change):
+
+      * ``backend``            : ``"vector"`` (default) or ``"duckdb"`` —
+                                 whether the store is semantically searchable
+                                 (its own Qdrant collection) or DuckDB-only.
+      * ``surface_as_source``  : ``bool`` (default ``False``) — the curated
+                                 allowlist knob. ``True`` ⇒ the Hub should show
+                                 this store as a "Sources" tile even when it is
+                                 DuckDB-only. Keeps dead/legacy stores off the
+                                 grid unless explicitly opted in.
+      * ``id_shape``           : ``"url"`` (default) — shape of the canonical
+                                 id the adapter emits (v3.0.0: every id is a
+                                 canonical URL).
     """
 
     name: str

--- a/tests/index/_federated/test_manifest.py
+++ b/tests/index/_federated/test_manifest.py
@@ -1,0 +1,72 @@
+"""Tests for the federated store manifest export."""
+
+from __future__ import annotations
+
+from src.index._federated.manifest import (
+    build_manifest,
+    manifest_entry,
+)
+
+
+class _BareAdapter:
+    """Adapter that declares none of the optional manifest attrs."""
+
+    name = "bare_store"
+    entity_types = ["thing"]
+
+
+class _DuckDBSourceAdapter:
+    name = "duck_store"
+    entity_types = ["community"]
+    backend = "duckdb"
+    surface_as_source = True
+    id_shape = "url"
+
+
+def test_entry_defaults_for_bare_adapter() -> None:
+    e = manifest_entry(_BareAdapter())
+    assert e == {
+        "name": "bare_store",
+        "duckdb": "bare_store.duckdb",
+        "entity_types": ["thing"],
+        "backend": "vector",          # default
+        "surface_as_source": False,   # default
+        "id_shape": "url",            # default
+    }
+
+
+def test_entry_reads_declared_attrs() -> None:
+    e = manifest_entry(_DuckDBSourceAdapter())
+    assert e["backend"] == "duckdb"
+    assert e["surface_as_source"] is True
+    assert e["duckdb"] == "duck_store.duckdb"
+
+
+def test_build_manifest_shape_and_sorted() -> None:
+    entries = build_manifest()
+    assert entries, "expected at least one registered store"
+    names = [e["name"] for e in entries]
+    assert names == sorted(names)
+    required = {"name", "duckdb", "entity_types", "backend", "surface_as_source", "id_shape"}
+    for e in entries:
+        assert required <= e.keys()
+        assert e["duckdb"] == f"{e['name']}.duckdb"
+
+
+def test_zenodo_communities_is_a_duckdb_source_tile() -> None:
+    by_name = {e["name"]: e for e in build_manifest()}
+    zc = by_name["zenodo_communities"]
+    assert zc["backend"] == "duckdb"
+    assert zc["surface_as_source"] is True
+    assert zc["entity_types"] == ["community"]
+
+
+def test_sources_filter_includes_vector_and_allowlisted_duckdb() -> None:
+    sources = {e["name"]: e for e in build_manifest(sources_only=True)}
+    # DuckDB-only but allowlisted → present.
+    assert "zenodo_communities" in sources
+    # Vector-backed stores → present by default.
+    assert "openalex" in sources
+    # Every emitted source is either vector or explicitly allowlisted.
+    for e in sources.values():
+        assert e["backend"] == "vector" or e["surface_as_source"]


### PR DESCRIPTION
Gives consumers (the Hub's "Sources" tiles, federated search) a single structured contract to build against, so they never infer a store's shape from its name or filename.

### Why
Store names are *not* uniform and can't be: some are `<source>_<entity>` (`github_repos`, `zenodo_communities`), some are bare `<source>` holding many tables in one DuckDB (`openalex` = 10 tables, `snsf` = 17). The only invariant is `store name == <name>.duckdb == registry key`. So consumers should read a manifest, not parse names.

### What
- **`src/index/_federated/manifest.py`** — `python -m src.index._federated.manifest` (and `--sources`) emits per store:
  `{name, duckdb, entity_types, backend, surface_as_source, id_shape}`.
- **`registry.py`** — documents three **optional** declarative adapter attrs (`backend` / `surface_as_source` / `id_shape`), read via `getattr` — deliberately **not** added to the `IndexAdapter` Protocol, so existing adapters keep satisfying `isinstance` unchanged.
- **`zenodo_communities` adapter** — `backend="duckdb"`, `surface_as_source=True` (the curated allowlist opt-in for the one DuckDB-only store we want tiled), `id_shape="url"`.
- **`docs/architecture/index-store-naming.md`** — the invariant, Pattern A vs B, why `<source>_<table>` can't be universal, and Hub consumer guidance.

### `--sources` semantics
Vector-backed stores (already tiled) **plus** DuckDB-only stores explicitly allowlisted via `surface_as_source` → curated, so dead/legacy stores stay off the grid and `zenodo_communities` shows up without hardcoding.

### Tests
`tests/index/_federated/test_manifest.py` — defaults, declared attrs, shape/sort, the `zenodo_communities` tile, the `--sources` filter. Full `tests/v2/` gate: **1354 passed, 1 skipped**.

No behaviour change to any existing adapter or search path — additive.