### PR TITLE
feat(gitlab): ethz + datascience project leaves (Phase 2a)

### DIFF
--- a/config/index/gitlab_datascience_projects.yaml
+++ b/config/index/gitlab_datascience_projects.yaml
@@ -1,0 +1,28 @@
+gitlab:
+  host: gitlab.datascience.ch
+  per_page: 100
+  min_card_chars: 64
+  collection: gitlab_datascience_projects
+
+rcp:
+  # Same RCP deployment as the openalex / zenodo / huggingface / infoscience
+  # indexers — single Qwen3-Embedding-8B / Qwen3-Reranker-8B pair.
+  base_url: https://inference-rcp.epfl.ch/v1
+  embedding_model: Qwen/Qwen3-Embedding-8B
+  embedding_dim: 4096
+  query_instruction: "Given a search query, retrieve relevant GitLab projects"
+  reranker_model: Qwen/Qwen3-Reranker-8B
+  batch_size: 32
+  max_concurrency: 4
+  timeout_seconds: 120
+
+qdrant:
+  # Compose service `gme-qdrant` on the `dev` network. See
+  # `.internal/ror/qdrant-setup.md` for the hostname rationale.
+  url: http://gme-qdrant:6333
+  prefer_grpc: false
+
+chunking:
+  size_tokens: 512               # READMEs are short; bigger chunks than openalex's 256
+  overlap_tokens: 64
+  tokenizer: cl100k_base

--- a/config/index/gitlab_ethz_projects.yaml
+++ b/config/index/gitlab_ethz_projects.yaml
@@ -1,0 +1,28 @@
+gitlab:
+  host: gitlab.ethz.ch
+  per_page: 100
+  min_card_chars: 64
+  collection: gitlab_ethz_projects
+
+rcp:
+  # Same RCP deployment as the openalex / zenodo / huggingface / infoscience
+  # indexers — single Qwen3-Embedding-8B / Qwen3-Reranker-8B pair.
+  base_url: https://inference-rcp.epfl.ch/v1
+  embedding_model: Qwen/Qwen3-Embedding-8B
+  embedding_dim: 4096
+  query_instruction: "Given a search query, retrieve relevant GitLab projects"
+  reranker_model: Qwen/Qwen3-Reranker-8B
+  batch_size: 32
+  max_concurrency: 4
+  timeout_seconds: 120
+
+qdrant:
+  # Compose service `gme-qdrant` on the `dev` network. See
+  # `.internal/ror/qdrant-setup.md` for the hostname rationale.
+  url: http://gme-qdrant:6333
+  prefer_grpc: false
+
+chunking:
+  size_tokens: 512               # READMEs are short; bigger chunks than openalex's 256
+  overlap_tokens: 64
+  tokenizer: cl100k_base

