### PR TITLE
feat(federated): cross-store DuckDB maintenance/optimize driver

### DIFF
--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -91,3 +91,31 @@ A misconfigured / unreachable LLM provider (empty key, wrong `*_BASE_URL`, dead
 host) no longer hangs the worker forever — the chat call has a default
 per-request timeout (120 s) so a stuck provider fails bounded instead of
 occupying the single worker indefinitely. Tune with `V2_LLM_TIMEOUT_SECONDS`.
+
+## 6. Cross-store DuckDB maintenance
+
+One command walks every on-disk store under `$INDEX_DATA_DIR` and refreshes its
+compacted read-only snapshot (the `<store>.ro.duckdb` the Hub reads):
+
+```bash
+# Health report (read-only): tables, row counts, live + snapshot sizes
+python -m src.index._federated.maintenance --check
+
+# Optimize every store: CHECKPOINT (fold WAL) + republish the compacted .ro snapshot
+python -m src.index._federated.maintenance
+
+# One store only
+python -m src.index._federated.maintenance --store snsf
+```
+
+Enumeration is by disk, so it covers every store with a DuckDB file (including
+unregistered ones) and skips FAISS-only stores (`ror`). It needs **exclusive
+write access** per store — run it when the serving process isn't holding the
+live file open. It does **not** deep-compact the live file (DuckDB has no safe
+in-place VACUUM); the `.ro` snapshot is the compacted copy. Honours
+`INDEX_DUCKDB_SNAPSHOT` (set falsey to disable snapshotting).
+
+`--check` is also the quickest way to spot **legacy/stale stores** still on
+disk — e.g. pre-split monoliths `github.duckdb` / `huggingface.duckdb` /
+`communities.duckdb` sitting alongside the split stores — which are candidates
+for retirement once consumers point at the split ones.

