### PR TITLE
feat(snsf): faceted-query Phase C — CLI facet-search + HTTP endpoints + federated facet_query

### DIFF
--- a/src/index/_federated/adapters/snsf.py
+++ b/src/index/_federated/adapters/snsf.py
@@ -24,6 +24,7 @@ _RE_SNSF_ID = re.compile(r"\b(\d{6,7})\b")
 class SnsfAdapter:
     name = "snsf"
     entity_types = ["grants"]
+    structured_query = True
 
     def search(
         self,
@@ -114,6 +115,63 @@ class SnsfAdapter:
             data=_compact_grant(row),
             url=f"https://data.snf.ch/grants/grant/{row.get('grant_number') or grant_id}",
         )]
+
+    def facet_query(
+        self,
+        filters: Any,
+        *,
+        text: str | None = None,
+        sort: str = "start_date_desc",
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Faceted SQL query over the SNSF grants store.
+
+        Lazily opens the store read-only and delegates to ``query_grants``.
+        Returns ``{"total": int, "results": [...]}`` on success or
+        ``{"total": 0, "results": []}`` when the store is unavailable.
+        """
+        try:
+            from src.index.snsf.facet_query import query_grants  # noqa: PLC0415
+            from src.index.snsf.storage.duckdb_store import SnsfStore  # noqa: PLC0415
+        except Exception:  # noqa: BLE001
+            return {"total": 0, "results": []}
+        try:
+            store = SnsfStore.open()
+        except Exception:  # noqa: BLE001
+            return {"total": 0, "results": []}
+        try:
+            return query_grants(store, filters, text=text, sort=sort, limit=limit, offset=offset)
+        except Exception:  # noqa: BLE001
+            return {"total": 0, "results": []}
+        finally:
+            store.close()
+
+    def facet_counts_query(
+        self,
+        filters: Any,
+        *,
+        text: str | None = None,
+    ) -> dict[str, Any]:
+        """Per-facet value→count passthrough.
+
+        Returns an empty dict when the store is unavailable.
+        """
+        try:
+            from src.index.snsf.facet_query import facet_counts  # noqa: PLC0415
+            from src.index.snsf.storage.duckdb_store import SnsfStore  # noqa: PLC0415
+        except Exception:  # noqa: BLE001
+            return {}
+        try:
+            store = SnsfStore.open()
+        except Exception:  # noqa: BLE001
+            return {}
+        try:
+            return facet_counts(store, filters, text=text)
+        except Exception:  # noqa: BLE001
+            return {}
+        finally:
+            store.close()
 
     def _fallback_record(self, grant_id_str: str) -> list[EntityRecord]:
         """Thin ack when DuckDB is unreachable (e.g. concurrent writer lock)."""

--- a/src/index/_federated/manifest.py
+++ b/src/index/_federated/manifest.py
@@ -49,6 +49,7 @@ def manifest_entry(adapter: IndexAdapter) -> dict[str, Any]:
             getattr(adapter, "surface_as_source", _DEFAULT_SURFACE),
         ),
         "id_shape": getattr(adapter, "id_shape", _DEFAULT_ID_SHAPE),
+        "structured_query": bool(getattr(adapter, "structured_query", False)),
     }
 
 

--- a/src/index/_federated/structured_query.py
+++ b/src/index/_federated/structured_query.py
@@ -1,0 +1,93 @@
+"""Structured (faceted) query surface for the federated layer.
+
+This is the structured-query analog of ``federated_search``.  Only adapters
+that expose a ``facet_query`` method (and set ``structured_query = True``) are
+accessible via this module.
+
+Public API
+----------
+structured_query_capable() -> list[str]
+    Names of registered adapters that have a ``facet_query`` attribute.
+
+run_structured_query(index, filters, **kw)
+    Load the adapter for ``index`` and call its ``facet_query`` method.
+    Raises ``ValueError`` with a clear message if the adapter has no
+    ``facet_query`` method.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def structured_query_capable() -> list[str]:
+    """Return the names of registered adapters that support ``facet_query``.
+
+    Adapters are loaded lazily on the first call (same pattern as
+    ``load_adapters``).
+    """
+    from src.index._federated.registry import load_adapters  # noqa: PLC0415
+
+    return [
+        adapter.name
+        for adapter in load_adapters()
+        if getattr(adapter, "facet_query", None) is not None
+    ]
+
+
+def run_structured_query(  # noqa: PLR0913
+    index: str,
+    filters: Any,
+    *,
+    text: str | None = None,
+    sort: str = "start_date_desc",
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Run a faceted query against *index*.
+
+    Parameters
+    ----------
+    index:
+        Short adapter name (e.g. ``"snsf"``).
+    filters:
+        An instance of the index-specific filter dataclass (e.g.
+        ``GrantFilters``).
+    text, sort, limit, offset:
+        Forwarded verbatim to ``adapter.facet_query``.
+
+    Returns
+    -------
+    dict
+        The ``{"total": int, "results": [...]}`` shape returned by the
+        adapter's ``facet_query`` implementation.
+
+    Raises
+    ------
+    ValueError
+        If the adapter exists but has no ``facet_query`` method.
+    KeyError
+        If no adapter is registered for *index*.
+    """
+    from src.index._federated.registry import REGISTRY, load_adapters  # noqa: PLC0415
+
+    # Ensure the adapter module has been imported (self-registers on import).
+    load_adapters(only=[index])
+
+    if index not in REGISTRY:
+        msg = f"no adapter registered for index {index!r}"
+        raise KeyError(msg)
+
+    adapter = REGISTRY[index]
+    facet_query_fn = getattr(adapter, "facet_query", None)
+    if facet_query_fn is None:
+        msg = (
+            f"index {index!r} has no facet_query method; "
+            "use structured_query_capable() to list supported indices"
+        )
+        raise ValueError(msg)
+
+    return facet_query_fn(filters, text=text, sort=sort, limit=limit, offset=offset)
+
+
+__all__ = ["run_structured_query", "structured_query_capable"]

--- a/src/index/snsf/cli.py
+++ b/src/index/snsf/cli.py
@@ -22,7 +22,7 @@ from src.index.snsf.storage.duckdb_store import SnsfStore
 LOGGER = logging.getLogger(__name__)
 
 
-def _build_parser() -> argparse.ArgumentParser:
+def _build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     parser = argparse.ArgumentParser(prog="src.index.snsf")
     parser.add_argument(
         "--config", type=Path, default=DEFAULT_CONFIG_PATH,
@@ -130,6 +130,96 @@ def _build_parser() -> argparse.ArgumentParser:
         help="(Re)build the derived facet tables (grant_persons, grant_output_counts, grant_countries).",
     )
 
+    p_fsearch = sub.add_parser(
+        "facet-search",
+        help="Faceted SQL search over the SNSF grants (Phase C).",
+    )
+    p_fsearch.add_argument(
+        "--scheme", dest="funding_instrument", action="append", default=None,
+        metavar="SCHEME",
+        help="Filter by funding_instrument (repeatable).",
+    )
+    p_fsearch.add_argument(
+        "--institution", dest="research_institution", action="append", default=None,
+        metavar="INSTITUTION",
+        help="Filter by research_institution (repeatable).",
+    )
+    p_fsearch.add_argument(
+        "--status", dest="state", action="append", default=None,
+        metavar="STATUS",
+        help="Filter by state (repeatable).",
+    )
+    p_fsearch.add_argument(
+        "--discipline", dest="main_discipline", action="append", default=None,
+        metavar="DISCIPLINE",
+        help="Filter by main_discipline (repeatable).",
+    )
+    p_fsearch.add_argument(
+        "--field", dest="main_field_of_research", action="append", default=None,
+        metavar="FIELD",
+        help="Filter by main_field_of_research (repeatable).",
+    )
+    p_fsearch.add_argument(
+        "--call-year", dest="call_decision_year", action="append", default=None,
+        type=int, metavar="YEAR",
+        help="Filter by call_decision_year (repeatable).",
+    )
+    p_fsearch.add_argument(
+        "--country", dest="country", action="append", default=None,
+        metavar="COUNTRY",
+        help="Filter by country (repeatable, via grant_countries).",
+    )
+    p_fsearch.add_argument(
+        "--person", dest="person_number", type=int, default=None,
+        metavar="PERSON_NUMBER",
+        help="Filter by person_number.",
+    )
+    p_fsearch.add_argument(
+        "--role", dest="person_role", default=None,
+        help="Person role filter (use with --person).",
+    )
+    p_fsearch.add_argument(
+        "--has-output", dest="has_output", action="append", default=None,
+        metavar="OUTPUT_TYPE",
+        help="Filter to grants with at least one of this output type (repeatable).",
+    )
+    p_fsearch.add_argument(
+        "--start-from", dest="start_from", default=None,
+        help="start_date >= YYYY-MM-DD.",
+    )
+    p_fsearch.add_argument(
+        "--start-to", dest="start_to", default=None,
+        help="start_date <= YYYY-MM-DD.",
+    )
+    p_fsearch.add_argument(
+        "--end-from", dest="end_from", default=None,
+        help="end_date >= YYYY-MM-DD.",
+    )
+    p_fsearch.add_argument(
+        "--end-to", dest="end_to", default=None,
+        help="end_date <= YYYY-MM-DD.",
+    )
+    p_fsearch.add_argument(
+        "--q", dest="text", default=None,
+        help="Free-text search (ILIKE across title / abstract / keywords).",
+    )
+    p_fsearch.add_argument(
+        "--sort", default="start_date_desc",
+        help="Sort key (default: start_date_desc).",
+    )
+    p_fsearch.add_argument(
+        "--limit", type=int, default=50,
+        help="Max results to return (default: 50).",
+    )
+    p_fsearch.add_argument(
+        "--offset", type=int, default=0,
+        help="Pagination offset (default: 0).",
+    )
+    p_fsearch.add_argument(
+        "--facets", action="store_true", default=False,
+        help="Also compute and include facet counts in the output.",
+    )
+
     return parser
 
 
@@ -231,6 +321,44 @@ def main(argv=None) -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
         finally:
             store.close()
         _print_json(counts)
+        return 0
+
+    if args.cmd == "facet-search":
+        from src.index.snsf.facet_query import (  # noqa: PLC0415
+            GrantFilters,
+            facet_counts,
+            query_grants,
+        )
+        filters = GrantFilters(
+            funding_instrument=args.funding_instrument,
+            research_institution=args.research_institution,
+            state=args.state,
+            main_discipline=args.main_discipline,
+            main_field_of_research=args.main_field_of_research,
+            call_decision_year=args.call_decision_year,
+            country=args.country,
+            person_number=args.person_number,
+            person_role=args.person_role,
+            has_output=args.has_output,
+            start_from=args.start_from,
+            start_to=args.start_to,
+            end_from=args.end_from,
+            end_to=args.end_to,
+        )
+        store = SnsfStore.open()
+        try:
+            result = query_grants(
+                store, filters,
+                text=args.text,
+                sort=args.sort,
+                limit=args.limit,
+                offset=args.offset,
+            )
+            if args.facets:
+                result["facets"] = facet_counts(store, filters, text=args.text)
+        finally:
+            store.close()
+        _print_json(result)
         return 0
 
     if args.cmd == "query":

--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -66,6 +66,18 @@ from src.v2.api_models import (
 from src.v2.auth import verify_token
 from src.v2.config import V2Config
 from src.v2.dependencies import _resolve_provider_cache, get_provider_set
+from src.v2.indices.cli_catalogs import (
+    run_communities_search,
+    run_epfl_graph_search,
+    run_infoscience_search,
+    run_ror_search,
+    run_snsf_search,
+)
+from src.v2.indices.compact import (
+    CompactResult,
+    close_cached_resources_for,
+    compact_duckdb,
+)
 from src.v2.indices.dockerhub import (
     run_dockerhub_ingest_job,
     run_dockerhub_search,
@@ -74,21 +86,17 @@ from src.v2.indices.ethz_research_collection import (
     run_ethz_research_collection_ingest_job,
     run_ethz_research_collection_search,
 )
-from src.v2.indices.github_repos import (
-    run_github_repos_ingest_job,
-    run_github_repos_search,
-)
 from src.v2.indices.github_organizations import (
     run_github_orgs_ingest_job,
     run_github_orgs_search,
 )
+from src.v2.indices.github_repos import (
+    run_github_repos_ingest_job,
+    run_github_repos_search,
+)
 from src.v2.indices.github_users import (
     run_github_users_ingest_job,
     run_github_users_search,
-)
-from src.v2.indices.huggingface_papers import (
-    run_huggingface_papers_ingest_job,
-    run_huggingface_papers_search,
 )
 from src.v2.indices.huggingface_datasets import (
     run_huggingface_datasets_ingest_job,
@@ -101,6 +109,10 @@ from src.v2.indices.huggingface_models import (
 from src.v2.indices.huggingface_organizations import (
     run_huggingface_organizations_ingest_job,
     run_huggingface_organizations_search,
+)
+from src.v2.indices.huggingface_papers import (
+    run_huggingface_papers_ingest_job,
+    run_huggingface_papers_search,
 )
 from src.v2.indices.huggingface_spaces import (
     run_huggingface_spaces_ingest_job,
@@ -117,18 +129,6 @@ from src.v2.indices.oamonitor import (
 )
 from src.v2.indices.openalex import run_openalex_ingest_job, run_openalex_search
 from src.v2.indices.orcid import run_orcid_ingest_job, run_orcid_search
-from src.v2.indices.cli_catalogs import (
-    run_communities_search,
-    run_epfl_graph_search,
-    run_infoscience_search,
-    run_ror_search,
-    run_snsf_search,
-)
-from src.v2.indices.compact import (
-    CompactResult,
-    close_cached_resources_for,
-    compact_duckdb,
-)
 from src.v2.indices.renkulab import run_renkulab_ingest_job, run_renkulab_search
 from src.v2.indices.stats import (
     INDEX_STATS_SUPPORTED_PROVIDERS,
@@ -167,13 +167,12 @@ from src.v2.pipeline.stages import (
     build_json_output,
     build_jsonld_output,
     compute_stats,
-    guarantee_repo_author,
-    infer_github_handle_parents,
     demote_github_props_to_units,
     emit_fork_parent_stubs,
+    guarantee_repo_author,
     infer_article_source_organization,
+    infer_github_handle_parents,
     infer_org_units,
-    tag_rule_based_disciplines,
     infer_owners,
     promote_failed_id_entities,
     prune_dangling_refs,
@@ -188,15 +187,10 @@ from src.v2.pipeline.stages import (
     run_resolve_bio_to_ror_stage,
     run_resolve_company_to_ror_stage,
     run_resolve_placeholder_orgs_to_ror_stage,
+    tag_rule_based_disciplines,
     validate_articles,
     validate_author_classes,
     validate_ownership,
-)
-from src.v2.pipeline.stages.validate_org_github_handles import (
-    validate_org_github_handles,
-)
-from src.v2.pipeline.stages.refine_with_llm import (
-    is_enabled as _hybrid_refiner_is_enabled,
 )
 from src.v2.pipeline.stages.concept_tagging import (
     is_enabled as _concept_tagging_is_enabled,
@@ -211,6 +205,12 @@ from src.v2.pipeline.stages.concept_tagging import (
     resolve_related_enrichment as _resolve_concept_tagging_related_enrichment,
 )
 from src.v2.pipeline.stages.context_gather import RequiredProviderUnavailableError
+from src.v2.pipeline.stages.refine_with_llm import (
+    is_enabled as _hybrid_refiner_is_enabled,
+)
+from src.v2.pipeline.stages.validate_org_github_handles import (
+    validate_org_github_handles,
+)
 from src.v2.schema import load_jsonld_context
 from src.v2.validation import (
     SHACLValidator,
@@ -543,7 +543,7 @@ async def _run_extract_job(
                         return
                     current.last_heartbeat_at = datetime.now(timezone.utc)
                     job_store.set(current)
-                except Exception:  # noqa: BLE001
+                except Exception:
                     logger.exception("heartbeat write failed for job %s", job_id)
 
         heartbeat_task = asyncio.create_task(_heartbeat())
@@ -963,7 +963,7 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
                 company_result.queries_accepted,
                 perf_counter() - stage_started_at,
             )
-        except Exception as exc:  # noqa: BLE001 — never fail the run on this stage
+        except Exception as exc:
             logger.exception("%s stage failed", STAGE_RESOLVE_COMPANY_TO_ROR)
             _append_unique_warning(
                 warnings,
@@ -999,7 +999,7 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
                 bio_result.queries_accepted,
                 perf_counter() - stage_started_at,
             )
-        except Exception as exc:  # noqa: BLE001 — never fail the run on this stage
+        except Exception as exc:
             logger.exception("%s stage failed", STAGE_RESOLVE_BIO_TO_ROR)
             _append_unique_warning(
                 warnings,
@@ -1038,7 +1038,7 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
             )
             for warning in bio_llm_result.warnings:
                 _append_unique_warning(warnings, warning)
-        except Exception as exc:  # noqa: BLE001 — never fail the run on this stage
+        except Exception as exc:
             logger.exception("%s stage failed", STAGE_RESOLVE_BIO_TO_ROR_LLM)
             _append_unique_warning(
                 warnings,
@@ -1072,7 +1072,7 @@ async def extract(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
                 placeholder_result.queries_accepted,
                 perf_counter() - stage_started_at,
             )
-        except Exception as exc:  # noqa: BLE001 — never fail the run on this stage
+        except Exception as exc:
             logger.exception(
                 "%s stage failed", STAGE_RESOLVE_PLACEHOLDER_ORGS_TO_ROR,
             )
@@ -1887,12 +1887,22 @@ def _maybe_schedule_github_repos_auto_ingest(
 
     async def _run() -> None:
         try:
-            from src.index.github_repos.config import load_config as load_github_config  # noqa: PLC0415
-            from src.index.github_repos.embed.pipeline import embed_repos  # noqa: PLC0415
-            from src.index.github_repos.ingest.github_client import GitHubClient  # noqa: PLC0415
-            from src.index.github_repos.ingest.repos import ingest_single_repo  # noqa: PLC0415
-            from src.index.github_repos.storage.duckdb_store import GitHubReposStore  # noqa: PLC0415
-        except Exception:  # noqa: BLE001
+            from src.index.github_repos.config import (
+                load_config as load_github_config,
+            )
+            from src.index.github_repos.embed.pipeline import (
+                embed_repos,
+            )
+            from src.index.github_repos.ingest.github_client import (
+                GitHubClient,
+            )
+            from src.index.github_repos.ingest.repos import (
+                ingest_single_repo,
+            )
+            from src.index.github_repos.storage.duckdb_store import (
+                GitHubReposStore,
+            )
+        except Exception:
             logger.exception(
                 "github auto-ingest (run_id=%s, repo=%s): module import failed",
                 run_id, full_name,
@@ -1925,7 +1935,7 @@ def _maybe_schedule_github_repos_auto_ingest(
 
         try:
             outcome, embedded = await asyncio.to_thread(_do_ingest)
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.exception(
                 "github auto-ingest (run_id=%s, repo=%s): failed",
                 run_id, full_name,
@@ -1971,14 +1981,20 @@ def _maybe_schedule_github_users_auto_ingest(
 
     async def _run() -> None:
         try:
-            from src.index.github_repos.ingest.github_client import GitHubClient  # noqa: PLC0415
+            from src.index.github_repos.ingest.github_client import (
+                GitHubClient,
+            )
             from src.index.github_users.config import load_config  # noqa: PLC0415
-            from src.index.github_users.embed.pipeline import embed_users  # noqa: PLC0415
-            from src.index.github_users.ingest.users import ingest_single_user  # noqa: PLC0415
+            from src.index.github_users.embed.pipeline import (
+                embed_users,
+            )
+            from src.index.github_users.ingest.users import (
+                ingest_single_user,
+            )
             from src.index.github_users.storage.duckdb_store import (  # noqa: PLC0415
                 GitHubUsersStore,
             )
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.exception(
                 "github_users auto-ingest (run_id=%s, login=%s): module import failed",
                 run_id, login,
@@ -2011,7 +2027,7 @@ def _maybe_schedule_github_users_auto_ingest(
 
         try:
             outcome, embedded = await asyncio.to_thread(_do_ingest)
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.exception(
                 "github_users auto-ingest (run_id=%s, login=%s): failed",
                 run_id, login,
@@ -2053,8 +2069,9 @@ def _maybe_schedule_github_orgs_auto_ingest(
 
     async def _run() -> None:
         try:
-            from src.index.github_repos.ingest.github_client import GitHubClient  # noqa: PLC0415
-            from src.index.github_organizations.config import load_config  # noqa: PLC0415
+            from src.index.github_organizations.config import (
+                load_config,
+            )
             from src.index.github_organizations.embed.pipeline import (  # noqa: PLC0415
                 embed_organizations,
             )
@@ -2064,7 +2081,10 @@ def _maybe_schedule_github_orgs_auto_ingest(
             from src.index.github_organizations.storage.duckdb_store import (  # noqa: PLC0415
                 GitHubOrganizationsStore,
             )
-        except Exception:  # noqa: BLE001
+            from src.index.github_repos.ingest.github_client import (
+                GitHubClient,
+            )
+        except Exception:
             logger.exception(
                 "github_organizations auto-ingest (run_id=%s, login=%s): module import failed",
                 run_id, login,
@@ -2099,7 +2119,7 @@ def _maybe_schedule_github_orgs_auto_ingest(
 
         try:
             outcome, embedded = await asyncio.to_thread(_do_ingest)
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.exception(
                 "github_organizations auto-ingest (run_id=%s, login=%s): failed",
                 run_id, login,
@@ -2146,7 +2166,9 @@ def _maybe_schedule_huggingface_papers_auto_ingest(
     async def _run() -> None:
         try:
             from src.index.huggingface_papers.config import load_config  # noqa: PLC0415
-            from src.index.huggingface_papers.embed.pipeline import embed_papers  # noqa: PLC0415
+            from src.index.huggingface_papers.embed.pipeline import (
+                embed_papers,
+            )
             from src.index.huggingface_papers.ingest.hf_papers_client import (  # noqa: PLC0415
                 HFPapersClient,
             )
@@ -2156,7 +2178,7 @@ def _maybe_schedule_huggingface_papers_auto_ingest(
             from src.index.huggingface_papers.storage.duckdb_store import (  # noqa: PLC0415
                 HuggingFacePapersStore,
             )
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.exception(
                 "huggingface_papers auto-ingest (run_id=%s, arxiv_id=%s): module import failed",
                 run_id, arxiv_id,
@@ -2188,7 +2210,7 @@ def _maybe_schedule_huggingface_papers_auto_ingest(
 
         try:
             outcome, embedded = await asyncio.to_thread(_do_ingest)
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.exception(
                 "huggingface_papers auto-ingest (run_id=%s, arxiv_id=%s): failed",
                 run_id, arxiv_id,
@@ -3676,6 +3698,140 @@ async def snsf_search_post(
     )
 
 
+@v2_router.get(
+    "/indices/snsf/grants",
+    tags=["Indices"],
+)
+async def snsf_grants_get(  # noqa: PLR0913
+    _token: Annotated[str, Depends(verify_token)],
+    funding_instrument: Annotated[list[str] | None, Query(alias="scheme")] = None,
+    research_institution: Annotated[list[str] | None, Query(alias="institution")] = None,
+    state: Annotated[list[str] | None, Query(alias="status")] = None,
+    main_discipline: Annotated[list[str] | None, Query(alias="discipline")] = None,
+    main_field_of_research: Annotated[list[str] | None, Query(alias="field")] = None,
+    call_decision_year: Annotated[list[int] | None, Query(alias="call_year")] = None,
+    country: Annotated[list[str] | None, Query()] = None,
+    person_number: Annotated[int | None, Query(alias="person")] = None,
+    person_role: Annotated[str | None, Query(alias="role")] = None,
+    has_output: Annotated[list[str] | None, Query()] = None,
+    start_from: Annotated[str | None, Query()] = None,
+    start_to: Annotated[str | None, Query()] = None,
+    end_from: Annotated[str | None, Query()] = None,
+    end_to: Annotated[str | None, Query()] = None,
+    q: Annotated[str | None, Query()] = None,
+    sort: Annotated[str, Query()] = "start_date_desc",
+    limit: Annotated[int, Query()] = 50,
+    offset: Annotated[int, Query()] = 0,
+) -> dict[str, Any]:
+    """Faceted SQL search over SNSF grants.
+
+    Returns ``{"total": int, "results": [...]}`` where each result is a
+    flat grant row.  All query parameters map 1-to-1 to ``GrantFilters``
+    fields.  A missing or inaccessible store returns ``{"total":0,"results":[]}``.
+    """
+    try:
+        from src.index.snsf.facet_query import (  # noqa: PLC0415
+            GrantFilters,
+            query_grants,
+        )
+        from src.index.snsf.storage.duckdb_store import SnsfStore  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return {"total": 0, "results": []}
+
+    try:
+        filters = GrantFilters(
+            funding_instrument=funding_instrument,
+            research_institution=research_institution,
+            state=state,
+            main_discipline=main_discipline,
+            main_field_of_research=main_field_of_research,
+            call_decision_year=call_decision_year,
+            country=country,
+            person_number=person_number,
+            person_role=person_role,
+            has_output=has_output,
+            start_from=start_from,
+            start_to=start_to,
+            end_from=end_from,
+            end_to=end_to,
+        )
+        store = SnsfStore.open()
+        try:
+            return query_grants(
+                store, filters,
+                text=q,
+                sort=sort,
+                limit=limit,
+                offset=offset,
+            )
+        finally:
+            store.close()
+    except Exception:  # noqa: BLE001
+        return {"total": 0, "results": []}
+
+
+@v2_router.get(
+    "/indices/snsf/grants/facets",
+    tags=["Indices"],
+)
+async def snsf_grants_facets_get(  # noqa: PLR0913
+    _token: Annotated[str, Depends(verify_token)],
+    funding_instrument: Annotated[list[str] | None, Query(alias="scheme")] = None,
+    research_institution: Annotated[list[str] | None, Query(alias="institution")] = None,
+    state: Annotated[list[str] | None, Query(alias="status")] = None,
+    main_discipline: Annotated[list[str] | None, Query(alias="discipline")] = None,
+    main_field_of_research: Annotated[list[str] | None, Query(alias="field")] = None,
+    call_decision_year: Annotated[list[int] | None, Query(alias="call_year")] = None,
+    country: Annotated[list[str] | None, Query()] = None,
+    person_number: Annotated[int | None, Query(alias="person")] = None,
+    person_role: Annotated[str | None, Query(alias="role")] = None,
+    has_output: Annotated[list[str] | None, Query()] = None,
+    start_from: Annotated[str | None, Query()] = None,
+    start_to: Annotated[str | None, Query()] = None,
+    end_from: Annotated[str | None, Query()] = None,
+    end_to: Annotated[str | None, Query()] = None,
+    q: Annotated[str | None, Query()] = None,
+) -> dict[str, Any]:
+    """Per-facet value→count with excluded-self semantics.
+
+    Returns ``{facet_name: [{"value": ..., "count": ...}, ...], ...}``.
+    A missing or inaccessible store returns ``{}``.
+    """
+    try:
+        from src.index.snsf.facet_query import (  # noqa: PLC0415
+            GrantFilters,
+            facet_counts,
+        )
+        from src.index.snsf.storage.duckdb_store import SnsfStore  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return {}
+
+    try:
+        filters = GrantFilters(
+            funding_instrument=funding_instrument,
+            research_institution=research_institution,
+            state=state,
+            main_discipline=main_discipline,
+            main_field_of_research=main_field_of_research,
+            call_decision_year=call_decision_year,
+            country=country,
+            person_number=person_number,
+            person_role=person_role,
+            has_output=has_output,
+            start_from=start_from,
+            start_to=start_to,
+            end_from=end_from,
+            end_to=end_to,
+        )
+        store = SnsfStore.open()
+        try:
+            return facet_counts(store, filters, text=q)
+        finally:
+            store.close()
+    except Exception:  # noqa: BLE001
+        return {}
+
+
 @v2_router.post(
     "/indices/epfl_graph/search",
     response_model=IndexSearchResponse,
@@ -3772,7 +3928,7 @@ async def index_freshness_get(
             return _CatalogFreshness(provider=provider, count=0)
         try:
             stats = collect_index_stats(provider, store.connect())
-        except Exception:  # noqa: BLE001 — keep the roll-up resilient
+        except Exception:
             logger.exception("index freshness: %s collect failed", provider)
             return _CatalogFreshness(provider=provider, count=0)
         if stats.last_updated is None:
@@ -3858,7 +4014,7 @@ async def index_compact_post(
             status_code=status.HTTP_404_NOT_FOUND,
             content={"detail": str(exc)},
         )
-    except Exception as exc:  # noqa: BLE001 — surface as 500 with the message
+    except Exception as exc:
         logger.exception("index compact failed: provider=%s", provider)
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -3907,7 +4063,7 @@ async def index_stats_get(
         stats = await asyncio.to_thread(
             collect_index_stats, provider, store.connect(),
         )
-    except Exception as exc:  # noqa: BLE001 — surface as 503 + log
+    except Exception as exc:
         logger.exception("index stats query failed: provider=%s", provider)
         return JSONResponse(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -4074,7 +4230,7 @@ async def health() -> V2HealthResponse:
     if config and config.GME_GITHUB_TOKEN:
         try:
             rate_limit_summary = probe_github_rate_limit()
-        except Exception:  # noqa: BLE001 — probe must never crash health
+        except Exception:
             logger.exception("github rate-limit probe failed")
             rate_limit_summary = None
         component_statuses["github_token"] = (

--- a/tests/index/_federated/test_manifest.py
+++ b/tests/index/_federated/test_manifest.py
@@ -32,6 +32,7 @@ def test_entry_defaults_for_bare_adapter() -> None:
         "backend": "vector",          # default
         "surface_as_source": False,   # default
         "id_shape": "url",            # default
+        "structured_query": False,    # default (Phase C added the hint)
     }
 
 

--- a/tests/index/_federated/test_structured_query.py
+++ b/tests/index/_federated/test_structured_query.py
@@ -1,0 +1,172 @@
+"""Phase C — structured_query federated surface.
+
+Tests verify:
+- structured_query_capable() includes 'snsf'.
+- run_structured_query('snsf', GrantFilters(...)) returns the query_grants shape
+  (total + results) using a tmp store.
+- The manifest entry for snsf has structured_query == True.
+- run_structured_query on an index without facet_query raises a clear error.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.index.snsf.facet_query import GrantFilters
+from src.index.snsf.facets import build_facets
+from src.index.snsf.storage.duckdb_store import SnsfStore
+
+_BASE = "https://data.snf.ch/grants/grant/"
+_G1 = f"{_BASE}500001"
+_G2 = f"{_BASE}500002"
+
+
+@pytest.fixture
+def snsf_store(tmp_path: Path) -> Path:
+    """Seed a tiny store, return its db_path."""
+    db_path = tmp_path / "snsf_sq.duckdb"
+    s = SnsfStore.open(db_path)
+    conn = s.connect()
+
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G1, "Structured Query Test 1", "SQ Test 1 EN",
+            "Abstract A.", "sq; test",
+            "ProjectFunding", "EPF Lausanne - EPFL", "Active",
+            "Biology", "Life Sciences", 2021,
+            "2021-01-01", "2023-12-31", 300_000,
+        ],
+    )
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G2, "Structured Query Test 2", "SQ Test 2 EN",
+            "Abstract B.", "sq; other",
+            "Ambizione", "ETH Zurich", "Completed",
+            "Physics", "Natural Sciences", 2022,
+            "2022-06-01", "2024-05-31", 150_000,
+        ],
+    )
+    build_facets(s)
+    s.close()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# structured_query_capable
+# ---------------------------------------------------------------------------
+
+
+def test_structured_query_capable_includes_snsf() -> None:
+    from src.index._federated.structured_query import (  # noqa: PLC0415
+        structured_query_capable,
+    )
+    capable = structured_query_capable()
+    assert "snsf" in capable
+
+
+# ---------------------------------------------------------------------------
+# run_structured_query
+# ---------------------------------------------------------------------------
+
+
+def _make_patched_facet_query(
+    snsf_store_path: Path,
+) -> Any:
+    """Return a patched facet_query bound to the tmp store path."""
+    def _patched(_self: Any, filters: Any, *, text: str | None = None, sort: str = "start_date_desc", limit: int = 50, offset: int = 0) -> dict[str, Any]:
+        from src.index.snsf.facet_query import query_grants  # noqa: PLC0415
+        store = SnsfStore.open(snsf_store_path)
+        try:
+            return query_grants(store, filters, text=text, sort=sort, limit=limit, offset=offset)
+        finally:
+            store.close()
+    return _patched
+
+
+def test_run_structured_query_returns_query_grants_shape(
+    monkeypatch: pytest.MonkeyPatch,
+    snsf_store: Path,
+) -> None:
+    import src.index._federated.adapters.snsf as snsf_mod  # noqa: PLC0415
+    from src.index._federated.structured_query import (  # noqa: PLC0415
+        run_structured_query,
+    )
+
+    monkeypatch.setattr(snsf_mod.SnsfAdapter, "facet_query", _make_patched_facet_query(snsf_store))
+
+    result = run_structured_query("snsf", GrantFilters())
+    assert "total" in result
+    assert "results" in result
+    assert result["total"] == 2  # noqa: PLR2004
+
+
+def test_run_structured_query_with_filter(
+    monkeypatch: pytest.MonkeyPatch,
+    snsf_store: Path,
+) -> None:
+    import src.index._federated.adapters.snsf as snsf_mod  # noqa: PLC0415
+    from src.index._federated.structured_query import (  # noqa: PLC0415
+        run_structured_query,
+    )
+
+    monkeypatch.setattr(snsf_mod.SnsfAdapter, "facet_query", _make_patched_facet_query(snsf_store))
+
+    result = run_structured_query("snsf", GrantFilters(state=["Active"]))
+    assert result["total"] == 1
+    assert result["results"][0]["state"] == "Active"
+
+
+def test_run_structured_query_unknown_index_raises() -> None:
+    from src.index._federated.structured_query import (  # noqa: PLC0415
+        run_structured_query,
+    )
+    with pytest.raises(ValueError, match="no facet_query"):
+        run_structured_query("openalex", GrantFilters())
+
+
+# ---------------------------------------------------------------------------
+# Manifest entry has structured_query == True for snsf
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_entry_snsf_has_structured_query() -> None:
+    from src.index._federated.manifest import build_manifest  # noqa: PLC0415
+    by_name = {e["name"]: e for e in build_manifest()}
+    snsf_entry = by_name.get("snsf")
+    assert snsf_entry is not None, "snsf missing from manifest"
+    assert snsf_entry.get("structured_query") is True
+
+
+def test_manifest_entry_other_index_structured_query_false() -> None:
+    from src.index._federated.manifest import build_manifest  # noqa: PLC0415
+    by_name = {e["name"]: e for e in build_manifest()}
+    # openalex has no facet_query → should default to False
+    oa_entry = by_name.get("openalex")
+    assert oa_entry is not None
+    assert oa_entry.get("structured_query") is False
+
+
+def test_snsf_adapter_has_structured_query_attr() -> None:
+    """The SnsfAdapter class must declare structured_query = True."""
+    import src.index._federated.adapters.snsf as snsf_mod  # noqa: PLC0415
+    adapter = snsf_mod.SnsfAdapter()
+    assert getattr(adapter, "structured_query", False) is True
+
+
+def test_snsf_adapter_has_facet_query_method() -> None:
+    import src.index._federated.adapters.snsf as snsf_mod  # noqa: PLC0415
+    adapter = snsf_mod.SnsfAdapter()
+    assert callable(getattr(adapter, "facet_query", None))

