### PR TITLE
feat(snsf): faceted-query Phase D — LLM agent tool (search/facets/fetch)

### DIFF
--- a/src/v2/agents/llm/agent_tools/snsf_grants.py
+++ b/src/v2/agents/llm/agent_tools/snsf_grants.py
@@ -1,0 +1,198 @@
+"""Pydantic-AI Tools backed by :class:`SnsfGrantsProvider`.
+
+Three tools so the LLM can drive a search/facets/fetch loop over the SNSF
+P3 grants database:
+
+* ``search_snsf_grants`` — faceted + free-text search over ~90 k Swiss
+  National Science Foundation grants (thin rows).
+* ``snsf_grant_facets`` — per-facet value→count so the agent can discover
+  available filter values.
+* ``fetch_snsf_grant`` — full grant record (incl. abstract / lay summaries)
+  by grant number or URL.
+
+Splitting search from fetch keeps prompts small: search returns thin hits
+(grant_number URL, title, applicant, institution, scheme, discipline, state,
+dates, amount, output counts) and the agent decides when to spend the context
+budget on a full body.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pydantic_ai import Tool
+
+from src.v2.observation.query_log import record_query
+
+if TYPE_CHECKING:
+    from src.v2.ingest.providers.snsf_grants import SnsfGrantsProvider
+
+logger = logging.getLogger(__name__)
+
+_SEARCH_DESCRIPTION = (
+    "Faceted + free-text search over the SNSF P3 grants database (~90 k "
+    "Swiss National Science Foundation grants). Use this when README / "
+    "CITATION / metadata mentions an SNSF grant, a Swiss-funded project, "
+    "or a PI at a Swiss institution, or to enrich an entity with its SNSF "
+    "grants. "
+    "Filter params: `funding_instrument` (e.g. 'ProjectFunding', 'Ambizione', "
+    "'NCCR'), `research_institution` (e.g. 'EPF Lausanne - EPFL', 'ETH Zurich'), "
+    "`state` (e.g. 'Active', 'Completed'), `main_discipline`, "
+    "`main_field_of_research`, `country` (collaboration country), "
+    "`person_number` (SNSF person id int), `has_output` (list of output types "
+    "e.g. ['publications', 'datasets']), `start_from`/`start_to` (ISO date "
+    "strings, e.g. '2020-01-01'). All list filters are OR within the list. "
+    "`text` is a free-text ILIKE match across title/abstract/keywords. "
+    "`sort`: 'start_date_desc' (default), 'start_date_asc', 'amount_desc', "
+    "'amount_asc'. `limit`: default 20. "
+    "Returns thin rows (grant_number URL, title, title_english, "
+    "responsible_applicant, research_institution, main_discipline, "
+    "funding_instrument, keywords, state, start_date, end_date, "
+    "amount_granted, n_publications, n_datasets, n_collaborations). "
+    "Call fetch_snsf_grant with a grant_number to get the full record "
+    "including abstract and lay summaries."
+)
+
+_FACETS_DESCRIPTION = (
+    "Return per-facet value→count for the SNSF grants database given the "
+    "current filter set (excluded-self semantics: each facet's counts are "
+    "computed without that facet's own active filter). Use this to discover "
+    "available filter values before or alongside search_snsf_grants. "
+    "Accepts the same filter params as search_snsf_grants."
+)
+
+_FETCH_DESCRIPTION = (
+    "Fetch the full SNSF grant record (including abstract and lay summaries "
+    "in EN/DE/FR/IT) by grant_number (canonical URL like "
+    "'https://data.snf.ch/grants/grant/12345' or bare integer string). "
+    "Use only after a promising search hit — it spends meaningful context "
+    "budget. Returns the complete grants table row."
+)
+
+
+def _service_name(op: str) -> str:
+    return f"snsf_grants.{op}"
+
+
+def make_search_snsf_grants_tool(provider: SnsfGrantsProvider) -> Tool:
+    """Tool factory: faceted + free-text search over SNSF grants."""
+
+    async def search_snsf_grants(  # noqa: PLR0913
+        funding_instrument: list[str] | None = None,
+        research_institution: list[str] | None = None,
+        state: list[str] | None = None,
+        main_discipline: list[str] | None = None,
+        main_field_of_research: list[str] | None = None,
+        country: list[str] | None = None,
+        person_number: int | None = None,
+        has_output: list[str] | None = None,
+        start_from: str | None = None,
+        start_to: str | None = None,
+        text: str | None = None,
+        sort: str = "start_date_desc",
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Faceted + free-text search over SNSF P3 grants. See tool description."""
+        from src.index.snsf.facet_query import GrantFilters  # noqa: PLC0415
+
+        logger.info(
+            "tool call: search_snsf_grants — state=%r institution=%r text=%r limit=%d",
+            state, research_institution, text, limit,
+        )
+        record_query(
+            service=_service_name("search"),
+            query=text or str(state or ""),
+        )
+        filters = GrantFilters(
+            funding_instrument=funding_instrument,
+            research_institution=research_institution,
+            state=state,
+            main_discipline=main_discipline,
+            main_field_of_research=main_field_of_research,
+            country=country,
+            person_number=person_number,
+            has_output=has_output,
+            start_from=start_from,
+            start_to=start_to,
+        )
+        return provider.search(filters, text=text, sort=sort, limit=limit)
+
+    return Tool(
+        search_snsf_grants,
+        name="search_snsf_grants",
+        description=_SEARCH_DESCRIPTION,
+    )
+
+
+def make_snsf_grant_facets_tool(provider: SnsfGrantsProvider) -> Tool:
+    """Tool factory: facet counts for a filter set."""
+
+    async def snsf_grant_facets(  # noqa: PLR0913
+        funding_instrument: list[str] | None = None,
+        research_institution: list[str] | None = None,
+        state: list[str] | None = None,
+        main_discipline: list[str] | None = None,
+        main_field_of_research: list[str] | None = None,
+        country: list[str] | None = None,
+        person_number: int | None = None,
+        has_output: list[str] | None = None,
+        start_from: str | None = None,
+        start_to: str | None = None,
+        text: str | None = None,
+    ) -> dict[str, Any]:
+        """Return facet counts for the SNSF grants database. See tool description."""
+        from src.index.snsf.facet_query import GrantFilters  # noqa: PLC0415
+
+        logger.info("tool call: snsf_grant_facets — state=%r text=%r", state, text)
+        record_query(
+            service=_service_name("facets"),
+            query=text or str(state or ""),
+        )
+        filters = GrantFilters(
+            funding_instrument=funding_instrument,
+            research_institution=research_institution,
+            state=state,
+            main_discipline=main_discipline,
+            main_field_of_research=main_field_of_research,
+            country=country,
+            person_number=person_number,
+            has_output=has_output,
+            start_from=start_from,
+            start_to=start_to,
+        )
+        return provider.facets(filters, text=text)
+
+    return Tool(
+        snsf_grant_facets,
+        name="snsf_grant_facets",
+        description=_FACETS_DESCRIPTION,
+    )
+
+
+def make_fetch_snsf_grant_tool(provider: SnsfGrantsProvider) -> Tool:
+    """Tool factory: fetch the full grant record by grant_number."""
+
+    async def fetch_snsf_grant(
+        grant_number: str,
+    ) -> dict[str, Any] | None:
+        """Fetch full SNSF grant record incl. abstract. See tool description."""
+        logger.info("tool call: fetch_snsf_grant — grant_number=%s", grant_number)
+        record_query(
+            service=_service_name("fetch"),
+            query=grant_number,
+        )
+        return provider.fetch(grant_number)
+
+    return Tool(
+        fetch_snsf_grant,
+        name="fetch_snsf_grant",
+        description=_FETCH_DESCRIPTION,
+    )
+
+
+__all__ = [
+    "make_fetch_snsf_grant_tool",
+    "make_search_snsf_grants_tool",
+    "make_snsf_grant_facets_tool",
+]