--- a/src/index/_federated/maintenance.py
+++ b/src/index/_federated/maintenance.py
@@ -1,0 +1,175 @@
+"""Cross-store DuckDB maintenance: checkpoint + compact + refresh `.ro` snapshot.
+
+Walks every on-disk index store under ``$INDEX_DATA_DIR`` (default
+``data/index``) and, per store, runs the shared
+:func:`src.index._snapshot.publish_snapshot` through a live writer connection:
+``CHECKPOINT`` (fold the WAL into the live file) + rewrite every served table
+into a fresh, compacted ``<store>.ro.duckdb`` — the read-only file the Hub
+reads. ``--check`` reports rows + file sizes + snapshot staleness without
+writing anything.
+
+Enumeration is by **disk**, not the federated registry, so it covers *every*
+store on disk — including ones without a federated adapter (e.g. the per-entity
+HuggingFace stores) and excluding FAISS-only stores (e.g. `ror`) that have no
+DuckDB file.
+
+Scope: this refreshes the compacted `.ro` snapshot and folds the live WAL. It
+deliberately does **not** deep-compact the *live* file — DuckDB has no safe
+in-place VACUUM, and a CTAS rewrite would drop PK/constraints; the `.ro` copy
+is the compacted artifact consumers read.
+
+Requires exclusive write access per store: run when the serving process is not
+holding that store's live file open.
+
+Usage:
+    python -m src.index._federated.maintenance            # optimize every store
+    python -m src.index._federated.maintenance --store snsf
+    python -m src.index._federated.maintenance --check    # report only, no writes
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def index_data_root() -> Path:
+    """The index data root — mirrors each store's ``paths.index_data_root()``."""
+    return Path(os.getenv("INDEX_DATA_DIR", "data/index")).expanduser().resolve()
+
+
+def discover_stores(only: str | None = None) -> list[tuple[str, Path]]:
+    """Return ``(store_name, live_duckdb_path)`` for every on-disk store.
+
+    Live layout is ``<root>/<store>/duckdb/<store>.duckdb``; a flat
+    ``<root>/<store>/<store>.duckdb`` is also accepted. ``.ro``/``.tmp`` files
+    are skipped. Sorted by name; deduped by resolved path.
+    """
+    root = index_data_root()
+    seen: set[Path] = set()
+    out: list[tuple[str, Path]] = []
+    for pattern in ("*/duckdb/*.duckdb", "*/*.duckdb"):
+        for p in sorted(root.glob(pattern)):
+            name = p.name
+            if name.endswith(".ro.duckdb") or name.endswith(".tmp"):
+                continue
+            rp = p.resolve()
+            if rp in seen:
+                continue
+            seen.add(rp)
+            store = p.stem
+            if only and store != only:
+                continue
+            out.append((store, p))
+    out.sort(key=lambda t: t[0])
+    return out
+
+
+def _file_bytes(p: Path) -> int | None:
+    try:
+        return p.stat().st_size
+    except OSError:
+        return None
+
+
+def check_store(name: str, live_path: Path) -> dict[str, Any]:
+    """Read-only health report: tables, row counts, live + snapshot sizes."""
+    import duckdb  # noqa: PLC0415
+
+    from src.index._snapshot import snapshot_path_for  # noqa: PLC0415
+
+    snap = snapshot_path_for(live_path)
+    counts: dict[str, int | None] = {}
+    error: str | None = None
+    con = None
+    try:
+        con = duckdb.connect(str(live_path), read_only=True)
+        tables = [
+            t for (t,) in con.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'main'",
+            ).fetchall()
+        ]
+        for t in tables:
+            try:
+                counts[t] = con.execute(f'SELECT count(*) FROM "{t}"').fetchone()[0]
+            except Exception:  # noqa: BLE001
+                counts[t] = None
+    except Exception as exc:  # noqa: BLE001
+        error = str(exc)
+    finally:
+        if con is not None:
+            con.close()
+    return {
+        "store": name,
+        "live_path": str(live_path),
+        "live_bytes": _file_bytes(live_path),
+        "snapshot_present": snap.exists(),
+        "snapshot_bytes": _file_bytes(snap) if snap.exists() else None,
+        "tables": counts,
+        **({"error": error} if error else {}),
+    }
+
+
+def optimize_store(name: str, live_path: Path) -> dict[str, Any]:
+    """Checkpoint the live file and (re)publish the compacted `.ro` snapshot."""
+    import duckdb  # noqa: PLC0415
+
+    from src.index._snapshot import publish_snapshot, snapshot_path_for  # noqa: PLC0415
+
+    snap = snapshot_path_for(live_path)
+    before = _file_bytes(snap) if snap.exists() else None
+    result: dict[str, Any]
+    con = None
+    try:
+        con = duckdb.connect(str(live_path))  # writer — needs exclusive access
+        result = publish_snapshot(con, live_path, force=True)
+    except Exception as exc:  # noqa: BLE001 — never abort the whole sweep on one store
+        result = {"published": False, "error": str(exc)}
+    finally:
+        if con is not None:
+            con.close()
+    return {
+        "store": name,
+        "live_bytes": _file_bytes(live_path),
+        "snapshot_bytes_before": before,
+        "snapshot_bytes_after": _file_bytes(snap) if snap.exists() else None,
+        "result": result,
+    }
+
+
+def run(*, only: str | None = None, check: bool = False) -> dict[str, Any]:
+    root = index_data_root()
+    stores = discover_stores(only)
+    if not stores:
+        return {
+            "data_root": str(root),
+            "stores": [],
+            "note": f"no live DuckDB stores found under {root}",
+        }
+    fn = check_store if check else optimize_store
+    return {
+        "data_root": str(root),
+        "mode": "check" if check else "optimize",
+        "stores": [fn(name, path) for name, path in stores],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Cross-store DuckDB maintenance.")
+    parser.add_argument("--store", help="operate on this store only")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report rows/sizes/snapshot staleness; do not write",
+    )
+    args = parser.parse_args(argv)
+    print(json.dumps(run(only=args.store, check=args.check), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/index/_federated/test_maintenance.py
+++ b/tests/index/_federated/test_maintenance.py
@@ -1,0 +1,84 @@
+"""Tests for the cross-store DuckDB maintenance driver."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from src.index._federated import maintenance
+from src.index._snapshot import snapshot_path_for
+
+
+def _make_store(root: Path, name: str, rows: int) -> Path:
+    """Create a live store at <root>/<name>/duckdb/<name>.duckdb with `rows`."""
+    d = root / name / "duckdb"
+    d.mkdir(parents=True)
+    path = d / f"{name}.duckdb"
+    con = duckdb.connect(str(path))
+    con.execute("CREATE TABLE items (id INTEGER, label TEXT)")
+    con.executemany(
+        "INSERT INTO items VALUES (?, ?)",
+        [(i, f"row-{i}") for i in range(rows)],
+    )
+    con.close()
+    return path
+
+
+@pytest.fixture()
+def data_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("INDEX_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("INDEX_DUCKDB_SNAPSHOT", "1")
+    monkeypatch.setenv("INDEX_SNAPSHOT_MIN_INTERVAL_SECONDS", "0")
+    _make_store(tmp_path, "alpha_store", 3)
+    _make_store(tmp_path, "beta_store", 5)
+    return tmp_path
+
+
+def test_discover_finds_live_stores_only(data_root: Path) -> None:
+    stores = dict(maintenance.discover_stores())
+    assert set(stores) == {"alpha_store", "beta_store"}
+    # No .ro/.tmp leakage and the path is the live file.
+    assert stores["alpha_store"].name == "alpha_store.duckdb"
+
+
+def test_discover_store_filter(data_root: Path) -> None:
+    stores = maintenance.discover_stores(only="beta_store")
+    assert [n for n, _ in stores] == ["beta_store"]
+
+
+def test_check_reports_counts_without_writing(data_root: Path) -> None:
+    out = maintenance.run(check=True)
+    assert out["mode"] == "check"
+    by = {s["store"]: s for s in out["stores"]}
+    assert by["alpha_store"]["tables"]["items"] == 3
+    assert by["beta_store"]["tables"]["items"] == 5
+    assert by["alpha_store"]["live_bytes"] > 0
+    # --check must not publish snapshots.
+    assert by["alpha_store"]["snapshot_present"] is False
+    assert not snapshot_path_for(dict(maintenance.discover_stores())["alpha_store"]).exists()
+
+
+def test_optimize_publishes_compacted_snapshots(data_root: Path) -> None:
+    out = maintenance.run()
+    assert out["mode"] == "optimize"
+    by = {s["store"]: s for s in out["stores"]}
+    for name in ("alpha_store", "beta_store"):
+        assert by[name]["result"]["published"] is True
+        snap = snapshot_path_for(dict(maintenance.discover_stores())[name])
+        assert snap.exists()
+        # Snapshot is a queryable copy with the same rows.
+        con = duckdb.connect(str(snap), read_only=True)
+        try:
+            n = con.execute("SELECT count(*) FROM items").fetchone()[0]
+        finally:
+            con.close()
+        assert n == (3 if name == "alpha_store" else 5)
+
+
+def test_run_empty_root_is_graceful(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INDEX_DATA_DIR", str(tmp_path / "empty"))
+    out = maintenance.run()
+    assert out["stores"] == []
+    assert "no live DuckDB stores" in out["note"]


### PR DESCRIPTION
The payoff of the manifest symmetry: one command optimizes **every** store.

```bash
python -m src.index._federated.maintenance            # optimize all stores
python -m src.index._federated.maintenance --check    # read-only health report
python -m src.index._federated.maintenance --store snsf
```

### What it does
Per store, opens the live writer connection and runs the shared `publish_snapshot(force=True)`: `CHECKPOINT` (fold the WAL into the live file) + rewrite every served table into a fresh, compacted `<store>.ro.duckdb` — the read-only file the Hub reads.

- **`--check`**: read-only report (tables, row counts, live + snapshot sizes); no writes. Also the quickest way to spot **legacy/stale on-disk stores** (pre-split monoliths `github.duckdb` / `huggingface.duckdb` / `communities.duckdb` still sitting beside the split stores — retirement candidates).
- **Enumerates by disk**, not the registry → covers every store with a DuckDB file (incl. unregistered per-entity HF stores) and skips FAISS-only `ror`.
- **Best-effort per store**: one store's failure never aborts the sweep.

### Scope / caveats
- Needs **exclusive write access** per store (run when the serving process isn't holding the live file open).
- Does **not** deep-compact the live file — DuckDB has no safe in-place VACUUM, and a CTAS rewrite would drop PK/constraints; the `.ro` snapshot is the compacted artifact consumers read.
- Honours `INDEX_DUCKDB_SNAPSHOT` (set falsey to disable).

### Verified
Live `--check` ran clean across all **23** real stores. Tests: `tests/index/_federated/test_maintenance.py` (discover / --store filter / --check no-write / optimize publishes compacted snapshot / empty-root graceful). Full `tests/v2/` gate: **1395 passed, 1 skipped**.

Docs: `OPERATIONS_RUNBOOK.md` §6.