--- a/src/index/_federated/adapters/gitlab_datascience_projects.py
+++ b/src/index/_federated/adapters/gitlab_datascience_projects.py
@@ -1,0 +1,109 @@
+"""Adapter wrapping `src.index.gitlab_datascience_projects` for federated search/lookup."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.index._federated.registry import EntityRecord, Hit, register
+
+
+class GitLabDatascienceProjectsAdapter:
+    name = "gitlab_datascience_projects"
+    entity_types: list[str] = ["project"]  # noqa: RUF012
+
+    # Manifest hints (see IndexAdapter docstring).
+    backend = "vector"
+    surface_as_source = True
+    id_shape = "url"  # project_id is already the canonical https://gitlab.datascience.ch/... URL
+
+    def search(
+        self,
+        *,
+        query: str,
+        entity_type: str | None,  # noqa: ARG002 — single-type index
+        top_k: int,
+        filters: dict[str, Any] | None,  # noqa: ARG002
+    ) -> list[Hit]:
+        try:
+            from src.index.gitlab_datascience_projects.retrieval import (  # noqa: PLC0415
+                search,
+            )
+        except Exception:  # noqa: BLE001
+            return []
+        try:
+            results = search(query, top_k=top_k)
+        except Exception:  # noqa: BLE001
+            return []
+        out: list[Hit] = []
+        for r in results:
+            payload = r.get("payload") or {}
+            project_id = payload.get("project_id") or payload.get("entity_id")
+            if not project_id:
+                continue
+            out.append(Hit(
+                index=self.name,
+                entity_type="project",
+                id=str(project_id),
+                title=payload.get("description") or str(project_id),
+                score=float(r.get("rerank_score") or r.get("vector_score") or 0.0),
+                summary=_summary(payload),
+                url=str(project_id),
+                payload=payload,
+            ))
+        return out
+
+    def lookup(self, identifier: str) -> list[EntityRecord]:  # noqa: PLR0911
+        if not isinstance(identifier, str) or not identifier.strip():
+            return []
+        s = identifier.strip()
+        # Validate that it's a GitLab URL using the canonicalization helper.
+        try:
+            from src.v2.canonicalization.gitlab import parse_gitlab_iri  # noqa: PLC0415
+        except Exception:  # noqa: BLE001
+            return []
+        parsed = parse_gitlab_iri(s)
+        if parsed is None:
+            return []
+        host, _kind, _path = parsed
+        if host != "gitlab.datascience.ch":
+            return []
+        try:
+            from src.index.gitlab_datascience_projects.store import (  # noqa: PLC0415
+                open_store,
+            )
+        except Exception:  # noqa: BLE001
+            return []
+        store = None
+        try:
+            store = open_store()
+            row = store.fetch_project(s)
+            if row is None:
+                return []
+            return [EntityRecord(
+                index=self.name,
+                entity_type="project",
+                id=s,
+                data=row,
+                url=s,
+            )]
+        except Exception:  # noqa: BLE001
+            return []
+        finally:
+            if store is not None:
+                try:  # noqa: SIM105
+                    store.close()
+                except Exception:  # noqa: BLE001, S110
+                    pass
+
+
+def _summary(payload: dict[str, Any]) -> str | None:
+    parts = [
+        str(payload.get("description") or ""),
+        str(payload.get("namespace") or ""),
+        str(payload.get("topics") or ""),
+    ]
+    parts = [p for p in parts if p]
+    return " — ".join(parts) if parts else None
+
+
+register(GitLabDatascienceProjectsAdapter())

--- a/src/index/_federated/adapters/gitlab_ethz_projects.py
+++ b/src/index/_federated/adapters/gitlab_ethz_projects.py
@@ -1,0 +1,105 @@
+"""Adapter wrapping `src.index.gitlab_ethz_projects` for federated search/lookup."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.index._federated.registry import EntityRecord, Hit, register
+
+
+class GitLabEthzProjectsAdapter:
+    name = "gitlab_ethz_projects"
+    entity_types: list[str] = ["project"]  # noqa: RUF012
+
+    # Manifest hints (see IndexAdapter docstring).
+    backend = "vector"
+    surface_as_source = True
+    id_shape = "url"  # project_id is already the canonical https://gitlab.ethz.ch/... URL
+
+    def search(
+        self,
+        *,
+        query: str,
+        entity_type: str | None,  # noqa: ARG002 — single-type index
+        top_k: int,
+        filters: dict[str, Any] | None,  # noqa: ARG002
+    ) -> list[Hit]:
+        try:
+            from src.index.gitlab_ethz_projects.retrieval import search  # noqa: PLC0415
+        except Exception:  # noqa: BLE001
+            return []
+        try:
+            results = search(query, top_k=top_k)
+        except Exception:  # noqa: BLE001
+            return []
+        out: list[Hit] = []
+        for r in results:
+            payload = r.get("payload") or {}
+            project_id = payload.get("project_id") or payload.get("entity_id")
+            if not project_id:
+                continue
+            out.append(Hit(
+                index=self.name,
+                entity_type="project",
+                id=str(project_id),
+                title=payload.get("description") or str(project_id),
+                score=float(r.get("rerank_score") or r.get("vector_score") or 0.0),
+                summary=_summary(payload),
+                url=str(project_id),
+                payload=payload,
+            ))
+        return out
+
+    def lookup(self, identifier: str) -> list[EntityRecord]:  # noqa: PLR0911
+        if not isinstance(identifier, str) or not identifier.strip():
+            return []
+        s = identifier.strip()
+        # Validate that it's a GitLab URL using the canonicalization helper.
+        try:
+            from src.v2.canonicalization.gitlab import parse_gitlab_iri  # noqa: PLC0415
+        except Exception:  # noqa: BLE001
+            return []
+        parsed = parse_gitlab_iri(s)
+        if parsed is None:
+            return []
+        host, _kind, _path = parsed
+        if host != "gitlab.ethz.ch":
+            return []
+        try:
+            from src.index.gitlab_ethz_projects.store import open_store  # noqa: PLC0415
+        except Exception:  # noqa: BLE001
+            return []
+        store = None
+        try:
+            store = open_store()
+            row = store.fetch_project(s)
+            if row is None:
+                return []
+            return [EntityRecord(
+                index=self.name,
+                entity_type="project",
+                id=s,
+                data=row,
+                url=s,
+            )]
+        except Exception:  # noqa: BLE001
+            return []
+        finally:
+            if store is not None:
+                try:  # noqa: SIM105
+                    store.close()
+                except Exception:  # noqa: BLE001, S110
+                    pass
+
+
+def _summary(payload: dict[str, Any]) -> str | None:
+    parts = [
+        str(payload.get("description") or ""),
+        str(payload.get("namespace") or ""),
+        str(payload.get("topics") or ""),
+    ]
+    parts = [p for p in parts if p]
+    return " — ".join(parts) if parts else None
+
+
+register(GitLabEthzProjectsAdapter())