--- a/src/v2/ingest/providers/snsf_grants.py
+++ b/src/v2/ingest/providers/snsf_grants.py
@@ -1,0 +1,145 @@
+"""SnsfGrantsProvider — thin read-only facade over the SNSF DuckDB store.
+
+Used by the LLM agent tool factories in
+``src.v2.agents.llm.agent_tools.snsf_grants``.
+
+The provider is cheap to construct (no DB opened at init) and opens a
+read-only DuckDB connection only for the duration of each method call, so
+it is safe to run alongside a concurrent writer.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from src.index.snsf.facet_query import GrantFilters
+
+logger = logging.getLogger(__name__)
+
+
+class _ROStore:
+    """Minimal shim that exposes ``connect()`` backed by a read-only DuckDB
+    connection.  ``query_grants`` and ``facet_counts`` only call
+    ``store.connect()`` so this is sufficient.
+    """
+
+    def __init__(self, conn: Any) -> None:  # conn: duckdb.DuckDBPyConnection
+        self._conn = conn
+
+    def connect(self) -> Any:
+        return self._conn
+
+
+class SnsfGrantsProvider:
+    """Read-only query provider for the SNSF P3 DuckDB store.
+
+    Parameters
+    ----------
+    store_path:
+        Path to the ``snsf.duckdb`` file.  Defaults to the canonical path
+        returned by :func:`src.index.snsf.paths.duckdb_path`.  The file is
+        **not** opened at construction time.
+    """
+
+    def __init__(self, store_path: Path | None = None) -> None:
+        if store_path is None:
+            from src.index.snsf.paths import duckdb_path  # noqa: PLC0415
+
+            store_path = duckdb_path()
+        self._store_path = store_path
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        filters: GrantFilters,
+        *,
+        text: str | None = None,
+        sort: str = "start_date_desc",
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Faceted + free-text grant search.
+
+        Returns the thin result rows (grant_number, title, state, dates,
+        amount, output counts …) produced by :func:`query_grants`.  Returns
+        ``[]`` if the store file is absent or unreadable.
+        """
+        if not self._store_path.exists():
+            return []
+        try:
+            import duckdb  # noqa: PLC0415
+
+            from src.index.snsf.facet_query import query_grants  # noqa: PLC0415
+
+            with duckdb.connect(str(self._store_path), read_only=True) as conn:
+                store = _ROStore(conn)
+                result = query_grants(store, filters, text=text, sort=sort, limit=limit)
+                return result["results"]
+        except Exception:
+            logger.exception("snsf_grants.search failed; returning []")
+            return []
+
+    def facets(
+        self,
+        filters: GrantFilters,
+        *,
+        text: str | None = None,
+    ) -> dict[str, Any]:
+        """Facet counts (excluded-self semantics) for the current filter set.
+
+        Returns ``{}`` if the store file is absent or unreadable.
+        """
+        if not self._store_path.exists():
+            return {}
+        try:
+            import duckdb  # noqa: PLC0415
+
+            from src.index.snsf.facet_query import facet_counts  # noqa: PLC0415
+
+            with duckdb.connect(str(self._store_path), read_only=True) as conn:
+                store = _ROStore(conn)
+                return facet_counts(store, filters, text=text)
+        except Exception:
+            logger.exception("snsf_grants.facets failed; returning {}")
+            return {}
+
+    def fetch(self, grant_number: str) -> dict[str, Any] | None:
+        """Fetch the full grant row (incl. abstract / lay summaries).
+
+        Accepts the canonical grant URL or a bare integer string / int.
+        Returns ``None`` if the store file is absent, the grant is not found,
+        or the store is unreadable.
+        """
+        if not self._store_path.exists():
+            return None
+        try:
+            import duckdb  # noqa: PLC0415
+
+            from src.v2.canonicalization.snsf import snsf_grant_iri  # noqa: PLC0415
+
+            canonical = snsf_grant_iri(grant_number) or grant_number
+            with duckdb.connect(str(self._store_path), read_only=True) as conn:
+                cur = conn.execute(
+                    "SELECT * FROM grants WHERE grant_number = ?",
+                    [canonical],
+                )
+                row = cur.fetchone()
+                if row is None:
+                    return None
+                cols = [d[0] for d in cur.description]
+                result: dict[str, Any] = {}
+                for col, val in zip(cols, row, strict=False):
+                    result[col] = val.isoformat() if hasattr(val, "isoformat") else val
+                return result
+        except Exception:
+            logger.exception("snsf_grants.fetch failed; returning None")
+            return None
+
+
+__all__ = ["SnsfGrantsProvider"]

