### PR TITLE
feat(v2 api): GET /v2/manifest serves the federated store manifest

### DIFF
--- a/docs/architecture/index-store-naming.md
+++ b/docs/architecture/index-store-naming.md
@@ -48,6 +48,10 @@ never parse names:
 }
 ```
 
+The same payload is served over HTTP at **`GET /v2/manifest`** (token-gated,
+`tags=["Indices"]`) — the Hub's preferred consumption path. `GET
+/v2/manifest?sources=true` applies the `--sources` filter below.
+
 `--sources` filters to the stores the Hub should tile: **vector-backed stores
 plus DuckDB-only stores explicitly allowlisted** via `surface_as_source`. This is
 the curated allowlist — DuckDB-only stores stay off the grid unless they opt in

--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -2507,6 +2507,30 @@ def _index_job_status_path(job_id: str) -> str:
     return f"/v2/indices/jobs/{job_id}"
 
 
+@v2_router.get(
+    "/manifest",
+    tags=["Indices"],
+)
+async def get_manifest(
+    _token: Annotated[str, Depends(verify_token)],
+    sources: Annotated[
+        bool,
+        Query(description="Only stores that should appear as Hub 'Sources' tiles."),
+    ] = False,
+) -> list[dict[str, Any]]:
+    """Federated index-store manifest — the contract consumers build against.
+
+    One entry per registered store:
+    ``{name, duckdb, entity_types, backend, surface_as_source, id_shape}``.
+    Mirrors ``python -m src.index._federated.manifest``. ``?sources=true``
+    returns only the stores that should surface as Hub "Sources" tiles
+    (vector-backed plus allowlisted DuckDB-only).
+    """
+    from src.index._federated.manifest import build_manifest  # noqa: PLC0415
+
+    return build_manifest(sources_only=sources)
+
+
 @v2_router.post(
     "/indices/zenodo_records/ingest",
     response_model=IndexIngestJobAccepted,

--- a/tests/v2/test_api_manifest.py
+++ b/tests/v2/test_api_manifest.py
@@ -1,0 +1,74 @@
+"""GET /v2/manifest — the federated store manifest over HTTP."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.v2.api import v2_router
+
+# Matches the token seeded by tests/v2/conftest.py's autouse env fixture.
+TEST_API_TOKEN = "test-api-token"  # noqa: S105 — test fixture
+_AUTH = {"Authorization": f"Bearer {TEST_API_TOKEN}"}
+
+HTTP_OK = 200
+HTTP_UNAUTHORIZED = 401
+HTTP_FORBIDDEN = 403
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(v2_router)
+    return app
+
+
+def _get(path: str, *, auth: bool = True) -> tuple[int, Any]:
+    async def _run() -> tuple[int, Any]:
+        transport = ASGITransport(app=_app())
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            headers=_AUTH if auth else {},
+        ) as client:
+            r = await client.get(path)
+        return r.status_code, (r.json() if r.headers.get("content-type", "").startswith("application/json") else None)
+
+    import asyncio
+
+    return asyncio.run(_run())
+
+
+_REQUIRED = {"name", "duckdb", "entity_types", "backend", "surface_as_source", "id_shape"}
+
+
+def test_manifest_returns_all_stores() -> None:
+    status, body = _get("/v2/manifest")
+    assert status == HTTP_OK
+    assert isinstance(body, list) and body
+    for entry in body:
+        assert _REQUIRED <= entry.keys()
+        assert entry["duckdb"] == f"{entry['name']}.duckdb"
+
+
+def test_manifest_includes_zenodo_communities_tile() -> None:
+    _, body = _get("/v2/manifest")
+    by = {e["name"]: e for e in body}
+    assert by["zenodo_communities"]["backend"] == "duckdb"
+    assert by["zenodo_communities"]["surface_as_source"] is True
+
+
+def test_manifest_sources_filter() -> None:
+    _, all_body = _get("/v2/manifest")
+    _, src_body = _get("/v2/manifest?sources=true")
+    src_names = {e["name"] for e in src_body}
+    assert "zenodo_communities" in src_names              # allowlisted duckdb-only
+    assert len(src_body) <= len(all_body)
+    for e in src_body:
+        assert e["backend"] == "vector" or e["surface_as_source"]
+
+
+def test_manifest_requires_auth() -> None:
+    status, _ = _get("/v2/manifest", auth=False)
+    assert status in (HTTP_UNAUTHORIZED, HTTP_FORBIDDEN)


### PR DESCRIPTION
Exposes the store manifest (`build_manifest()`, from #119) over HTTP so the Hub consumes the contract via a request instead of running the CLI.

- **`GET /v2/manifest`** → the per-store manifest list (`{name, duckdb, entity_types, backend, surface_as_source, id_shape}`).
- **`GET /v2/manifest?sources=true`** → only stores that should surface as Hub "Sources" tiles (vector-backed + allowlisted DuckDB-only).
- Token-gated (`verify_token`), `tags=["Indices"]` — consistent with the other v2 index routes. Lazy-imports the manifest builder so it adds no import cost to the app.

Tests: `tests/v2/test_api_manifest.py` — shape/invariant (`duckdb == <name>.duckdb`), the `zenodo_communities` tile, the `--sources`/`?sources=true` filter, and auth-required. Full `tests/v2/` gate: **1374 passed, 1 skipped**.

Docs: `docs/architecture/index-store-naming.md` notes the endpoint as the Hub's preferred consumption path.