--- a/src/index/_federated/registry.py
+++ b/src/index/_federated/registry.py
@@ -107,6 +107,7 @@ def load_adapters(only: list[str] | None = None) -> list[IndexAdapter]:
         "ethz_research_collection", "github_repos", "github_users",
         "github_organizations", "snsf", "renkulab", "epfl_graph", "swissubase",
         "zenodo_communities", "dockerhub", "gitlab_epfl_projects",
+        "gitlab_ethz_projects", "gitlab_datascience_projects",
     ]
     targets = [c for c in candidates if (only is None or c in only)]
     for name in targets:

--- a/src/index/gitlab_datascience_projects/__init__.py
+++ b/src/index/gitlab_datascience_projects/__init__.py
@@ -1,0 +1,1 @@
+"""Index for public projects on gitlab.datascience.ch."""

--- a/src/index/gitlab_datascience_projects/config.py
+++ b/src/index/gitlab_datascience_projects/config.py
@@ -1,0 +1,20 @@
+"""Config loader for the gitlab_datascience_projects index."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from src.index._gitlab_base.config_base import GitLabIndexConfig, load_gitlab_config
+
+DEFAULT_CONFIG_PATH = Path("config/index/gitlab_datascience_projects.yaml")
+
+GitLabDatascienceProjectsConfig = GitLabIndexConfig
+
+
+def load_config(path: Optional[Path] = None) -> GitLabDatascienceProjectsConfig:
+    return load_gitlab_config(
+        yaml_path=path or DEFAULT_CONFIG_PATH,
+        store_name="gitlab_datascience_projects",
+        token_env="GITLAB_DATASCIENCE_TOKEN",  # noqa: S106
+    )

--- a/src/index/gitlab_datascience_projects/embed.py
+++ b/src/index/gitlab_datascience_projects/embed.py
@@ -1,0 +1,22 @@
+"""Embed gitlab_datascience_projects into Qdrant via the RCP embeddings endpoint."""
+
+from __future__ import annotations
+
+from src.index._gitlab_base.project_embed import embed_projects
+from src.index.gitlab_datascience_projects.config import load_config
+from src.index.gitlab_datascience_projects.store import open_store
+
+
+def run_embed(*, limit: int | None = None) -> dict[str, int]:
+    """Chunk and embed un-embedded gitlab_datascience_projects into Qdrant."""
+    cfg = load_config()
+    store = open_store()
+    try:
+        return embed_projects(
+            config=cfg,
+            store=store,
+            collection=cfg.gitlab.collection,
+            limit=limit,
+        )
+    finally:
+        store.close()

--- a/src/index/gitlab_datascience_projects/ingest.py
+++ b/src/index/gitlab_datascience_projects/ingest.py
@@ -1,0 +1,25 @@
+"""Ingest public projects from gitlab.datascience.ch into the local DuckDB store."""
+
+from __future__ import annotations
+
+from src.index._gitlab_base.client import GitLabClient
+from src.index._gitlab_base.project_ingest import ingest_projects
+from src.index.gitlab_datascience_projects.config import load_config
+from src.index.gitlab_datascience_projects.store import open_store
+
+
+def run_ingest(*, limit: int | None = None) -> dict[str, int]:
+    """Fetch public projects from gitlab.datascience.ch and upsert into DuckDB."""
+    cfg = load_config()
+    client = GitLabClient(host=cfg.gitlab.host, token=cfg.gitlab.token)
+    store = open_store()
+    try:
+        return ingest_projects(
+            host=cfg.gitlab.host,
+            client=client,
+            store=store,
+            limit=limit,
+        )
+    finally:
+        client.close()
+        store.close()

--- a/src/index/gitlab_datascience_projects/paths.py
+++ b/src/index/gitlab_datascience_projects/paths.py
@@ -1,0 +1,15 @@
+"""Filesystem layout for the gitlab_datascience_projects index."""
+
+from __future__ import annotations
+
+from src.index._gitlab_base.paths_base import (
+    GitLabIndexPathsBase,
+    resolve_gitlab_paths,
+)
+
+GitLabDatascienceProjectsPaths = GitLabIndexPathsBase
+
+
+def get_gitlab_datascience_projects_paths() -> GitLabDatascienceProjectsPaths:
+    """Resolve ``<INDEX_DATA_DIR>/gitlab_datascience_projects/`` and ensure subdirs exist."""
+    return resolve_gitlab_paths("gitlab_datascience_projects")

--- a/src/index/gitlab_datascience_projects/retrieval.py
+++ b/src/index/gitlab_datascience_projects/retrieval.py
@@ -1,0 +1,33 @@
+"""Semantic search over the gitlab_datascience_projects Qdrant collection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.index._gitlab_base.project_retrieval import project_semantic_search
+from src.index.gitlab_datascience_projects.config import load_config
+from src.index.gitlab_datascience_projects.store import open_store
+
+
+def search(
+    query: str,
+    *,
+    top_k: int = 10,
+    candidate_k: int = 50,
+    filter_payload: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Semantically search gitlab_datascience_projects."""
+    cfg = load_config()
+    store = open_store()
+    try:
+        return project_semantic_search(
+            config=cfg,
+            collection=cfg.gitlab.collection,
+            store=store,
+            query=query,
+            top_k=top_k,
+            candidate_k=candidate_k,
+            filter_payload=filter_payload,
+        )
+    finally:
+        store.close()

--- a/src/index/gitlab_datascience_projects/store.py
+++ b/src/index/gitlab_datascience_projects/store.py
@@ -1,0 +1,13 @@
+"""DuckDB store accessor for the gitlab_datascience_projects index."""
+
+from __future__ import annotations
+
+from src.index._gitlab_base.project_store import GitLabProjectStore
+from src.index.gitlab_datascience_projects.paths import (
+    get_gitlab_datascience_projects_paths,
+)
+
+
+def open_store() -> GitLabProjectStore:
+    """Open (and bootstrap) the gitlab_datascience_projects DuckDB store."""
+    return GitLabProjectStore.open(get_gitlab_datascience_projects_paths().duckdb_path)

--- a/src/index/gitlab_ethz_projects/__init__.py
+++ b/src/index/gitlab_ethz_projects/__init__.py
@@ -1,0 +1,1 @@
+"""Index for public projects on gitlab.ethz.ch."""

--- a/src/index/gitlab_ethz_projects/config.py
+++ b/src/index/gitlab_ethz_projects/config.py
@@ -1,0 +1,20 @@
+"""Config loader for the gitlab_ethz_projects index."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from src.index._gitlab_base.config_base import GitLabIndexConfig, load_gitlab_config
+
+DEFAULT_CONFIG_PATH = Path("config/index/gitlab_ethz_projects.yaml")
+
+GitLabEthzProjectsConfig = GitLabIndexConfig
+
+
+def load_config(path: Optional[Path] = None) -> GitLabEthzProjectsConfig:
+    return load_gitlab_config(
+        yaml_path=path or DEFAULT_CONFIG_PATH,
+        store_name="gitlab_ethz_projects",
+        token_env="GITLAB_ETHZ_TOKEN",  # noqa: S106
+    )

--- a/src/index/gitlab_ethz_projects/embed.py
+++ b/src/index/gitlab_ethz_projects/embed.py
@@ -1,0 +1,22 @@
+"""Embed gitlab_ethz_projects into Qdrant via the RCP embeddings endpoint."""
+
+from __future__ import annotations
+
+from src.index._gitlab_base.project_embed import embed_projects
+from src.index.gitlab_ethz_projects.config import load_config
+from src.index.gitlab_ethz_projects.store import open_store
+
+
+def run_embed(*, limit: int | None = None) -> dict[str, int]:
+    """Chunk and embed un-embedded gitlab_ethz_projects into Qdrant."""
+    cfg = load_config()
+    store = open_store()
+    try:
+        return embed_projects(
+            config=cfg,
+            store=store,
+            collection=cfg.gitlab.collection,
+            limit=limit,
+        )
+    finally:
+        store.close()

--- a/src/index/gitlab_ethz_projects/ingest.py
+++ b/src/index/gitlab_ethz_projects/ingest.py
@@ -1,0 +1,25 @@
+"""Ingest public projects from gitlab.ethz.ch into the local DuckDB store."""
+
+from __future__ import annotations
+
+from src.index._gitlab_base.client import GitLabClient
+from src.index._gitlab_base.project_ingest import ingest_projects
+from src.index.gitlab_ethz_projects.config import load_config
+from src.index.gitlab_ethz_projects.store import open_store
+
+
+def run_ingest(*, limit: int | None = None) -> dict[str, int]:
+    """Fetch public projects from gitlab.ethz.ch and upsert into DuckDB."""
+    cfg = load_config()
+    client = GitLabClient(host=cfg.gitlab.host, token=cfg.gitlab.token)
+    store = open_store()
+    try:
+        return ingest_projects(
+            host=cfg.gitlab.host,
+            client=client,
+            store=store,
+            limit=limit,
+        )
+    finally:
+        client.close()
+        store.close()

--- a/src/index/gitlab_ethz_projects/paths.py
+++ b/src/index/gitlab_ethz_projects/paths.py
@@ -1,0 +1,15 @@
+"""Filesystem layout for the gitlab_ethz_projects index."""
+
+from __future__ import annotations
+
+from src.index._gitlab_base.paths_base import (
+    GitLabIndexPathsBase,
+    resolve_gitlab_paths,
+)
+
+GitLabEthzProjectsPaths = GitLabIndexPathsBase
+
+
+def get_gitlab_ethz_projects_paths() -> GitLabEthzProjectsPaths:
+    """Resolve ``<INDEX_DATA_DIR>/gitlab_ethz_projects/`` and ensure subdirs exist."""
+    return resolve_gitlab_paths("gitlab_ethz_projects")

--- a/src/index/gitlab_ethz_projects/retrieval.py
+++ b/src/index/gitlab_ethz_projects/retrieval.py
@@ -1,0 +1,33 @@
+"""Semantic search over the gitlab_ethz_projects Qdrant collection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.index._gitlab_base.project_retrieval import project_semantic_search
+from src.index.gitlab_ethz_projects.config import load_config
+from src.index.gitlab_ethz_projects.store import open_store
+
+
+def search(
+    query: str,
+    *,
+    top_k: int = 10,
+    candidate_k: int = 50,
+    filter_payload: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Semantically search gitlab_ethz_projects."""
+    cfg = load_config()
+    store = open_store()
+    try:
+        return project_semantic_search(
+            config=cfg,
+            collection=cfg.gitlab.collection,
+            store=store,
+            query=query,
+            top_k=top_k,
+            candidate_k=candidate_k,
+            filter_payload=filter_payload,
+        )
+    finally:
+        store.close()

--- a/src/index/gitlab_ethz_projects/store.py
+++ b/src/index/gitlab_ethz_projects/store.py
@@ -1,0 +1,11 @@
+"""DuckDB store accessor for the gitlab_ethz_projects index."""
+
+from __future__ import annotations
+
+from src.index._gitlab_base.project_store import GitLabProjectStore
+from src.index.gitlab_ethz_projects.paths import get_gitlab_ethz_projects_paths
+
+
+def open_store() -> GitLabProjectStore:
+    """Open (and bootstrap) the gitlab_ethz_projects DuckDB store."""
+    return GitLabProjectStore.open(get_gitlab_ethz_projects_paths().duckdb_path)

--- a/tests/index/gitlab_datascience_projects/test_adapter_and_manifest.py
+++ b/tests/index/gitlab_datascience_projects/test_adapter_and_manifest.py
@@ -1,0 +1,10 @@
+from src.index._federated.manifest import build_manifest
+
+
+def test_store_in_manifest_as_vector_source_tile():
+    by = {e["name"]: e for e in build_manifest()}
+    e = by["gitlab_datascience_projects"]
+    assert e["backend"] == "vector"
+    assert e["surface_as_source"] is True
+    assert e["duckdb"] == "gitlab_datascience_projects.duckdb"
+    assert e["entity_types"] == ["project"]

--- a/tests/index/gitlab_datascience_projects/test_paths.py
+++ b/tests/index/gitlab_datascience_projects/test_paths.py
@@ -1,0 +1,13 @@
+from src.index.gitlab_datascience_projects.config import load_config
+from src.index.gitlab_datascience_projects.paths import get_gitlab_datascience_projects_paths
+
+
+def test_duckdb_path_layout():
+    p = get_gitlab_datascience_projects_paths().duckdb_path
+    assert p.as_posix().endswith("gitlab_datascience_projects/duckdb/gitlab_datascience_projects.duckdb")
+
+
+def test_config_loads():
+    cfg = load_config()
+    assert cfg.gitlab.host == "gitlab.datascience.ch"
+    assert cfg.gitlab.collection == "gitlab_datascience_projects"

--- a/tests/index/gitlab_ethz_projects/test_adapter_and_manifest.py
+++ b/tests/index/gitlab_ethz_projects/test_adapter_and_manifest.py
@@ -1,0 +1,10 @@
+from src.index._federated.manifest import build_manifest
+
+
+def test_store_in_manifest_as_vector_source_tile():
+    by = {e["name"]: e for e in build_manifest()}
+    e = by["gitlab_ethz_projects"]
+    assert e["backend"] == "vector"
+    assert e["surface_as_source"] is True
+    assert e["duckdb"] == "gitlab_ethz_projects.duckdb"
+    assert e["entity_types"] == ["project"]

--- a/tests/index/gitlab_ethz_projects/test_paths.py
+++ b/tests/index/gitlab_ethz_projects/test_paths.py
@@ -1,0 +1,13 @@
+from src.index.gitlab_ethz_projects.config import load_config
+from src.index.gitlab_ethz_projects.paths import get_gitlab_ethz_projects_paths
+
+
+def test_duckdb_path_layout():
+    p = get_gitlab_ethz_projects_paths().duckdb_path
+    assert p.as_posix().endswith("gitlab_ethz_projects/duckdb/gitlab_ethz_projects.duckdb")
+
+
+def test_config_loads():
+    cfg = load_config()
+    assert cfg.gitlab.host == "gitlab.ethz.ch"
+    assert cfg.gitlab.collection == "gitlab_ethz_projects"


### PR DESCRIPTION
Phase 2a of the GitLab index: fans the project store out to the other two self-hosted Swiss instances. Pure wiring — **zero changes to `_gitlab_base`** (the engine was built parameterized by host + Qdrant collection in Phase 1), so this is just thin leaves + adapters + config + registry entries, mirroring `gitlab_epfl_projects`.

### Adds
- **`gitlab_ethz_projects`** — host `gitlab.ethz.ch`, token `GITLAB_ETHZ_TOKEN`, collection `gitlab_ethz_projects`.
- **`gitlab_datascience_projects`** — host `gitlab.datascience.ch`, token `GITLAB_DATASCIENCE_TOKEN`, collection `gitlab_datascience_projects`.

Each: thin leaf package (paths/config/store/ingest/embed/retrieval delegating to `_gitlab_base`), a config yaml (rcp/qdrant/chunking identical to epfl; only host+collection differ), a federated adapter with an instance-specific lookup host guard (`host != "gitlab.ethz.ch"` / `!= "gitlab.datascience.ch"`), and registry registration.

All three `gitlab_*_projects` now appear in `GET /v2/manifest` (`backend=vector, surface_as_source=true`) and are covered by the maintenance driver.

### Tests
Per-leaf paths + config + adapter/manifest tests (mirroring epfl). Full `tests/v2/` gate: **1405 passed, 1 skipped**.

### Next
Phase 2b/3 = groups + users (needs a new `_gitlab_accounts_base` mirroring `_github_accounts_base`) + the gitlab.com curated-seed traversal — their own PRs.