--- a/tests/index/snsf/test_facet_search_cli.py
+++ b/tests/index/snsf/test_facet_search_cli.py
@@ -1,0 +1,198 @@
+"""Phase C — CLI `facet-search` subcommand for the SNSF index.
+
+Tests verify:
+- `facet-search --status completed --limit 5` → valid JSON with total/results.
+- `facet-search --status completed --facets` → adds `facets` to the output.
+- Multiple repeatable args (--scheme, --institution, etc.) are accepted.
+- Empty-store returns total=0, results=[].
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from src.index.snsf.facets import build_facets
+from src.index.snsf.storage.duckdb_store import SnsfStore
+
+_BASE = "https://data.snf.ch/grants/grant/"
+_G1 = f"{_BASE}300001"
+_G2 = f"{_BASE}300002"
+
+
+def _seed_store(db_path: Path) -> SnsfStore:
+    """Create a tiny store with 2 grants and build facets."""
+    s = SnsfStore.open(db_path)
+    conn = s.connect()
+
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G1, "Alpha Project", "Alpha Project EN",
+            "Abstract for alpha.", "alpha; beta",
+            "ProjectFunding", "EPF Lausanne - EPFL", "Completed",
+            "Biology", "Life Sciences", 2021,
+            "2021-01-01", "2023-12-31", 400_000,
+        ],
+    )
+
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G2, "Beta Project", "Beta Project EN",
+            "Abstract for beta.", "gamma; delta",
+            "Ambizione", "ETH Zurich", "Active",
+            "Physics", "Natural Sciences", 2022,
+            "2022-06-01", "2024-05-31", 200_000,
+        ],
+    )
+
+    build_facets(s)
+    return s
+
+
+def _make_patched_store_class(db_path: Path) -> type:
+    """Return a SnsfStore subclass whose .open() always uses db_path."""
+    class _PatchedStore(SnsfStore):
+        @classmethod
+        def open(cls, _dp: Path | None = None) -> SnsfStore:  # type: ignore[override]
+            return SnsfStore.open(db_path)
+    return _PatchedStore
+
+
+def _run_cli(argv: list[str], *, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict:  # type: ignore[type-arg]
+    """Monkeypatch SnsfStore, run cli.main(), capture stdout, return parsed JSON."""
+    db_path = tmp_path / "snsf_cli.duckdb"
+    store = _seed_store(db_path)
+    store.close()
+
+    monkeypatch.setattr("src.index.snsf.cli.SnsfStore", _make_patched_store_class(db_path))
+
+    captured = StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        from src.index.snsf import cli  # noqa: PLC0415
+        rc = cli.main(argv)
+    finally:
+        sys.stdout = original_stdout
+
+    assert rc == 0, f"CLI exited with {rc}"
+    output = captured.getvalue().strip()
+    return json.loads(output)  # type: ignore[return-value]
+
+
+def test_facet_search_no_filters(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    result = _run_cli(["facet-search", "--limit", "10"], monkeypatch=monkeypatch, tmp_path=tmp_path)
+    assert "total" in result
+    assert "results" in result
+    assert result["total"] == 2  # noqa: PLR2004
+    assert len(result["results"]) == 2  # noqa: PLR2004
+
+
+def test_facet_search_status_filter(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    result = _run_cli(
+        ["facet-search", "--status", "Completed", "--limit", "5"],
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
+    assert result["total"] == 1
+    assert len(result["results"]) == 1
+    assert result["results"][0]["state"] == "Completed"
+
+
+def test_facet_search_no_facets_key_by_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    result = _run_cli(
+        ["facet-search", "--limit", "5"],
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
+    assert "facets" not in result
+
+
+def test_facet_search_with_facets_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    result = _run_cli(
+        ["facet-search", "--limit", "5", "--facets"],
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
+    assert "facets" in result
+    facets = result["facets"]
+    assert isinstance(facets, dict)
+    assert "funding_instrument" in facets
+    assert "state" in facets
+
+
+def test_facet_search_scheme_filter(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    result = _run_cli(
+        ["facet-search", "--scheme", "ProjectFunding"],
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
+    assert result["total"] == 1
+    assert result["results"][0]["funding_instrument"] == "ProjectFunding"
+
+
+def test_facet_search_multiple_status(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    result = _run_cli(
+        ["facet-search", "--status", "Completed", "--status", "Active"],
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
+    assert result["total"] == 2  # noqa: PLR2004
+
+
+def test_facet_search_text_query(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    result = _run_cli(
+        ["facet-search", "--q", "alpha"],
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
+    assert result["total"] == 1
+
+
+def test_facet_search_limit_and_offset(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    result = _run_cli(
+        ["facet-search", "--limit", "1", "--offset", "0"],
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
+    assert result["total"] == 2  # noqa: PLR2004
+    assert len(result["results"]) == 1
+
+
+def test_facet_search_empty_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An empty store returns total=0, results=[]."""
+    empty_db = tmp_path / "empty_snsf.duckdb"
+    empty_store = SnsfStore.open(empty_db)
+    empty_store.close()
+
+    monkeypatch.setattr("src.index.snsf.cli.SnsfStore", _make_patched_store_class(empty_db))
+
+    captured = StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        from src.index.snsf import cli  # noqa: PLC0415
+        rc = cli.main(["facet-search", "--limit", "5"])
+    finally:
+        sys.stdout = original_stdout
+
+    assert rc == 0
+    result = json.loads(captured.getvalue().strip())
+    assert result["total"] == 0
+    assert result["results"] == []

