### PR TITLE
feat(snsf): faceted-query Phase B — query_grants + facet_counts

### DIFF
--- a/src/index/snsf/facet_query.py
+++ b/src/index/snsf/facet_query.py
@@ -1,0 +1,371 @@
+"""Faceted SQL query over the SNSF DuckDB store.
+
+Public API:
+    GrantFilters  -- dataclass with all supported filter fields.
+    query_grants  -- execute a faceted + free-text grant search, return rows + total.
+    facet_counts  -- per-facet value->count with excluded-self semantics.
+
+All SQL is fully parameterised; user-supplied values are *never* interpolated
+into SQL strings.  The only things embedded in the SQL text are column names
+and table names -- all drawn from fixed module-level constants.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.index.snsf.storage.duckdb_store import SnsfStore
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Facets backed by a direct column on `grants`
+_COL_FACETS: list[str] = [
+    "funding_instrument",
+    "research_institution",
+    "state",
+    "main_discipline",
+    "main_field_of_research",
+    "call_decision_year",
+]
+
+# Canonical output-type name -> grant_output_counts column
+_OUTPUT_COL: dict[str, str] = {
+    "publications": "n_publications",
+    "datasets": "n_datasets",
+    "collaborations": "n_collaborations",
+    "academic_events": "n_academic_events",
+    "knowledge_transfers": "n_knowledge_transfers",
+    "public_communications": "n_public_communications",
+    "use_inspired": "n_use_inspired",
+}
+
+# sort key -> ORDER BY expression (column references are fixed, not user-supplied)
+_SORT_MAP: dict[str, str] = {
+    "start_date_desc": "g.start_date DESC NULLS LAST",
+    "start_date_asc": "g.start_date ASC NULLS LAST",
+    "amount_desc": "g.amount_granted DESC NULLS LAST",
+    "amount_asc": "g.amount_granted ASC NULLS LAST",
+}
+_DEFAULT_SORT = "g.start_date DESC NULLS LAST"
+
+# The LEFT JOIN clause shared by query_grants and facet_counts
+_JOIN = "LEFT JOIN grant_output_counts oc ON oc.grant_number = g.grant_number"
+
+
+# ---------------------------------------------------------------------------
+# GrantFilters
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GrantFilters:
+    """All supported facet filter fields. All optional (default None = inactive)."""
+
+    funding_instrument: list[str] | None = field(default=None)
+    research_institution: list[str] | None = field(default=None)
+    state: list[str] | None = field(default=None)
+    main_discipline: list[str] | None = field(default=None)
+    main_field_of_research: list[str] | None = field(default=None)
+    call_decision_year: list[int] | None = field(default=None)
+    country: list[str] | None = field(default=None)
+    person_number: int | None = field(default=None)
+    person_role: str | None = field(default=None)
+    has_output: list[str] | None = field(default=None)
+    start_from: str | None = field(default=None)
+    start_to: str | None = field(default=None)
+    end_from: str | None = field(default=None)
+    end_to: str | None = field(default=None)
+
+
+# ---------------------------------------------------------------------------
+# _build_where helpers
+# ---------------------------------------------------------------------------
+
+
+def _add_col_facets(
+    filters: GrantFilters,
+    exclude: str | None,
+    predicates: list[str],
+    params: list[Any],
+) -> None:
+    """Append IN-list predicates for the column-backed facets."""
+    for col in _COL_FACETS:
+        if col == exclude:
+            continue
+        values: list[Any] | None = getattr(filters, col)
+        if not values:
+            continue
+        placeholders = ", ".join(["?"] * len(values))
+        # col is a fixed string from _COL_FACETS — not user-supplied
+        predicates.append(f"g.{col} IN ({placeholders})")
+        params.extend(values)
+
+
+def _add_country_predicate(
+    filters: GrantFilters,
+    exclude: str | None,
+    predicates: list[str],
+    params: list[Any],
+) -> None:
+    """Append EXISTS predicate for the country facet."""
+    if exclude == "country":
+        return
+    country_vals = filters.country
+    if not country_vals:
+        return
+    placeholders = ", ".join(["?"] * len(country_vals))
+    # All values are parameterised; {placeholders} is only ?-markers, not user input
+    pred = (
+        "EXISTS ("  # noqa: S608
+        "SELECT 1 FROM grant_countries gc "
+        "WHERE gc.grant_number = g.grant_number "
+        f"AND gc.country IN ({placeholders})"
+        ")"
+    )
+    predicates.append(pred)
+    params.extend(country_vals)
+
+
+def _add_person_predicate(
+    filters: GrantFilters,
+    predicates: list[str],
+    params: list[Any],
+) -> None:
+    """Append EXISTS predicate for the person_number (+ optional role) facet."""
+    if filters.person_number is None:
+        return
+    if filters.person_role:
+        predicates.append(
+            "EXISTS ("
+            "SELECT 1 FROM grant_persons gp "
+            "WHERE gp.grant_number = g.grant_number "
+            "AND gp.person_number = ? "
+            "AND gp.role = ?"
+            ")",
+        )
+        params.extend([filters.person_number, filters.person_role])
+    else:
+        predicates.append(
+            "EXISTS ("
+            "SELECT 1 FROM grant_persons gp "
+            "WHERE gp.grant_number = g.grant_number "
+            "AND gp.person_number = ?"
+            ")",
+        )
+        params.append(filters.person_number)
+
+
+def _add_output_predicates(
+    filters: GrantFilters,
+    predicates: list[str],
+) -> None:
+    """Append oc.n_<type> > 0 predicates for the has_output filter."""
+    if not filters.has_output:
+        return
+    for output_name in filters.has_output:
+        col_name = _OUTPUT_COL.get(output_name)
+        if col_name:
+            # col_name is from _OUTPUT_COL — fixed constant, not user input
+            predicates.append(f"oc.{col_name} > 0")
+
+
+def _add_date_predicates(
+    filters: GrantFilters,
+    predicates: list[str],
+    params: list[Any],
+) -> None:
+    """Append start/end date range predicates."""
+    if filters.start_from is not None:
+        predicates.append("g.start_date >= ?")
+        params.append(filters.start_from)
+    if filters.start_to is not None:
+        predicates.append("g.start_date <= ?")
+        params.append(filters.start_to)
+    if filters.end_from is not None:
+        predicates.append("g.end_date >= ?")
+        params.append(filters.end_from)
+    if filters.end_to is not None:
+        predicates.append("g.end_date <= ?")
+        params.append(filters.end_to)
+
+
+def _add_text_predicate(
+    text: str | None,
+    predicates: list[str],
+    params: list[Any],
+) -> None:
+    """Append ILIKE free-text predicate across title / title_english / abstract / keywords."""
+    if not text:
+        return
+    like_val = f"%{text}%"
+    predicates.append(
+        "(g.title ILIKE ? OR g.title_english ILIKE ? "
+        "OR g.abstract ILIKE ? OR g.keywords ILIKE ?)",
+    )
+    params.extend([like_val, like_val, like_val, like_val])
+
+
+# ---------------------------------------------------------------------------
+# _build_where — private
+# ---------------------------------------------------------------------------
+
+
+def _build_where(
+    filters: GrantFilters,
+    text: str | None,
+    *,
+    exclude: str | None = None,
+) -> tuple[str, list[Any]]:
+    """Build a SQL WHERE-clause body (without the word WHERE) + ordered params.
+
+    Parameters
+    ----------
+    filters:
+        The active filter set.
+    text:
+        Optional free-text search string (matched with ILIKE).
+    exclude:
+        A facet name to omit from the predicates (used by ``facet_counts`` for
+        the excluded-self semantics).
+
+    Returns
+    -------
+    (clause, params)
+        ``clause`` is a string placed after ``WHERE``.
+        ``params`` is the ordered list of ``?`` substitution values.
+    """
+    predicates: list[str] = []
+    params: list[Any] = []
+
+    _add_col_facets(filters, exclude, predicates, params)
+    _add_country_predicate(filters, exclude, predicates, params)
+    _add_person_predicate(filters, predicates, params)
+    _add_output_predicates(filters, predicates)
+    _add_date_predicates(filters, predicates, params)
+    _add_text_predicate(text, predicates, params)
+
+    if not predicates:
+        return "1=1", []
+    return " AND ".join(predicates), params
+
+
+# ---------------------------------------------------------------------------
+# query_grants
+# ---------------------------------------------------------------------------
+
+
+def _row_to_dict(
+    description: list[Any],
+    row: tuple[Any, ...],
+) -> dict[str, Any]:
+    """Convert a DuckDB result row to a dict, serialising dates to ISO strings."""
+    result: dict[str, Any] = {}
+    for (col_name, *_), value in zip(description, row, strict=False):
+        if hasattr(value, "isoformat"):
+            result[col_name] = value.isoformat()
+        else:
+            result[col_name] = value
+    return result
+
+
+def query_grants(  # noqa: PLR0913
+    store: SnsfStore,
+    filters: GrantFilters,
+    *,
+    text: str | None = None,
+    sort: str = "start_date_desc",
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Execute a faceted grant search.
+
+    Returns
+    -------
+    {"total": int, "results": [row_dict, ...]}
+        ``total`` is the count without limit/offset.
+        Each ``row_dict`` contains the columns listed in the SELECT plus
+        ``n_publications``, ``n_datasets``, ``n_collaborations``.
+    """
+    where, params = _build_where(filters, text)
+    order = _SORT_MAP.get(sort, _DEFAULT_SORT)
+
+    conn = store.connect()
+
+    # total count (no limit/offset) — where embeds only ?-parameterised predicates
+    count_sql = (
+        f"SELECT count(*) FROM grants g {_JOIN} WHERE {where}"  # noqa: S608
+    )
+    total_row = conn.execute(count_sql, params).fetchone()
+    total = int(total_row[0]) if total_row else 0
+
+    # result rows — same parameterised where clause
+    select_sql = (
+        "SELECT g.grant_number, g.title, g.title_english, g.responsible_applicant, "  # noqa: S608
+        "g.research_institution, g.main_discipline, g.funding_instrument, "
+        "g.keywords, g.state, g.start_date, g.end_date, g.amount_granted, "
+        "COALESCE(oc.n_publications, 0) AS n_publications, "
+        "COALESCE(oc.n_datasets, 0) AS n_datasets, "
+        f"COALESCE(oc.n_collaborations, 0) AS n_collaborations FROM grants g {_JOIN} "
+        f"WHERE {where} ORDER BY {order} LIMIT ? OFFSET ?"
+    )
+    cur = conn.execute(select_sql, [*params, limit, offset])
+    description = cur.description
+    rows = [_row_to_dict(description, row) for row in cur.fetchall()]
+
+    return {"total": total, "results": rows}
+
+
+# ---------------------------------------------------------------------------
+# facet_counts
+# ---------------------------------------------------------------------------
+
+
+def facet_counts(
+    store: SnsfStore,
+    filters: GrantFilters,
+    *,
+    text: str | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Return per-facet value->count with excluded-self semantics.
+
+    For each categorical facet, the count query applies all *other* active
+    filters but omits the filter for the facet being counted -- matching the
+    standard faceted-search "fold" behaviour on the SNSF website.
+
+    Returns
+    -------
+    {facet_name: [{"value": ..., "count": ...}, ...], ...}
+    """
+    conn = store.connect()
+    result: dict[str, list[dict[str, Any]]] = {}
+
+    # column-backed facets -- col is a fixed string from _COL_FACETS, never user input
+    for col in _COL_FACETS:
+        where, params = _build_where(filters, text, exclude=col)
+        sql = (
+            f"SELECT g.{col} AS value, count(*) AS count FROM grants g {_JOIN} "  # noqa: S608
+            f"WHERE {where} AND g.{col} IS NOT NULL GROUP BY g.{col} "
+            "ORDER BY count DESC, value LIMIT 100"
+        )
+        cur = conn.execute(sql, params)
+        result[col] = [{"value": row[0], "count": row[1]} for row in cur.fetchall()]
+
+    # country facet (via grant_countries)
+    where_c, params_c = _build_where(filters, text, exclude="country")
+    country_sql = (
+        "SELECT gc.country AS value, count(DISTINCT gc.grant_number) AS count "  # noqa: S608
+        "FROM grant_countries gc WHERE gc.grant_number IN "
+        f"(SELECT g.grant_number FROM grants g {_JOIN} WHERE {where_c}) "
+        "GROUP BY gc.country ORDER BY count DESC LIMIT 100"
+    )
+    cur_c = conn.execute(country_sql, params_c)
+    result["country"] = [{"value": row[0], "count": row[1]} for row in cur_c.fetchall()]
+
+    return result
+
+
+__all__ = ["GrantFilters", "facet_counts", "query_grants"]

--- a/tests/index/snsf/test_facet_query.py
+++ b/tests/index/snsf/test_facet_query.py
@@ -1,0 +1,564 @@
+"""Phase B: facet_query.py — query_grants + facet_counts.
+
+Tests cover:
+- Single facet filter (funding_instrument, state, etc.) returns only matching grants.
+- text= does ILIKE match on title / abstract / keywords.
+- sort= (start_date_desc, start_date_asc, amount_desc, amount_asc) orders correctly.
+- limit/offset paginate; total reflects the unfiltered-by-page count.
+- country filter selects grants via grant_countries EXISTS join.
+- person_number (+optional role) selects grants via grant_persons EXISTS join.
+- has_output=["publications"] selects only grants with n_publications > 0.
+- facet_counts returns per-facet value→count with another filter active (excluded-self
+  semantics: funding_instrument facet not narrowed by an active funding_instrument filter).
+- Result rows carry n_publications, n_datasets, n_collaborations output counts.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.index.snsf.facet_query import GrantFilters, facet_counts, query_grants
+from src.index.snsf.facets import build_facets
+from src.index.snsf.storage.duckdb_store import SnsfStore
+
+_BASE = "https://data.snf.ch/grants/grant/"
+_G1 = f"{_BASE}200001"
+_G2 = f"{_BASE}200002"
+_G3 = f"{_BASE}200003"
+_G4 = f"{_BASE}200004"
+
+# Expected counts — named constants to satisfy PLR2004
+_TOTAL_GRANTS = 4
+_TWO = 2
+_ONE = 1
+_ZERO = 0
+_PERSON_99 = 99
+_PERSON_77 = 77
+_YEAR_2020 = 2020
+_YEAR_2018 = 2018
+_YEAR_2015 = 2015
+_G1_PUBS = 2  # 2 publications for G1
+_G1_COLLABS = 1  # 1 collaboration (Germany) for G1
+_G4_COLLABS = 1  # 1 collaboration (France) for G4
+
+
+@pytest.fixture
+def store(tmp_path):  # type: ignore[no-untyped-def]
+    """Tiny SnsfStore with 4 grants, varied attributes, outputs, country, person."""
+    s = SnsfStore.open(tmp_path / "snsf_fq.duckdb")
+    conn = s.connect()
+
+    # G1: ProjectFunding / EPFL / active / Biology / Life Sciences / 2020 / CHF 500k
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G1, "Protéines de la membrane cellulaire",
+            "Cell membrane proteins",
+            "This abstract discusses membrane biology and protein folding.",
+            "membrane; protein; biology",
+            "ProjectFunding", "EPF Lausanne - EPFL", "Active",
+            "Biology", "Life Sciences", 2020,
+            "2020-01-01", "2022-12-31", 500_000,
+        ],
+    )
+
+    # G2: Ambizione / ETH Zurich / Completed / Chemistry / Natural Sciences / 2018 / CHF 300k
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G2, "Synthèse organique avancée",
+            "Advanced organic synthesis",
+            "Research on catalyst design for sustainable chemistry.",
+            "catalyst; chemistry; green",
+            "Ambizione", "ETH Zurich", "Completed",
+            "Chemistry", "Natural Sciences", 2018,
+            "2018-06-01", "2021-05-31", 300_000,
+        ],
+    )
+
+    # G3: ProjectFunding / UniBern / Active / Physics / Natural Sciences / 2020 / CHF 800k
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G3, "Physique des particules",
+            "Particle physics experiment",
+            "Collider-based experimental study of high energy phenomena.",
+            "physics; particles; collider",
+            "ProjectFunding", "University of Bern", "Active",
+            "Physics", "Natural Sciences", 2020,
+            "2020-03-15", "2023-03-14", 800_000,
+        ],
+    )
+
+    # G4: NCCR / UniGeneva / Completed / Mathematics / Formal Sciences / 2015 / CHF 1.2M
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G4, "Algèbre et topologie",
+            "Algebra and topology",
+            "Pure mathematics — algebraic structures and their topological invariants.",
+            "algebra; topology; mathematics",
+            "NCCR", "University of Geneva", "Completed",
+            "Mathematics", "Formal Sciences", 2015,
+            "2015-01-01", "2020-12-31", 1_200_000,
+        ],
+    )
+
+    # Publications: 2 for G1, 1 for G2, 0 for G3, G4
+    conn.execute(
+        "INSERT INTO output_publications (publication_id, grant_number) VALUES ('pub1', ?)",
+        [_G1],
+    )
+    conn.execute(
+        "INSERT INTO output_publications (publication_id, grant_number) VALUES ('pub2', ?)",
+        [_G1],
+    )
+    conn.execute(
+        "INSERT INTO output_publications (publication_id, grant_number) VALUES ('pub3', ?)",
+        [_G2],
+    )
+
+    # Dataset for G3
+    conn.execute(
+        "INSERT INTO output_datasets (dataset_id, grant_number) VALUES ('ds1', ?)",
+        [_G3],
+    )
+
+    # Collaboration with country for G1 (Germany) and G4 (France)
+    conn.execute(
+        "INSERT INTO output_collaborations "
+        "(collaboration_id, grant_number, country) VALUES ('col1', ?, 'Germany')",
+        [_G1],
+    )
+    conn.execute(
+        "INSERT INTO output_collaborations "
+        "(collaboration_id, grant_number, country) VALUES ('col2', ?, 'France')",
+        [_G4],
+    )
+
+    # Person 99 is responsible_applicant on G1 and G2
+    conn.execute(
+        "INSERT INTO persons (person_number, responsible_applicant_grants) "
+        "VALUES (?, ?)",
+        [99, json.dumps([_G1, _G2])],
+    )
+    # Person 77 is employee on G3
+    conn.execute(
+        "INSERT INTO persons (person_number, employee_grants) VALUES (?, ?)",
+        [77, json.dumps([_G3])],
+    )
+
+    # Build the facet tables
+    build_facets(s)
+
+    yield s
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# query_grants — basic filter assertions
+# ---------------------------------------------------------------------------
+
+
+def test_no_filter_returns_all(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters())
+    assert result["total"] == _TOTAL_GRANTS
+    assert len(result["results"]) == _TOTAL_GRANTS
+
+
+def test_filter_funding_instrument(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(funding_instrument=["ProjectFunding"]))
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G1, _G3}
+
+
+def test_filter_state(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(state=["Active"]))
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G1, _G3}
+
+
+def test_filter_research_institution(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(research_institution=["ETH Zurich"]))
+    assert result["total"] == _ONE
+    assert result["results"][0]["grant_number"] == _G2
+
+
+def test_filter_main_discipline(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(main_discipline=["Physics"]))
+    assert result["total"] == _ONE
+    assert result["results"][0]["grant_number"] == _G3
+
+
+def test_filter_main_field_of_research(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(main_field_of_research=["Natural Sciences"]))
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G2, _G3}
+
+
+def test_filter_call_decision_year(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(call_decision_year=[_YEAR_2020]))
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G1, _G3}
+
+
+def test_filter_multiple_values_in_list(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(state=["Active", "Completed"]))
+    assert result["total"] == _TOTAL_GRANTS
+
+
+def test_filter_country(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(country=["Germany"]))
+    assert result["total"] == _ONE
+    assert result["results"][0]["grant_number"] == _G1
+
+
+def test_filter_country_multiple(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(country=["Germany", "France"]))
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G1, _G4}
+
+
+def test_filter_person_number(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(person_number=_PERSON_99))
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G1, _G2}
+
+
+def test_filter_person_number_with_role(store: SnsfStore) -> None:
+    # Person 99 is responsible_applicant for G1 + G2, not employee
+    result = query_grants(
+        store, GrantFilters(person_number=_PERSON_99, person_role="responsible_applicant"),
+    )
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G1, _G2}
+
+    # With wrong role → no results
+    result_none = query_grants(
+        store, GrantFilters(person_number=_PERSON_99, person_role="employee"),
+    )
+    assert result_none["total"] == _ZERO
+
+
+def test_filter_person_77_employee(store: SnsfStore) -> None:
+    result = query_grants(
+        store, GrantFilters(person_number=_PERSON_77, person_role="employee"),
+    )
+    assert result["total"] == _ONE
+    assert result["results"][0]["grant_number"] == _G3
+
+
+def test_filter_has_output_publications(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(has_output=["publications"]))
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G1, _G2}
+
+
+def test_filter_has_output_datasets(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(has_output=["datasets"]))
+    assert result["total"] == _ONE
+    assert result["results"][0]["grant_number"] == _G3
+
+
+def test_filter_has_output_multiple(store: SnsfStore) -> None:
+    # Must have BOTH publications AND datasets -- no grant has both
+    result = query_grants(store, GrantFilters(has_output=["publications", "datasets"]))
+    assert result["total"] == _ZERO
+
+
+def test_filter_start_from(store: SnsfStore) -> None:
+    # G1 starts 2020-01-01, G3 2020-03-15, G2 2018, G4 2015
+    result = query_grants(store, GrantFilters(start_from="2020-01-01"))
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G1, _G3}
+
+
+def test_filter_start_to(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(start_to="2018-12-31"))
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G2, _G4}
+
+
+def test_filter_end_from(store: SnsfStore) -> None:
+    # G3 ends 2023-03-14, G1 ends 2022-12-31, G2 2021-05-31, G4 2020-12-31
+    result = query_grants(store, GrantFilters(end_from="2022-01-01"))
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G1, _G3}
+
+
+def test_filter_end_to(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(end_to="2021-12-31"))
+    assert result["total"] == _TWO
+    gnums = {r["grant_number"] for r in result["results"]}
+    assert gnums == {_G2, _G4}
+
+
+# ---------------------------------------------------------------------------
+# query_grants — text search
+# ---------------------------------------------------------------------------
+
+
+def test_text_matches_title(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), text="membrane")
+    assert result["total"] == _ONE
+    assert result["results"][0]["grant_number"] == _G1
+
+
+def test_text_matches_title_english(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), text="organic synthesis")
+    assert result["total"] == _ONE
+    assert result["results"][0]["grant_number"] == _G2
+
+
+def test_text_matches_abstract(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), text="collider")
+    assert result["total"] == _ONE
+    assert result["results"][0]["grant_number"] == _G3
+
+
+def test_text_matches_keywords(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), text="topology")
+    assert result["total"] == _ONE
+    assert result["results"][0]["grant_number"] == _G4
+
+
+def test_text_case_insensitive(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), text="MEMBRANE")
+    assert result["total"] == _ONE
+
+
+def test_text_no_match(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), text="xyzzyx_nomatch")
+    assert result["total"] == _ZERO
+
+
+def test_text_combined_with_filter(store: SnsfStore) -> None:
+    # text="protein" matches G1 but filter state=Completed -> 0 results
+    result = query_grants(
+        store, GrantFilters(state=["Completed"]), text="protein",
+    )
+    assert result["total"] == _ZERO
+
+
+# ---------------------------------------------------------------------------
+# query_grants — sort
+# ---------------------------------------------------------------------------
+
+
+def test_sort_start_date_desc(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), sort="start_date_desc", limit=_TOTAL_GRANTS)
+    dates = [r["start_date"] for r in result["results"]]
+    # First two are 2020-xx-xx, last is 2015
+    assert dates == sorted(dates, reverse=True)
+
+
+def test_sort_start_date_asc(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), sort="start_date_asc", limit=_TOTAL_GRANTS)
+    dates = [r["start_date"] for r in result["results"] if r["start_date"] is not None]
+    assert dates == sorted(dates)
+
+
+def test_sort_amount_desc(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), sort="amount_desc", limit=_TOTAL_GRANTS)
+    amounts = [r["amount_granted"] for r in result["results"]]
+    assert amounts == sorted(amounts, reverse=True)
+
+
+def test_sort_amount_asc(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), sort="amount_asc", limit=_TOTAL_GRANTS)
+    amounts = [r["amount_granted"] for r in result["results"]]
+    assert amounts == sorted(amounts)
+
+
+def test_sort_unknown_falls_back_to_start_date_desc(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), sort="bogus_sort", limit=_TOTAL_GRANTS)
+    dates = [r["start_date"] for r in result["results"] if r["start_date"] is not None]
+    assert dates == sorted(dates, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# query_grants — pagination
+# ---------------------------------------------------------------------------
+
+
+def test_limit(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(), limit=_TWO)
+    assert len(result["results"]) == _TWO
+    assert result["total"] == _TOTAL_GRANTS  # total is unaffected by limit
+
+
+def test_offset(store: SnsfStore) -> None:
+    all_result = query_grants(
+        store, GrantFilters(), sort="start_date_asc", limit=_TOTAL_GRANTS,
+    )
+    all_gnums = [r["grant_number"] for r in all_result["results"]]
+
+    page1 = query_grants(
+        store, GrantFilters(), sort="start_date_asc", limit=_TWO, offset=0,
+    )
+    page2 = query_grants(
+        store, GrantFilters(), sort="start_date_asc", limit=_TWO, offset=_TWO,
+    )
+
+    assert [r["grant_number"] for r in page1["results"]] == all_gnums[:_TWO]
+    assert [r["grant_number"] for r in page2["results"]] == all_gnums[_TWO:]
+
+
+def test_total_constant_across_pages(store: SnsfStore) -> None:
+    page1 = query_grants(store, GrantFilters(), limit=1, offset=0)
+    page2 = query_grants(store, GrantFilters(), limit=1, offset=1)
+    assert page1["total"] == page2["total"] == _TOTAL_GRANTS
+
+
+# ---------------------------------------------------------------------------
+# query_grants — result shape
+# ---------------------------------------------------------------------------
+
+
+def test_result_row_has_expected_columns(store: SnsfStore) -> None:
+    result = query_grants(
+        store, GrantFilters(funding_instrument=["ProjectFunding"]), sort="amount_asc", limit=1,
+    )
+    row = result["results"][0]
+    expected_cols = {
+        "grant_number", "title", "title_english", "responsible_applicant",
+        "research_institution", "main_discipline", "funding_instrument",
+        "keywords", "state", "start_date", "end_date", "amount_granted",
+        "n_publications", "n_datasets", "n_collaborations",
+    }
+    assert expected_cols.issubset(row.keys())
+
+
+def test_result_output_counts_g1(store: SnsfStore) -> None:
+    result = query_grants(store, GrantFilters(funding_instrument=["ProjectFunding"]))
+    rows_by_gnum = {r["grant_number"]: r for r in result["results"]}
+    g1 = rows_by_gnum[_G1]
+    assert g1["n_publications"] == _G1_PUBS
+    assert g1["n_collaborations"] == _G1_COLLABS
+    assert g1["n_datasets"] == _ZERO
+
+
+def test_result_output_counts_g4_zeros(store: SnsfStore) -> None:
+    # G4 has no publications, no datasets; it does have 1 collaboration (France)
+    result = query_grants(store, GrantFilters(funding_instrument=["NCCR"]))
+    assert result["total"] == _ONE
+    row = result["results"][0]
+    assert row["n_publications"] == _ZERO
+    assert row["n_datasets"] == _ZERO
+    assert row["n_collaborations"] == _G4_COLLABS  # France collaboration inserted in fixture
+
+
+# ---------------------------------------------------------------------------
+# facet_counts — basic shape
+# ---------------------------------------------------------------------------
+
+
+def test_facet_counts_returns_all_facets(store: SnsfStore) -> None:
+    fc = facet_counts(store, GrantFilters())
+    expected_facets = {
+        "funding_instrument", "research_institution", "state",
+        "main_discipline", "main_field_of_research", "call_decision_year",
+        "country",
+    }
+    assert expected_facets == set(fc.keys())
+
+
+def test_facet_counts_no_filter_funding_instrument(store: SnsfStore) -> None:
+    fc = facet_counts(store, GrantFilters())
+    fi_counts = {item["value"]: item["count"] for item in fc["funding_instrument"]}
+    assert fi_counts.get("ProjectFunding") == _TWO
+    assert fi_counts.get("Ambizione") == _ONE
+    assert fi_counts.get("NCCR") == _ONE
+
+
+def test_facet_counts_country(store: SnsfStore) -> None:
+    fc = facet_counts(store, GrantFilters())
+    c_counts = {item["value"]: item["count"] for item in fc["country"]}
+    assert c_counts.get("Germany") == _ONE
+    assert c_counts.get("France") == _ONE
+
+
+def test_facet_counts_ordered_by_count_desc(store: SnsfStore) -> None:
+    fc = facet_counts(store, GrantFilters())
+    # state: Active=2, Completed=2 — at least counts are descending/tied
+    state_counts = [item["count"] for item in fc["state"]]
+    assert state_counts == sorted(state_counts, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# facet_counts — excluded-self semantics
+# ---------------------------------------------------------------------------
+
+
+def test_facet_counts_excluded_self_funding_instrument(store: SnsfStore) -> None:
+    """With funding_instrument=["ProjectFunding"] active, the funding_instrument
+    facet counts are NOT narrowed by that filter — they still show all 3 schemes."""
+    fc = facet_counts(store, GrantFilters(funding_instrument=["ProjectFunding"]))
+    fi_counts = {item["value"]: item["count"] for item in fc["funding_instrument"]}
+    # All 4 grants (all schemes) should appear — self-excluded
+    assert "Ambizione" in fi_counts
+    assert "NCCR" in fi_counts
+    assert "ProjectFunding" in fi_counts
+
+
+def test_facet_counts_other_facets_narrowed_by_active_filter(store: SnsfStore) -> None:
+    """With funding_instrument=["ProjectFunding"] active, other facets (e.g. state)
+    ARE narrowed — only the two ProjectFunding grants (G1 Active, G3 Active) appear."""
+    fc = facet_counts(store, GrantFilters(funding_instrument=["ProjectFunding"]))
+    state_counts = {item["value"]: item["count"] for item in fc["state"]}
+    # Both G1 and G3 are Active -> _TWO; Completed should not appear (G2/G4 are Ambizione/NCCR)
+    assert state_counts.get("Active") == _TWO
+    assert "Completed" not in state_counts
+
+
+def test_facet_counts_country_excluded_self(store: SnsfStore) -> None:
+    """With country=["Germany"] active, country facet counts are NOT narrowed."""
+    fc = facet_counts(store, GrantFilters(country=["Germany"]))
+    c_counts = {item["value"]: item["count"] for item in fc["country"]}
+    assert "France" in c_counts
+
+
+def test_facet_counts_call_year_excluded_self(store: SnsfStore) -> None:
+    """With call_decision_year=[2020] active, call_decision_year facet not narrowed."""
+    fc = facet_counts(store, GrantFilters(call_decision_year=[_YEAR_2020]))
+    yr_values = {item["value"] for item in fc["call_decision_year"]}
+    assert _YEAR_2018 in yr_values
+    assert _YEAR_2015 in yr_values
+
+
+def test_facet_counts_with_text_filter(store: SnsfStore) -> None:
+    """text= narrows the base result set for all facets."""
+    fc = facet_counts(store, GrantFilters(), text="chemistry")
+    # Only G2 matches "chemistry" in keywords/abstract
+    fi_counts = {item["value"]: item["count"] for item in fc["funding_instrument"]}
+    assert fi_counts.get("Ambizione") == _ONE
+    assert "ProjectFunding" not in fi_counts


### PR DESCRIPTION
Phase B of the SNSF faceted query: the SQL query layer over the Phase-A facet tables (spec: `docs/superpowers/specs/2026-06-05-snsf-faceted-query-design.md`). No network, no embeddings; all user values parameterized.

`src/index/snsf/facet_query.py`:
- **`GrantFilters`** — every facet (funding scheme, institution, status, discipline, field of research, call year, country, person+role, output-presence, start/end date ranges).
- **`query_grants(store, filters, *, text, sort, limit, offset)`** → `{total, results}`. Free-text ILIKE on title/title_english/abstract/keywords; EXISTS joins to `grant_countries`/`grant_persons`; `has_output` via `grant_output_counts`; fixed-map sort (start_date / amount, asc/desc); result rows carry the output counts.
- **`facet_counts(store, filters, *, text)`** → per-facet value→count with **excluded-self semantics** (a facet's own active filter doesn't narrow its own counts) — the "fold" numbers the SNF site shows. 7 facets (6 column + country).

### Verified
- 47 Phase-B tests (every filter, text, 4 sorts, pagination, total-invariance, excluded-self counts) + the excluded-self semantics and **SQL-injection safety** confirmed by hand (a `DROP TABLE` in the text param did nothing).
- Full `tests/v2/` gate green.

Phase C (CLI `facet-search` + HTTP endpoints + federated `facet_query`) and D (agent tool) follow.