### PR TITLE
feat(snsf): faceted-query Phase A — derived facet tables + build_facets + bootstrap hook

### DIFF
--- a/docs/superpowers/specs/2026-06-05-snsf-faceted-query-design.md
+++ b/docs/superpowers/specs/2026-06-05-snsf-faceted-query-design.md
@@ -134,17 +134,64 @@ def facet_counts(store, filters: GrantFilters, *, text: str | None = None
    - Token-gated, `tags=["Indices"]`, mirroring the existing snsf endpoints.
    - Reads the snsf store read-only (the `.ro` snapshot in serving).
 
+## Integration: bootstrap, federated layer, and agent tool
+
+Beyond the standalone CLI/HTTP surfaces, the faceted query is wired into three
+shared seams so it's a first-class, ready-on-first-run capability:
+
+1. **Bootstrap hook.** The first-run `make bootstrap-index` /
+   `src.index._federated.bootstrap` (which opens every store's DuckDB) gains a
+   per-store optional **post-bootstrap hook**: for `snsf`, after `open()` it
+   runs `build_facets(store)` so the 3 facet tables exist (empty until ingest,
+   but present + schema-correct) on a fresh checkout. The hook is generic
+   (`POST_BOOTSTRAP: dict[str, Callable]`), so other stores can register one
+   later; only snsf uses it now. Re-running stays idempotent.
+
+2. **Federated query surface.** Expose the faceted query through the federated
+   layer so consumers reach it the same way they reach `federated_search`:
+   - The `snsf` federated adapter gains an optional **`facet_query(filters,
+     *, text, sort, limit, offset)`** method (read via `getattr`, like the
+     manifest hints — not added to the base `IndexAdapter` Protocol, so other
+     adapters are unaffected) delegating to `facet_query.query_grants`.
+   - A thin `src/index/_federated/structured_query.py` discovers adapters that
+     expose `facet_query` (and their facet schema) and routes a faceted query
+     to the right one — the structured-query analog of `federated_search`. The
+     manifest gains a `structured_query: true` hint on the snsf entry so the
+     capability is discoverable.
+
+3. **LLM agent tool.** A new `src/v2/agents/llm/agent_tools/snsf_grants.py`
+   following the per-index RAG-tool pattern (pydantic-ai `Tool`s backed by a
+   provider), giving the agent:
+   - **`search_snsf_grants`** — faceted + free-text search (the `GrantFilters`
+     fields + `text`, `sort`, `limit`), returning thin hits (grant URL id,
+     title, applicant, institution, scheme, discipline, status, dates, amount,
+     output counts). Description tells the LLM to use it when README / CITATION
+     / metadata mentions an SNSF grant, a Swiss-funded project, a PI + Swiss
+     institution, or to enrich an entity with its grants.
+   - **`snsf_grant_facets`** — facet counts for a filter set (so the agent can
+     discover available values, e.g. funding schemes for an institution).
+   - **`fetch_snsf_grant`** — full grant record (incl. abstract / lay
+     summaries) by grant URL id, split from search to keep prompts small.
+   Backed by a small `SnsfGrantsProvider` in `src/v2/ingest/providers/` (opens
+   the snsf `.ro` store read-only, calls `facet_query`), `record_query`-logged
+   like the other RAG tools, and added to the agent runtime's tool list.
+
 ## Delivery (PR per phase, full `tests/v2/` gate each)
 
 - **Phase A** — `facets.sql` + `build_facets()` + the 3 tables; CLI
-  `build-facets`; tests asserting the flattening/rollups against a small
-  fixture store.
+  `build-facets`; the **bootstrap post-hook** for snsf; tests asserting the
+  flattening/rollups against a small fixture store + that bootstrap builds the
+  facet tables.
 - **Phase B** — `facet_query.py` (`GrantFilters`, `query_grants`,
   `facet_counts`) + FTS; tests for each facet filter, free-text, sort,
   pagination, and facet-count semantics.
-- **Phase C** — the CLI `facet-search` + the two HTTP endpoints + endpoint
-  tests.
-- **Phase D (optional)** — hybrid: intersect facet filters with the existing
+- **Phase C** — the CLI `facet-search`; the two HTTP endpoints; the
+  **federated** `facet_query` adapter method + `structured_query.py` +
+  manifest hint; endpoint + federated tests.
+- **Phase D** — the **agent tool** (`SnsfGrantsProvider` +
+  `agent_tools/snsf_grants.py`, registered in the runtime) + tool tests
+  (stubbed store, assert the tool returns the documented thin-hit shape).
+- **Phase E (optional)** — hybrid: intersect facet filters with the existing
   Qdrant semantic search for conceptual queries.
 
 ## Testing

--- a/docs/superpowers/specs/2026-06-05-snsf-faceted-query-design.md
+++ b/docs/superpowers/specs/2026-06-05-snsf-faceted-query-design.md
@@ -1,0 +1,166 @@
+# SNSF faceted query — design spec
+
+**Status:** approved decisions, pending implementation plan.
+**Date:** 2026-06-05.
+
+## Purpose
+
+Surface the SNSF P3 data we already hold (90k+ grants with abstracts, lay
+summaries, disciplines, fields of research, funding schemes, institutions,
+persons, and 7 output types) as a **faceted query** that mirrors the
+`https://data.snf.ch/grants` search — the same filters, facet counts, and
+result rows — over our local DuckDB store, with no calls to data.snf.ch.
+
+This is **not** a re-ingest. The audit (below) shows every facet on the SNF
+site already maps to a column we ingest from the bulk CSV. The gap is a query
+surface: today `snsf/query.py` is only semantic RAG (Qdrant); there is no
+faceted SQL query.
+
+## Facet → existing column map (audit)
+
+| data.snf.ch facet | source in our store |
+|---|---|
+| Funding scheme | `grants.funding_instrument` |
+| Research institution | `grants.research_institution` (+ `_type`) |
+| Status | `grants.state` |
+| Start / End date | `grants.start_date` / `grants.end_date` |
+| Call | `grants.call_full_title`, `grants.call_decision_year` |
+| Discipline | `grants.main_discipline` (+ `discipline_taxonomy`) |
+| Fields of Research | `grants.main_field_of_research` (+ `_la` / `_lb`) |
+| Countries of collaboration | `output_collaborations.country` |
+| Applicants / Project partners / Employees | `persons.{responsible_applicant,co_applicant,project_partner,practice_partner,employee,contact_person,applicant_abroad}_grants` (JSON grant-number arrays) |
+| Output data | the 7 `output_*` tables (presence/counts) |
+| free-text | `grants.title` / `grants.abstract` / `grants.keywords` |
+
+All `grant_number` values are the canonical SNSF grant URL
+(`https://data.snf.ch/grants/grant/<n>`) after the v3.0.0 re-PK.
+
+## Decisions (locked)
+
+1. **Materialized facet tables** (rebuilt by a `build_facets()` step after
+   ingest), not SQL views — fast faceting/counts over 90k rows and they ride
+   into the `.ro` snapshot the Hub reads.
+2. **DuckDB FTS / ILIKE** for free-text on title+abstract+keywords, combined
+   with facet filters in one SQL query (deterministic, no embeddings). The
+   existing Qdrant semantic search stays a separate mode; an optional hybrid
+   phase comes last.
+3. **CLI + HTTP endpoints** both.
+
+## New derived tables (the "more tables")
+
+Built in `src/index/snsf/storage/facets.sql` + a `build_facets(store)` step,
+all keyed on `grant_number` (the URL). Idempotent (DELETE + INSERT from source
+tables; safe to re-run after any reload).
+
+1. **`grant_persons`** (`grant_number TEXT`, `person_number INTEGER`,
+   `role TEXT`, PK `(grant_number, person_number, role)`) — flattens each
+   `persons.*_grants` JSON array into rows via `json_each`, tagging the `role`
+   (responsible_applicant / co_applicant / project_partner / practice_partner /
+   employee / contact_person / applicant_abroad). Enables the Applicants /
+   Project partners / Employees facets and "who is on this grant".
+2. **`grant_output_counts`** (`grant_number TEXT PRIMARY KEY`,
+   `n_publications`, `n_datasets`, `n_collaborations`, `n_academic_events`,
+   `n_knowledge_transfers`, `n_public_communications`, `n_use_inspired`, all
+   INTEGER) — per-grant rollups (`GROUP BY grant_number`) across the 7
+   `output_*` tables. Enables the "Output data" facet + the "N scientific
+   publications" result line.
+3. **`grant_countries`** (`grant_number TEXT`, `country TEXT`, PK
+   `(grant_number, country)`) — distinct `output_collaborations.country` per
+   grant. Enables the Countries-of-collaboration facet.
+
+Indexes on the join/filter columns (`grant_persons.person_number`,
+`grant_countries.country`).
+
+`build_facets()` hooks into the snsf ingest flow (run after `load_persons` +
+the `load_output_*` loaders) and is exposed as a CLI subcommand
+(`python -m src.index.snsf build-facets`).
+
+## Query module — `src/index/snsf/facet_query.py`
+
+```python
+@dataclass
+class GrantFilters:
+    funding_instrument: list[str] | None = None
+    research_institution: list[str] | None = None
+    state: list[str] | None = None
+    main_discipline: list[str] | None = None
+    main_field_of_research: list[str] | None = None
+    call_decision_year: list[int] | None = None
+    country: list[str] | None = None          # via grant_countries
+    person_number: int | None = None          # via grant_persons
+    person_role: str | None = None            # narrows the person join
+    has_output: list[str] | None = None        # e.g. ["publications","datasets"]
+    start_from: date | None = None
+    start_to: date | None = None
+    end_from: date | None = None
+    end_to: date | None = None
+
+def query_grants(store, filters: GrantFilters, *, text: str | None = None,
+                 sort: str = "start_date_desc", limit: int = 50,
+                 offset: int = 0) -> GrantQueryResult: ...
+
+def facet_counts(store, filters: GrantFilters, *, text: str | None = None
+                 ) -> dict[str, list[FacetCount]]: ...
+```
+
+- `query_grants` builds one parameterized SQL `SELECT` over `grants` LEFT
+  JOIN `grant_output_counts`, with `EXISTS` subqueries against `grant_persons`
+  / `grant_countries` for those facets, an FTS/ILIKE predicate on
+  title+abstract+keywords when `text` is given, `ORDER BY` the `sort`, and
+  `LIMIT/OFFSET`. Returns rows + a `total` (windowed count).
+- `facet_counts` returns, per facet, the value→count list **with the other
+  filters applied** (standard faceted-search semantics — the "fold" numbers on
+  the SNF site). Implemented as one `GROUP BY` per facet over the filtered set.
+- All SQL is parameterized (no string interpolation of user input).
+
+### Result row shape (mirrors the search page)
+
+`grant_number` (URL), `title` (+ `title_english`), `responsible_applicant`,
+`research_institution`, `main_discipline`, `funding_instrument`, `keywords`,
+`state`, `start_date`, `end_date`, `amount_granted`, and the
+`grant_output_counts` (e.g. `n_publications`).
+
+## Surfaces
+
+1. **CLI** — `python -m src.index.snsf facet-search [--scheme … --institution …
+   --status … --discipline … --field … --call-year … --country … --has-output
+   … --start-from … --q …] [--sort …] [--limit/--offset]` → JSON results;
+   `--facets` flag adds the facet counts. Plus `build-facets`.
+2. **HTTP** (mirrors the page's URL-driven filters):
+   - `GET /v2/indices/snsf/grants` — query params for every facet + `q`,
+     `sort`, `limit`, `offset` → `{ total, results }`.
+   - `GET /v2/indices/snsf/grants/facets` — same params → `{ facet: [{value,
+     count}, …] }`.
+   - Token-gated, `tags=["Indices"]`, mirroring the existing snsf endpoints.
+   - Reads the snsf store read-only (the `.ro` snapshot in serving).
+
+## Delivery (PR per phase, full `tests/v2/` gate each)
+
+- **Phase A** — `facets.sql` + `build_facets()` + the 3 tables; CLI
+  `build-facets`; tests asserting the flattening/rollups against a small
+  fixture store.
+- **Phase B** — `facet_query.py` (`GrantFilters`, `query_grants`,
+  `facet_counts`) + FTS; tests for each facet filter, free-text, sort,
+  pagination, and facet-count semantics.
+- **Phase C** — the CLI `facet-search` + the two HTTP endpoints + endpoint
+  tests.
+- **Phase D (optional)** — hybrid: intersect facet filters with the existing
+  Qdrant semantic search for conceptual queries.
+
+## Testing
+
+Per the existing snsf tests, with a small hand-built fixture store (a handful
+of grants + persons + outputs): `build_facets` produces the right rows;
+`query_grants` honours each filter, free-text, sort, paging; `facet_counts`
+returns the right per-facet counts under an active filter set; endpoints return
+the documented shapes and are auth-gated.
+
+## Risks / notes
+
+- Facet tables are derived → must be rebuilt after any grants/persons/output
+  reload. `build_facets()` is wired into the ingest flow + the maintenance
+  story (the `.ro` snapshot picks them up).
+- `persons.*_grants` arrays hold the grant **URL** ids post-v3.0.0; the
+  flattening + the `grants` join both use the URL, so no id-shape mismatch.
+- DuckDB FTS extension availability — fall back to `ILIKE` on
+  title+abstract+keywords if the FTS extension isn't loadable in a given env.

--- a/src/index/_federated/bootstrap.py
+++ b/src/index/_federated/bootstrap.py
@@ -19,6 +19,24 @@ import inspect
 import json
 import os
 from pathlib import Path
+from typing import Any, Callable
+
+# ---------------------------------------------------------------------------
+# Post-bootstrap hooks
+# ---------------------------------------------------------------------------
+
+
+def _snsf_post_bootstrap(store: Any) -> None:
+    """Run build_facets after the snsf store is opened."""
+    from src.index.snsf.facets import build_facets  # noqa: PLC0415
+
+    build_facets(store)
+
+
+POST_BOOTSTRAP: dict[str, Callable[[Any], None]] = {
+    "snsf": _snsf_post_bootstrap,
+}
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -87,6 +105,10 @@ def bootstrap_store(name: str) -> str:
         store = _open_store(name)
         if store is None:
             return "skipped: no duckdb store"
+
+        # Run any registered post-bootstrap hook for this store.
+        if name in POST_BOOTSTRAP:
+            POST_BOOTSTRAP[name](store)
 
         if hasattr(store, "close"):
             store.close()

--- a/src/index/snsf/cli.py
+++ b/src/index/snsf/cli.py
@@ -125,6 +125,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p_cov.add_argument("--snsf-scope", default=None,
                        help="SNSF scope to count over (default: all)")
 
+    sub.add_parser(
+        "build-facets",
+        help="(Re)build the derived facet tables (grant_persons, grant_output_counts, grant_countries).",
+    )
+
     return parser
 
 
@@ -132,7 +137,7 @@ def _print_json(obj) -> None:
     print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
 
 
-def main(argv=None) -> int:
+def main(argv=None) -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
     parser = _build_parser()
     args = parser.parse_args(argv)
     logging.basicConfig(
@@ -216,6 +221,16 @@ def main(argv=None) -> int:
     if args.cmd == "orcid-coverage":
         from src.index.snsf.orcid_link import coverage_report
         _print_json(coverage_report(args.snsf_scope))
+        return 0
+
+    if args.cmd == "build-facets":
+        from src.index.snsf.facets import build_facets  # noqa: PLC0415
+        store = SnsfStore.open()
+        try:
+            counts = build_facets(store)
+        finally:
+            store.close()
+        _print_json(counts)
         return 0
 
     if args.cmd == "query":

--- a/src/index/snsf/facets.py
+++ b/src/index/snsf/facets.py
@@ -1,0 +1,150 @@
+"""build_facets: populate the three derived facet tables from SNSF source data.
+
+The tables (grant_persons, grant_output_counts, grant_countries) are defined in
+storage/facets.sql and are also appended to storage/schema.sql so they exist
+whenever SnsfStore.bootstrap() runs.
+
+build_facets() is idempotent: it DELETEs all rows from the three tables before
+rebuilding them from the source tables (grants, persons, output_*).  Re-running
+after any reload is safe and produces correct counts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.index.snsf.storage.duckdb_store import SnsfStore
+
+_FACETS_SQL_PATH = Path(__file__).parent / "storage" / "facets.sql"
+
+# (role name, column name in the persons table)
+_ROLE_COL_PAIRS: list[tuple[str, str]] = [
+    ("responsible_applicant", "responsible_applicant_grants"),
+    ("co_applicant", "co_applicant_grants"),
+    ("project_partner", "project_partner_grants"),
+    ("practice_partner", "practice_partner_grants"),
+    ("employee", "employee_grants"),
+    ("contact_person", "contact_person_grants"),
+    ("applicant_abroad", "applicant_abroad_grants"),
+]
+
+
+def build_facets(store: SnsfStore) -> dict[str, int]:
+    """(Re)build the three derived facet tables from the SNSF source tables.
+
+    Steps:
+    1. Ensure facet tables exist (execute facets.sql — idempotent DDL).
+    2. Inside a transaction, DELETE all rows from the three facet tables.
+    3. Re-populate from the source tables.
+    4. Return row counts: {"grant_persons": n, "grant_output_counts": n,
+       "grant_countries": n}.
+    """
+    conn = store.connect()
+
+    # Ensure tables exist (idempotent DDL)
+    facets_ddl = _FACETS_SQL_PATH.read_text(encoding="utf-8")
+    conn.execute(facets_ddl)
+
+    with store.transaction():
+        # --- Clear ---
+        conn.execute("DELETE FROM grant_persons")
+        conn.execute("DELETE FROM grant_output_counts")
+        conn.execute("DELETE FROM grant_countries")
+
+        # --- grant_persons: flatten each role's JSON grant-URL array ---
+        for role, col in _ROLE_COL_PAIRS:
+            conn.execute(
+                f"""
+                INSERT INTO grant_persons (grant_number, person_number, role)
+                SELECT DISTINCT json_extract_string(j.value, '$'),
+                                p.person_number,
+                                '{role}'
+                FROM   persons p,
+                       json_each(p.{col}) AS j
+                WHERE  p.{col} IS NOT NULL
+                ON CONFLICT DO NOTHING
+                """,  # noqa: S608 — role and col are fixed strings from _ROLE_COL_PAIRS
+            )
+
+        # --- grant_output_counts: per-grant rollup across all 7 output tables ---
+        conn.execute(
+            """
+            INSERT INTO grant_output_counts (
+                grant_number,
+                n_publications,
+                n_datasets,
+                n_collaborations,
+                n_academic_events,
+                n_knowledge_transfers,
+                n_public_communications,
+                n_use_inspired
+            )
+            SELECT
+                g.grant_number,
+                COALESCE(pub.c, 0),
+                COALESCE(ds.c,  0),
+                COALESCE(col.c, 0),
+                COALESCE(ae.c,  0),
+                COALESCE(kt.c,  0),
+                COALESCE(pc.c,  0),
+                COALESCE(ui.c,  0)
+            FROM grants g
+            LEFT JOIN (
+                SELECT grant_number, count(*) c FROM output_publications
+                GROUP BY grant_number
+            ) pub ON pub.grant_number = g.grant_number
+            LEFT JOIN (
+                SELECT grant_number, count(*) c FROM output_datasets
+                GROUP BY grant_number
+            ) ds  ON ds.grant_number  = g.grant_number
+            LEFT JOIN (
+                SELECT grant_number, count(*) c FROM output_collaborations
+                GROUP BY grant_number
+            ) col ON col.grant_number = g.grant_number
+            LEFT JOIN (
+                SELECT grant_number, count(*) c FROM output_academic_events
+                GROUP BY grant_number
+            ) ae  ON ae.grant_number  = g.grant_number
+            LEFT JOIN (
+                SELECT grant_number, count(*) c FROM output_knowledge_transfers
+                GROUP BY grant_number
+            ) kt  ON kt.grant_number  = g.grant_number
+            LEFT JOIN (
+                SELECT grant_number, count(*) c FROM output_public_communications
+                GROUP BY grant_number
+            ) pc  ON pc.grant_number  = g.grant_number
+            LEFT JOIN (
+                SELECT grant_number, count(*) c FROM output_use_inspired
+                GROUP BY grant_number
+            ) ui  ON ui.grant_number  = g.grant_number
+            """,
+        )
+
+        # --- grant_countries: distinct country per grant from collaborations ---
+        conn.execute(
+            """
+            INSERT INTO grant_countries (grant_number, country)
+            SELECT DISTINCT grant_number, country
+            FROM   output_collaborations
+            WHERE  country     IS NOT NULL
+            AND    TRIM(country) <> ''
+            AND    grant_number IS NOT NULL
+            ON CONFLICT DO NOTHING
+            """,
+        )
+
+    # --- Return counts ---
+    def _count(table: str) -> int:
+        result = conn.execute(f"SELECT count(*) FROM {table}").fetchone()  # noqa: S608
+        return int(result[0]) if result else 0
+
+    return {
+        "grant_persons": _count("grant_persons"),
+        "grant_output_counts": _count("grant_output_counts"),
+        "grant_countries": _count("grant_countries"),
+    }
+
+
+__all__ = ["build_facets"]

--- a/src/index/snsf/storage/facets.sql
+++ b/src/index/snsf/storage/facets.sql
@@ -1,0 +1,35 @@
+-- Derived facet tables for the SNSF P3 index.
+-- Idempotent: every statement uses IF NOT EXISTS so re-runs are safe.
+-- Built by build_facets() in src/index/snsf/facets.py after any ingest.
+
+-- Flattened person ↔ grant ↔ role mapping.
+-- Keyed on the canonical grant URL (grant_number).
+CREATE TABLE IF NOT EXISTS grant_persons (
+    grant_number   TEXT NOT NULL,
+    person_number  INTEGER NOT NULL,
+    role           TEXT NOT NULL,
+    PRIMARY KEY (grant_number, person_number, role)
+);
+
+-- Per-grant output rollups (one row per grant in the grants table).
+CREATE TABLE IF NOT EXISTS grant_output_counts (
+    grant_number              TEXT PRIMARY KEY,
+    n_publications            INTEGER NOT NULL DEFAULT 0,
+    n_datasets                INTEGER NOT NULL DEFAULT 0,
+    n_collaborations          INTEGER NOT NULL DEFAULT 0,
+    n_academic_events         INTEGER NOT NULL DEFAULT 0,
+    n_knowledge_transfers     INTEGER NOT NULL DEFAULT 0,
+    n_public_communications   INTEGER NOT NULL DEFAULT 0,
+    n_use_inspired            INTEGER NOT NULL DEFAULT 0
+);
+
+-- Distinct collaboration countries per grant.
+CREATE TABLE IF NOT EXISTS grant_countries (
+    grant_number  TEXT NOT NULL,
+    country       TEXT NOT NULL,
+    PRIMARY KEY (grant_number, country)
+);
+
+CREATE INDEX IF NOT EXISTS grant_persons_person_idx ON grant_persons(person_number);
+CREATE INDEX IF NOT EXISTS grant_persons_role_idx   ON grant_persons(role);
+CREATE INDEX IF NOT EXISTS grant_countries_country_idx ON grant_countries(country);

--- a/src/index/snsf/storage/schema.sql
+++ b/src/index/snsf/storage/schema.sql
@@ -267,3 +267,35 @@ CREATE TABLE IF NOT EXISTS output_use_inspired (
 );
 
 CREATE INDEX IF NOT EXISTS output_ui_grant_idx ON output_use_inspired(grant_number);
+
+-- ---------------------------------------------------------------------------
+-- Derived facet tables (built by src/index/snsf/facets.py :: build_facets)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS grant_persons (
+    grant_number   TEXT NOT NULL,
+    person_number  INTEGER NOT NULL,
+    role           TEXT NOT NULL,
+    PRIMARY KEY (grant_number, person_number, role)
+);
+
+CREATE TABLE IF NOT EXISTS grant_output_counts (
+    grant_number              TEXT PRIMARY KEY,
+    n_publications            INTEGER NOT NULL DEFAULT 0,
+    n_datasets                INTEGER NOT NULL DEFAULT 0,
+    n_collaborations          INTEGER NOT NULL DEFAULT 0,
+    n_academic_events         INTEGER NOT NULL DEFAULT 0,
+    n_knowledge_transfers     INTEGER NOT NULL DEFAULT 0,
+    n_public_communications   INTEGER NOT NULL DEFAULT 0,
+    n_use_inspired            INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS grant_countries (
+    grant_number  TEXT NOT NULL,
+    country       TEXT NOT NULL,
+    PRIMARY KEY (grant_number, country)
+);
+
+CREATE INDEX IF NOT EXISTS grant_persons_person_idx    ON grant_persons(person_number);
+CREATE INDEX IF NOT EXISTS grant_persons_role_idx      ON grant_persons(role);
+CREATE INDEX IF NOT EXISTS grant_countries_country_idx ON grant_countries(country);

--- a/tests/index/snsf/test_facets.py
+++ b/tests/index/snsf/test_facets.py
@@ -1,0 +1,204 @@
+"""Phase A: build_facets() — derived facet tables for the SNSF index.
+
+Tests cover:
+- Correct flattening of persons JSON grant arrays into grant_persons rows.
+- Correct grant_output_counts rollups (present + zero-output grants).
+- Correct grant_countries rows.
+- Idempotency: running build_facets twice yields the same counts, no duplicates.
+- Bootstrap hook: bootstrap_all(only=["snsf"]) leaves a grant_persons table in
+  the snsf DuckDB (schema is present even before any ingest data exists).
+"""
+
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pytest
+
+from src.index._federated import bootstrap
+from src.index.snsf.facets import build_facets
+from src.index.snsf.storage.duckdb_store import SnsfStore
+
+_BASE = "https://data.snf.ch/grants/grant/"
+_G1 = f"{_BASE}100001"
+_G2 = f"{_BASE}100002"
+
+# Expected row counts used in multiple assertions
+_EXPECTED_PERSONS_ROWS = 3
+_EXPECTED_GRANTS = 2
+_EXPECTED_PUB_COUNT = 2
+_EXPECTED_COLLAB_COUNT = 1
+_EXPECTED_COUNTRIES = 1
+
+
+@pytest.fixture
+def store(tmp_path):  # type: ignore[no-untyped-def]
+    """Tiny SnsfStore with two grants, one person, some outputs."""
+    s = SnsfStore.open(tmp_path / "snsf.duckdb")
+    conn = s.connect()
+
+    # Two grants
+    conn.execute("INSERT INTO grants (grant_number, title) VALUES (?, ?)", [_G1, "Grant one"])
+    conn.execute("INSERT INTO grants (grant_number, title) VALUES (?, ?)", [_G2, "Grant two"])
+
+    # One person attached to both grants in different roles
+    conn.execute(
+        "INSERT INTO persons (person_number, responsible_applicant_grants, co_applicant_grants) "
+        "VALUES (?, ?, ?)",
+        [42, json.dumps([_G1, _G2]), json.dumps([_G2])],
+    )
+
+    # Publications: 2 for G1, 0 for G2
+    conn.execute(
+        "INSERT INTO output_publications (publication_id, grant_number) VALUES ('pub1', ?)",
+        [_G1],
+    )
+    conn.execute(
+        "INSERT INTO output_publications (publication_id, grant_number) VALUES ('pub2', ?)",
+        [_G1],
+    )
+
+    # Collaboration with a country for G1
+    conn.execute(
+        "INSERT INTO output_collaborations (collaboration_id, grant_number, country) "
+        "VALUES ('col1', ?, 'Germany')",
+        [_G1],
+    )
+
+    yield s
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Core build_facets tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_facets_returns_counts(store: SnsfStore) -> None:
+    counts = build_facets(store)
+    assert isinstance(counts, dict)
+    assert "grant_persons" in counts
+    assert "grant_output_counts" in counts
+    assert "grant_countries" in counts
+
+
+def test_grant_persons_flattened(store: SnsfStore) -> None:
+    build_facets(store)
+    conn = store.connect()
+    rows = conn.execute(
+        "SELECT grant_number, person_number, role FROM grant_persons ORDER BY grant_number, role",
+    ).fetchall()
+    # person 42 is responsible_applicant for G1 + G2, and co_applicant for G2
+    assert (f"{_BASE}100001", 42, "responsible_applicant") in rows
+    assert (f"{_BASE}100002", 42, "responsible_applicant") in rows
+    assert (f"{_BASE}100002", 42, "co_applicant") in rows
+    assert len(rows) == _EXPECTED_PERSONS_ROWS
+
+
+def test_grant_persons_count_returned(store: SnsfStore) -> None:
+    counts = build_facets(store)
+    assert counts["grant_persons"] == _EXPECTED_PERSONS_ROWS
+
+
+def test_grant_output_counts_for_g1(store: SnsfStore) -> None:
+    build_facets(store)
+    conn = store.connect()
+    row = conn.execute(
+        "SELECT n_publications, n_collaborations, n_datasets "
+        "FROM grant_output_counts WHERE grant_number = ?",
+        [_G1],
+    ).fetchone()
+    assert row is not None
+    n_publications, n_collaborations, n_datasets = row
+    assert n_publications == _EXPECTED_PUB_COUNT
+    assert n_collaborations == _EXPECTED_COLLAB_COUNT
+    assert n_datasets == 0
+
+
+def test_grant_output_counts_zero_for_g2(store: SnsfStore) -> None:
+    build_facets(store)
+    conn = store.connect()
+    row = conn.execute(
+        "SELECT n_publications FROM grant_output_counts WHERE grant_number = ?",
+        [_G2],
+    ).fetchone()
+    assert row is not None
+    assert row[0] == 0
+
+
+def test_grant_output_counts_count_returned(store: SnsfStore) -> None:
+    counts = build_facets(store)
+    # One row per grant
+    assert counts["grant_output_counts"] == _EXPECTED_GRANTS
+
+
+def test_grant_countries(store: SnsfStore) -> None:
+    build_facets(store)
+    conn = store.connect()
+    rows = conn.execute(
+        "SELECT grant_number, country FROM grant_countries",
+    ).fetchall()
+    assert (f"{_BASE}100001", "Germany") in rows
+    assert len(rows) == _EXPECTED_COUNTRIES
+
+
+def test_grant_countries_count_returned(store: SnsfStore) -> None:
+    counts = build_facets(store)
+    assert counts["grant_countries"] == _EXPECTED_COUNTRIES
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_build_facets_idempotent(store: SnsfStore) -> None:
+    counts1 = build_facets(store)
+    counts2 = build_facets(store)
+    assert counts1 == counts2
+
+    conn = store.connect()
+    # No duplicate rows in grant_persons
+    total = conn.execute("SELECT count(*) FROM grant_persons").fetchone()[0]
+    assert total == _EXPECTED_PERSONS_ROWS
+
+    # No duplicate rows in grant_countries
+    total_c = conn.execute("SELECT count(*) FROM grant_countries").fetchone()[0]
+    assert total_c == _EXPECTED_COUNTRIES
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap hook
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_hook_creates_facet_tables(
+    tmp_path,  # type: ignore[no-untyped-def]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """bootstrap_all(only=["snsf"]) must create the grant_persons table (and
+    siblings) in the snsf DuckDB, even before any ingest data is present."""
+    snsf_dir = tmp_path / "snsf" / "duckdb"
+    snsf_dir.mkdir(parents=True)
+    db_file = snsf_dir / "snsf.duckdb"
+
+    monkeypatch.setenv("INDEX_DATA_DIR", str(tmp_path))
+
+    result = bootstrap.bootstrap_all(only=["snsf"])
+    status = result.get("snsf", "")
+    assert not status.startswith("error"), f"bootstrap error: {status}"
+
+    # The DuckDB must now have the grant_persons table.
+    assert db_file.exists(), "DuckDB not created"
+    conn = duckdb.connect(str(db_file), read_only=True)
+    tables = {
+        r[0]
+        for r in conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'",
+        ).fetchall()
+    }
+    conn.close()
+    assert "grant_persons" in tables, f"grant_persons missing; found: {tables}"
+    assert "grant_output_counts" in tables
+    assert "grant_countries" in tables


### PR DESCRIPTION
Phase A of the SNSF faceted query (spec: `docs/superpowers/specs/2026-06-05-snsf-faceted-query-design.md`). Surfaces the rich SNSF data we already hold as **materialized facet tables** that mirror the data.snf.ch search facets — no re-ingest.

### Adds
- **3 derived tables** (in `storage/schema.sql` + `storage/facets.sql`), all keyed on the canonical grant URL:
  - `grant_persons(grant_number, person_number, role)` — flattens the `persons.*_grants` JSON role-arrays (7 roles) into rows → the Applicants / Project partners / Employees facets. JSON URL strings unquoted via `json_extract_string(j.value,'$')`.
  - `grant_output_counts(grant_number, n_publications, n_datasets, …)` — per-grant rollups across the 7 `output_*` tables → the Output-data facet + "N publications" line.
  - `grant_countries(grant_number, country)` — distinct collaboration countries → the Countries facet.
- **`build_facets(store)`** (`src/index/snsf/facets.py`) — idempotent DELETE+rebuild; returns row counts.
- **Bootstrap hook** — `bootstrap.py` gains a generic `POST_BOOTSTRAP` map; `snsf` → `build_facets`, so `make bootstrap-index` leaves the facet tables present on a fresh checkout (caught by the existing per-store error isolation).
- **CLI** `python -m src.index.snsf build-facets`.

### Tests
`tests/index/snsf/test_facets.py` — flattening/roles, output rollups, countries, idempotency, and the bootstrap hook (10 tests). Full `tests/v2/` gate: **1429 passed, 1 skipped**.

Phases B (query module + facet counts), C (CLI search + HTTP + federated `facet_query`), D (agent tool) follow as their own PRs.