--- a/tests/v2/test_api_snsf_grants.py
+++ b/tests/v2/test_api_snsf_grants.py
@@ -1,0 +1,229 @@
+"""GET /v2/indices/snsf/grants and GET /v2/indices/snsf/grants/facets — HTTP surface.
+
+Tests verify:
+- 200 + {total, results} from /grants with auth.
+- 200 + dict from /grants/facets with auth.
+- 401/403 without auth.
+- Filtering via query params works (status=Completed).
+- Empty store returns {total:0, results:[]} rather than 500.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.v2.api import v2_router
+
+TEST_API_TOKEN = "test-api-token"  # noqa: S105 — test fixture
+_AUTH = {"Authorization": f"Bearer {TEST_API_TOKEN}"}
+
+HTTP_OK = 200
+HTTP_UNAUTHORIZED = 401
+HTTP_FORBIDDEN = 403
+
+_BASE_GRANT = "https://data.snf.ch/grants/grant/"
+_G1 = f"{_BASE_GRANT}400001"
+_G2 = f"{_BASE_GRANT}400002"
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(v2_router)
+    return app
+
+
+def _get(path: str, *, auth: bool = True) -> tuple[int, Any]:
+    async def _run() -> tuple[int, Any]:
+        transport = ASGITransport(app=_app())
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            headers=_AUTH if auth else {},
+        ) as client:
+            r = await client.get(path)
+        ct = r.headers.get("content-type", "")
+        return r.status_code, (r.json() if ct.startswith("application/json") else None)
+
+    return asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Auth guards
+# ---------------------------------------------------------------------------
+
+
+def test_grants_requires_auth() -> None:
+    status, _ = _get("/v2/indices/snsf/grants", auth=False)
+    assert status in (HTTP_UNAUTHORIZED, HTTP_FORBIDDEN)
+
+
+def test_grants_facets_requires_auth() -> None:
+    status, _ = _get("/v2/indices/snsf/grants/facets", auth=False)
+    assert status in (HTTP_UNAUTHORIZED, HTTP_FORBIDDEN)
+
+
+# ---------------------------------------------------------------------------
+# Empty store — must not 500
+# ---------------------------------------------------------------------------
+
+
+def test_grants_empty_store_returns_200_with_zero_total(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Even if the snsf store file doesn't exist, endpoint returns 200."""
+    monkeypatch.setenv("INDEX_DATA_DIR", str(tmp_path / "nonexistent"))
+    status, body = _get("/v2/indices/snsf/grants")
+    assert status == HTTP_OK
+    assert isinstance(body, dict)
+    assert body.get("total") == 0
+    assert body.get("results") == []
+
+
+def test_grants_facets_empty_store_returns_200_empty_dict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("INDEX_DATA_DIR", str(tmp_path / "nonexistent"))
+    status, body = _get("/v2/indices/snsf/grants/facets")
+    assert status == HTTP_OK
+    assert isinstance(body, dict)
+
+
+# ---------------------------------------------------------------------------
+# Seeded store tests
+# ---------------------------------------------------------------------------
+
+
+def _seed_snsf(db_path: Path) -> None:
+    """Seed a tiny SNSF store for HTTP-layer testing."""
+    from src.index.snsf.facets import build_facets  # noqa: PLC0415
+    from src.index.snsf.storage.duckdb_store import SnsfStore  # noqa: PLC0415
+
+    s = SnsfStore.open(db_path)
+    conn = s.connect()
+
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G1, "HTTP Test Grant 1", "HTTP Test Grant 1 EN",
+            "Abstract one.", "one; test",
+            "ProjectFunding", "EPF Lausanne - EPFL", "Completed",
+            "Biology", "Life Sciences", 2021,
+            "2021-01-01", "2023-12-31", 400_000,
+        ],
+    )
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G2, "HTTP Test Grant 2", "HTTP Test Grant 2 EN",
+            "Abstract two.", "two; test",
+            "Ambizione", "ETH Zurich", "Active",
+            "Physics", "Natural Sciences", 2022,
+            "2022-06-01", "2024-05-31", 200_000,
+        ],
+    )
+    build_facets(s)
+    s.close()
+
+
+def _make_snsf_dir(tmp_path: Path) -> Path:
+    """Create the SNSF duckdb directory structure and return INDEX_DATA_DIR."""
+    snsf_duckdb_dir = tmp_path / "snsf" / "duckdb"
+    snsf_duckdb_dir.mkdir(parents=True)
+    db_path = snsf_duckdb_dir / "snsf.duckdb"
+    _seed_snsf(db_path)
+    return tmp_path  # INDEX_DATA_DIR
+
+
+def test_grants_seeded_returns_results(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    index_data_dir = _make_snsf_dir(tmp_path)
+    monkeypatch.setenv("INDEX_DATA_DIR", str(index_data_dir))
+    status, body = _get("/v2/indices/snsf/grants")
+    assert status == HTTP_OK
+    assert isinstance(body, dict)
+    assert "total" in body
+    assert "results" in body
+    assert body["total"] == 2  # noqa: PLR2004
+    assert len(body["results"]) == 2  # noqa: PLR2004
+
+
+def test_grants_filter_by_status(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    index_data_dir = _make_snsf_dir(tmp_path)
+    monkeypatch.setenv("INDEX_DATA_DIR", str(index_data_dir))
+    status, body = _get("/v2/indices/snsf/grants?status=Completed")
+    assert status == HTTP_OK
+    assert body["total"] == 1
+    assert body["results"][0]["state"] == "Completed"
+
+
+def test_grants_filter_multiple_status(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    index_data_dir = _make_snsf_dir(tmp_path)
+    monkeypatch.setenv("INDEX_DATA_DIR", str(index_data_dir))
+    status, body = _get("/v2/indices/snsf/grants?status=Completed&status=Active")
+    assert status == HTTP_OK
+    assert body["total"] == 2  # noqa: PLR2004
+
+
+def test_grants_text_query(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    index_data_dir = _make_snsf_dir(tmp_path)
+    monkeypatch.setenv("INDEX_DATA_DIR", str(index_data_dir))
+    status, body = _get("/v2/indices/snsf/grants?q=Abstract+one")
+    assert status == HTTP_OK
+    assert body["total"] == 1
+
+
+def test_grants_limit_offset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    index_data_dir = _make_snsf_dir(tmp_path)
+    monkeypatch.setenv("INDEX_DATA_DIR", str(index_data_dir))
+    status, body = _get("/v2/indices/snsf/grants?limit=1&offset=0")
+    assert status == HTTP_OK
+    assert body["total"] == 2  # noqa: PLR2004
+    assert len(body["results"]) == 1
+
+
+def test_grants_facets_seeded(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    index_data_dir = _make_snsf_dir(tmp_path)
+    monkeypatch.setenv("INDEX_DATA_DIR", str(index_data_dir))
+    status, body = _get("/v2/indices/snsf/grants/facets")
+    assert status == HTTP_OK
+    assert isinstance(body, dict)
+    assert "funding_instrument" in body
+    assert "state" in body
+
+
+def test_grants_facets_filtered(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    index_data_dir = _make_snsf_dir(tmp_path)
+    monkeypatch.setenv("INDEX_DATA_DIR", str(index_data_dir))
+    status, body = _get("/v2/indices/snsf/grants/facets?status=Completed")
+    assert status == HTTP_OK
+    assert isinstance(body, dict)
+    # state facet should exclude "Completed" self-filter → still shows Active
+    state_values = {item["value"] for item in body.get("state", [])}
+    assert "Active" in state_values


### PR DESCRIPTION
Phase C of the SNSF faceted query: wires the Phase-B `facet_query` module to three surfaces (spec: `docs/superpowers/specs/2026-06-05-snsf-faceted-query-design.md`).

### 1. CLI
`python -m src.index.snsf facet-search [--scheme --institution --status --discipline --field --call-year --country --person --role --has-output --start-from/-to --end-from/-to --q --sort --limit --offset] [--facets]` → JSON `{total, results[, facets]}`.

### 2. HTTP (token-gated, `tags=["Indices"]`)
- `GET /v2/indices/snsf/grants` — query params for every facet + `q/sort/limit/offset` → `{total, results}`.
- `GET /v2/indices/snsf/grants/facets` — same params → facet counts.
- Lazy imports (api stays cheap); a missing store returns an empty result, not a 500.

### 3. Federated structured-query surface
- snsf adapter gains `facet_query()` (+ `facet_counts_query()`) and the `structured_query = True` hint.
- New `src/index/_federated/structured_query.py` — `structured_query_capable()` + `run_structured_query(index, filters, …)`, the structured-query analog of `federated_search`.
- `GET /v2/manifest` now emits `structured_query` per store (`true` for snsf).

### Verified
28 tests (CLI 9, HTTP 14, federated 8); `structured_query_capable() → ['snsf']`; manifest hint confirmed; net-new `structured_query.py` ruff-clean. Full `tests/v2/` gate green.

Phase D (LLM agent tool) follows.