--- a/src/v2/pipeline/stages/refine_with_llm.py
+++ b/src/v2/pipeline/stages/refine_with_llm.py
@@ -1603,6 +1603,10 @@ async def _run_org_resolver_pass(
     from src.v2.agents.llm.agent_tools.github_organization import (  # noqa: PLC0415
         make_github_organization_metadata_tool,
     )
+    from src.v2.agents.llm.agent_tools.snsf_grants import (  # noqa: PLC0415
+        make_search_snsf_grants_tool,
+    )
+    from src.v2.ingest.providers.snsf_grants import SnsfGrantsProvider  # noqa: PLC0415
 
     tools: list[Any] = []
     if getattr(providers, "ror_rag", None) is not None:
@@ -1613,6 +1617,7 @@ async def _run_org_resolver_pass(
         tools.append(make_epfl_graph_rag_search_tool(providers.epfl_graph_rag))
     if getattr(providers, "github", None) is not None:
         tools.append(make_github_organization_metadata_tool(providers.github))
+    tools.append(make_search_snsf_grants_tool(SnsfGrantsProvider()))
 
     if not tools:
         return (

--- a/tests/v2/test_agent_tool_snsf_grants.py
+++ b/tests/v2/test_agent_tool_snsf_grants.py
@@ -1,0 +1,264 @@
+"""Phase D: SNSF LLM agent tool — SnsfGrantsProvider + tool factories.
+
+Tests cover:
+- provider.search(GrantFilters(state=["Completed"])) returns matching thin rows.
+- provider.fetch(<grant_url>) returns the full row incl. abstract.
+- provider.facets(...) returns a dict of facet counts.
+- make_search_snsf_grants_tool(provider) returns a Tool with the right name,
+  and calling its .function(state=["Completed"]) returns the matching rows.
+- Absent-store guard: provider pointed at a non-existent path → search returns [],
+  fetch returns None (no exception).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from src.index.snsf.facet_query import GrantFilters
+from src.index.snsf.facets import build_facets
+from src.index.snsf.storage.duckdb_store import SnsfStore
+from src.v2.agents.llm.agent_tools.snsf_grants import (
+    make_fetch_snsf_grant_tool,
+    make_search_snsf_grants_tool,
+    make_snsf_grant_facets_tool,
+)
+from src.v2.ingest.providers.snsf_grants import SnsfGrantsProvider
+
+_BASE = "https://data.snf.ch/grants/grant/"
+_G1 = f"{_BASE}300001"
+_G2 = f"{_BASE}300002"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Build and seed a tiny SnsfStore, close it, then return its path.
+
+    The store is fully closed before the fixture yields so that the
+    SnsfGrantsProvider (which opens a *read-only* DuckDB connection) can
+    open the same file without a conflicting-configuration error.
+    """
+    path = tmp_path / "snsf_tool_test.duckdb"
+    s = SnsfStore.open(path)
+    conn = s.connect()
+
+    # Grant 1 — Active / ProjectFunding / EPFL
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G1, "Projet actif en biologie",
+            "Active biology project",
+            "Detailed abstract about cell membrane proteins.",
+            "membrane; protein; biology",
+            "ProjectFunding", "EPF Lausanne - EPFL", "Active",
+            "Biology", "Life Sciences", 2022,
+            "2022-01-01", "2024-12-31", 450_000,
+        ],
+    )
+
+    # G2: Completed / Ambizione / ETH Zurich
+    conn.execute(
+        "INSERT INTO grants "
+        "(grant_number, title, title_english, abstract, keywords, "
+        " funding_instrument, research_institution, state, main_discipline, "
+        " main_field_of_research, call_decision_year, start_date, end_date, amount_granted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            _G2, "Synthèse chimique verte",
+            "Green chemical synthesis",
+            "Completed study on sustainable catalysis and green chemistry methods.",
+            "catalyst; green; chemistry",
+            "Ambizione", "ETH Zurich", "Completed",
+            "Chemistry", "Natural Sciences", 2018,
+            "2018-06-01", "2021-05-31", 300_000,
+        ],
+    )
+
+    # One publication output for G1
+    conn.execute(
+        "INSERT INTO output_publications (publication_id, grant_number) VALUES ('pub1', ?)",
+        [_G1],
+    )
+
+    # One person linked to both grants
+    conn.execute(
+        "INSERT INTO persons (person_number, responsible_applicant_grants) VALUES (?, ?)",
+        [42, json.dumps([_G1, _G2])],
+    )
+
+    build_facets(s)
+    # Close the store so the provider can open the file read-only.
+    s.close()
+    return path
+
+
+@pytest.fixture
+def provider(db_path: Path) -> SnsfGrantsProvider:
+    return SnsfGrantsProvider(store_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# SnsfGrantsProvider.search
+# ---------------------------------------------------------------------------
+
+
+def test_provider_search_returns_matching_thin_rows(provider: SnsfGrantsProvider) -> None:
+    rows = provider.search(GrantFilters(state=["Completed"]))
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["grant_number"] == _G2
+    assert row["state"] == "Completed"
+    # thin row — has title but NOT abstract (query_grants does not select abstract)
+    assert "title" in row
+    assert "abstract" not in row
+
+
+def test_provider_search_all_no_filter(provider: SnsfGrantsProvider) -> None:
+    rows = provider.search(GrantFilters())
+    assert len(rows) == 2  # noqa: PLR2004
+
+
+def test_provider_search_with_text(provider: SnsfGrantsProvider) -> None:
+    rows = provider.search(GrantFilters(), text="catalysis")
+    assert len(rows) == 1
+    assert rows[0]["grant_number"] == _G2
+
+
+def test_provider_search_limit(provider: SnsfGrantsProvider) -> None:
+    rows = provider.search(GrantFilters(), limit=1)
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# SnsfGrantsProvider.fetch
+# ---------------------------------------------------------------------------
+
+
+def test_provider_fetch_returns_full_row_with_abstract(provider: SnsfGrantsProvider) -> None:
+    row = provider.fetch(_G1)
+    assert row is not None
+    assert row["grant_number"] == _G1
+    # full row includes abstract
+    assert row["abstract"] == "Detailed abstract about cell membrane proteins."
+
+
+def test_provider_fetch_returns_none_for_missing_grant(provider: SnsfGrantsProvider) -> None:
+    row = provider.fetch("https://data.snf.ch/grants/grant/999999")
+    assert row is None
+
+
+# ---------------------------------------------------------------------------
+# SnsfGrantsProvider.facets
+# ---------------------------------------------------------------------------
+
+
+def test_provider_facets_returns_dict(provider: SnsfGrantsProvider) -> None:
+    facets = provider.facets(GrantFilters())
+    assert isinstance(facets, dict)
+    # state facet should contain both Active and Completed
+    state_values = {item["value"] for item in facets.get("state", [])}
+    assert "Active" in state_values
+    assert "Completed" in state_values
+
+
+def test_provider_facets_with_text_filter(provider: SnsfGrantsProvider) -> None:
+    facets = provider.facets(GrantFilters(), text="biology")
+    assert isinstance(facets, dict)
+
+
+# ---------------------------------------------------------------------------
+# Absent-store guard
+# ---------------------------------------------------------------------------
+
+
+def test_absent_store_search_returns_empty(tmp_path: Path) -> None:
+    p = SnsfGrantsProvider(store_path=tmp_path / "nonexistent.duckdb")
+    result = p.search(GrantFilters())
+    assert result == []
+
+
+def test_absent_store_fetch_returns_none(tmp_path: Path) -> None:
+    p = SnsfGrantsProvider(store_path=tmp_path / "nonexistent.duckdb")
+    result = p.fetch(_G1)
+    assert result is None
+
+
+def test_absent_store_facets_returns_empty_dict(tmp_path: Path) -> None:
+    p = SnsfGrantsProvider(store_path=tmp_path / "nonexistent.duckdb")
+    result = p.facets(GrantFilters())
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Provider is cheap to construct (does NOT open/create the DB)
+# ---------------------------------------------------------------------------
+
+
+def test_provider_construction_does_not_create_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "no_create.duckdb"
+    _p = SnsfGrantsProvider(store_path=db_path)
+    assert not db_path.exists(), "constructor must not create the DB file"
+
+
+# ---------------------------------------------------------------------------
+# Tool factories
+# ---------------------------------------------------------------------------
+
+
+def _run(coro):  # type: ignore[no-untyped-def]
+    return asyncio.run(coro)
+
+
+def test_make_search_snsf_grants_tool_name_and_result(provider: SnsfGrantsProvider) -> None:
+    tool = make_search_snsf_grants_tool(provider)
+    assert tool.name == "search_snsf_grants"
+
+    # Call the underlying function with state filter → only Completed grant
+    rows = _run(tool.function(state=["Completed"]))
+    assert len(rows) == 1
+    assert rows[0]["grant_number"] == _G2
+
+
+def test_make_search_snsf_grants_tool_no_filter(provider: SnsfGrantsProvider) -> None:
+    tool = make_search_snsf_grants_tool(provider)
+    rows = _run(tool.function())
+    assert len(rows) == 2  # noqa: PLR2004
+
+
+def test_make_snsf_grant_facets_tool_name(provider: SnsfGrantsProvider) -> None:
+    tool = make_snsf_grant_facets_tool(provider)
+    assert tool.name == "snsf_grant_facets"
+    result = _run(tool.function())
+    assert isinstance(result, dict)
+    assert "state" in result
+
+
+def test_make_fetch_snsf_grant_tool_name_and_result(provider: SnsfGrantsProvider) -> None:
+    tool = make_fetch_snsf_grant_tool(provider)
+    assert tool.name == "fetch_snsf_grant"
+
+    row = _run(tool.function(grant_number=_G2))
+    assert row is not None
+    assert row["grant_number"] == _G2
+    assert "abstract" in row
+
+
+def test_make_fetch_snsf_grant_tool_missing(provider: SnsfGrantsProvider) -> None:
+    tool = make_fetch_snsf_grant_tool(provider)
+    row = _run(tool.function(grant_number="https://data.snf.ch/grants/grant/999999"))
+    assert row is None


### PR DESCRIPTION
Final phase of the SNSF faceted query: exposes it as **LLM agent tools** so the agent can query SNSF grants by facet/text and pull a grant's full record mid-reasoning.

- **`src/v2/ingest/providers/snsf_grants.py`** — `SnsfGrantsProvider` (lazy, opens the snsf store **read-only** via a small shim so it's safe alongside a writer). `search` / `facets` / `fetch`, each guarded → `[]`/`{}`/`None` if the store/facets are absent.
- **`src/v2/agents/llm/agent_tools/snsf_grants.py`** — three pydantic-ai `Tool` factories mirroring the per-index RAG-tool pattern: `search_snsf_grants` (faceted + free-text → thin hits), `snsf_grant_facets` (facet counts), `fetch_snsf_grant` (full record incl. abstract, split to keep prompts small). `record_query`-logged like the siblings.
- **Wired** into `refine_with_llm.py` alongside the other RAG tools, so the refine agent gets the search tool.

### Verified
17 tests (provider search/facets/fetch + absent-store guard + the 3 tool factories produce real Tools); the wired refine stage imports cleanly; ruff clean. Full `tests/v2/` gate: **1485 passed**.

**This completes the SNSF faceted query (Phases A–D):** derived facet tables + build_facets + bootstrap hook → `facet_query` module (query + counts) → CLI + HTTP endpoints + federated structured-query → agent tool.