### PR TITLE
feat(index): bootstrap-index — first-run create + schema-bootstrap of every store DuckDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+PYTHON ?= python
+
+.PHONY: bootstrap-index
+bootstrap-index:  ## Create + schema-bootstrap every index DuckDB (empty, idempotent)
+	$(PYTHON) -m src.index._federated.bootstrap

--- a/src/index/_federated/bootstrap.py
+++ b/src/index/_federated/bootstrap.py
@@ -1,0 +1,183 @@
+"""Bootstrap utility: open every index store's DuckDB to apply schema + migrations.
+
+Running this on a fresh checkout produces structurally-ready (empty) stores so
+that manifest, maintenance, and search-against-empty all work without any
+network access or API tokens.
+
+Usage
+-----
+    python -m src.index._federated.bootstrap
+    python -m src.index._federated.bootstrap --only dockerhub --only github_repos
+    make bootstrap-index
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import json
+import os
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_INDEX_SRC = Path(__file__).resolve().parents[1]  # src/index/
+_SKIP_STORES: frozenset[str] = frozenset({"huggingface"})
+_LEAF_STORES: frozenset[str] = frozenset(
+    {"gitlab_epfl_projects", "gitlab_ethz_projects", "gitlab_datascience_projects"},
+)
+_DEFAULT_INDEX_DATA_DIR = Path("data/index")
+
+
+def _index_data_dir() -> Path:
+    """Resolve INDEX_DATA_DIR (mirrors the pattern used by each store's paths.py)."""
+    raw = os.getenv("INDEX_DATA_DIR", "").strip()
+    if raw:
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        # relative → anchored at repo root (4 levels up from this file)
+        return Path(__file__).resolve().parents[4] / candidate
+    return Path(__file__).resolve().parents[4] / _DEFAULT_INDEX_DATA_DIR
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_store_names() -> list[str]:
+    """Return sorted list of store names (subdirs of src/index/ that are real stores).
+
+    Excludes:
+    - Directories starting with ``_`` or ``__``.
+    - Stores listed in ``_SKIP_STORES`` (e.g. ``huggingface`` legacy monolith).
+    """
+    return [
+        d.name
+        for d in sorted(_INDEX_SRC.iterdir())
+        if d.is_dir()
+        and not d.name.startswith("_")
+        and d.name not in _SKIP_STORES
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Per-store bootstrap
+# ---------------------------------------------------------------------------
+
+
+def bootstrap_store(name: str) -> str:
+    """Open (and close) one index store, applying its schema/migrations.
+
+    Returns one of:
+    - ``"created"``  — the DuckDB file did not exist before opening.
+    - ``"exists"``   — the DuckDB file already existed (idempotent re-run).
+    - ``"error: <msg>"`` — caught exception; does NOT propagate.
+    - ``"skipped: no duckdb store"`` — store has no recognisable opener.
+    """
+    try:
+        # Determine whether the file already exists before we open it.
+        duckdb_path = _index_data_dir() / name / "duckdb" / f"{name}.duckdb"
+        existed_before = duckdb_path.exists()
+
+        store = _open_store(name)
+        if store is None:
+            return "skipped: no duckdb store"
+
+        if hasattr(store, "close"):
+            store.close()
+
+    except Exception as exc:  # noqa: BLE001
+        return f"error: {exc}"
+    else:
+        return "exists" if existed_before else "created"
+
+
+def _open_store(name: str) -> object | None:
+    """Perform the actual import + open() call for *name*.
+
+    Returns the opened store object, or ``None`` if no recognisable opener
+    is found.
+    """
+    # ------------------------------------------------------------------
+    # Leaf stores: open via `src.index.<name>.store.open_store()`
+    # ------------------------------------------------------------------
+    if name in _LEAF_STORES:
+        mod = importlib.import_module(f"src.index.{name}.store")
+        open_fn = getattr(mod, "open_store", None)
+        if open_fn is not None:
+            return open_fn()
+        return None
+
+    # ------------------------------------------------------------------
+    # Convention stores: `src.index.<name>.storage.duckdb_store.<*Store>`
+    # ------------------------------------------------------------------
+    try:
+        mod = importlib.import_module(f"src.index.{name}.storage.duckdb_store")
+    except ModuleNotFoundError:
+        return None
+
+    # Find the first class whose name ends in "Store" and is defined in this module.
+    store_cls = None
+    for _attr_name, obj in inspect.getmembers(mod, inspect.isclass):
+        if obj.__name__.endswith("Store") and obj.__module__ == mod.__name__:
+            store_cls = obj
+            break
+
+    if store_cls is None:
+        return None
+
+    return store_cls.open()
+
+
+# ---------------------------------------------------------------------------
+# Bulk bootstrap
+# ---------------------------------------------------------------------------
+
+
+def bootstrap_all(only: list[str] | None = None) -> dict[str, str]:
+    """Bootstrap every discovered store and return ``{name: status}`` mapping.
+
+    Parameters
+    ----------
+    only:
+        When provided, only bootstrap stores whose names appear in this list.
+        Stores in *only* that are not discovered are silently ignored.
+    """
+    names = discover_store_names()
+    if only is not None:
+        only_set = set(only)
+        names = [n for n in names if n in only_set]
+
+    return {name: bootstrap_store(name) for name in names}
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap (create + schema-apply) every index DuckDB store.",
+    )
+    parser.add_argument(
+        "--only",
+        metavar="NAME",
+        action="append",
+        default=None,
+        help="Bootstrap only this store (repeatable). Omit to bootstrap all.",
+    )
+    args = parser.parse_args(argv)
+
+    result = bootstrap_all(only=args.only)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/index/_federated/test_bootstrap.py
+++ b/tests/index/_federated/test_bootstrap.py
@@ -1,0 +1,81 @@
+"""Tests for the bootstrap-index utility."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import duckdb
+
+if TYPE_CHECKING:
+    import pytest
+
+from src.index._federated.bootstrap import bootstrap_all, discover_store_names
+
+
+def test_discover_excludes_underscore_and_legacy() -> None:
+    """discover_store_names() returns real stores and excludes underscore dirs & huggingface."""
+    names = discover_store_names()
+
+    # Must be sorted
+    assert names == sorted(names)
+
+    # Known stores must be included
+    assert "dockerhub" in names
+    assert "gitlab_epfl_projects" in names
+    assert "github_repos" in names
+
+    # Legacy monolith must be excluded
+    assert "huggingface" not in names
+
+    # Underscore-prefixed dirs must be excluded
+    for name in names:
+        assert not name.startswith("_"), f"Underscore dir leaked: {name!r}"
+
+
+def test_bootstrap_creates_duckdb(monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    """bootstrap_all() creates DuckDB files with expected tables for each store."""
+    monkeypatch.setenv("INDEX_DATA_DIR", str(tmp_path))
+
+    result = bootstrap_all(only=["dockerhub", "gitlab_epfl_projects"])
+
+    # Both stores must succeed (status "created" or "exists", not "error: ...")
+    assert result["dockerhub"] in {"created", "exists"}, f"dockerhub status: {result['dockerhub']}"
+    assert result["gitlab_epfl_projects"] in {"created", "exists"}, (
+        f"gitlab_epfl_projects status: {result['gitlab_epfl_projects']}"
+    )
+
+    # DuckDB files must exist on disk
+    dockerhub_db = tmp_path / "dockerhub" / "duckdb" / "dockerhub.duckdb"
+    gitlab_db = tmp_path / "gitlab_epfl_projects" / "duckdb" / "gitlab_epfl_projects.duckdb"
+    assert dockerhub_db.exists(), f"Missing: {dockerhub_db}"
+    assert gitlab_db.exists(), f"Missing: {gitlab_db}"
+
+    # DuckDB files must have expected tables
+    with duckdb.connect(str(dockerhub_db), read_only=True) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'",
+            ).fetchall()
+        }
+        assert "images" in tables, f"dockerhub tables: {tables}"
+
+    with duckdb.connect(str(gitlab_db), read_only=True) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'",
+            ).fetchall()
+        }
+        assert "projects" in tables, f"gitlab_epfl_projects tables: {tables}"
+
+
+def test_bootstrap_is_idempotent(monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    """Running bootstrap_all() twice: first run → 'created', second run → 'exists'."""
+    monkeypatch.setenv("INDEX_DATA_DIR", str(tmp_path))
+
+    first = bootstrap_all(only=["dockerhub"])
+    assert first["dockerhub"] in {"created", "exists"}, f"first run: {first['dockerhub']}"
+
+    second = bootstrap_all(only=["dockerhub"])
+    assert second["dockerhub"] == "exists", f"second run should be 'exists', got: {second['dockerhub']}"


### PR DESCRIPTION
A first-run dev-onboarding utility: `make bootstrap-index` (and `python -m src.index._federated.bootstrap`) opens **every** index store's DuckDB, applying its own schema + migrations, so a fresh checkout is structurally ready — empty but queryable via `GET /v2/manifest` / the maintenance driver / search-against-empty — with **no network or tokens**.

- **Auto-discovers** stores by directory convention (subdirs of `src/index/`), skipping `_*` and the legacy `huggingface` monolith; the gitlab leaves open via their `store.py::open_store()`, all others via `storage/duckdb_store.py::<X>Store.open()` (each store's own `open()` so schema **and migrations** run).
- **Idempotent** — reports `created` vs `exists` per store; `--only NAME` to target a subset.
- **Per-store error isolation** — one store failing never aborts the sweep (status `error: …`).
- Verified: **all 25 stores create cleanly, zero errors**.

```bash
make bootstrap-index
# or: python -m src.index._federated.bootstrap [--only github_repos --only snsf ...]
```

Tests: `tests/index/_federated/test_bootstrap.py` (discovery filtering, create+table-present for two stores, idempotency). Full `tests/v2/` gate: **1414 passed, 1 skipped**.