### PR TITLE
feat(v2): repo enrichment fields — gme-internal hasCi, testCoverage, dockerHubUrl, latestVersion

### DIFF
--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -1,0 +1,180 @@
+"""Deterministic signal extractors for repository enrichment fields.
+
+These are pure functions (no I/O, no LLM) used by ``repository_agent.py``
+to surface ``gme-internal:*`` fields from already-gathered context data
+(README text, aux-files, root-listing entries).
+
+Public surface
+--------------
+parse_test_coverage(readme)  →  "87%" | None
+parse_docker_hub_url(readme, aux_files)  →  URL | None
+detect_has_ci(root_entries)  →  True | False | None
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# _has_ci detection
+# ---------------------------------------------------------------------------
+
+# Root-level names (case-insensitive) that indicate a CI/CD configuration.
+_CI_INDICATORS: frozenset[str] = frozenset({
+    ".github",
+    ".gitlab-ci.yml",
+    ".travis.yml",
+    ".circleci",
+    "azure-pipelines.yml",
+    "jenkinsfile",
+    ".drone.yml",
+    "bitbucket-pipelines.yml",
+    ".woodpecker.yml",
+})
+
+
+def detect_has_ci(root_entries: list[str] | None) -> bool | None:
+    """Return True if any known CI indicator is in *root_entries*, False if
+    the list is available but empty / contains no CI files, or None when
+    the listing was not available (caller passed None).
+
+    Comparison is case-insensitive so repos that capitalise their
+    dotfiles are handled correctly.
+    """
+    if root_entries is None:
+        return None
+    for name in root_entries:
+        if isinstance(name, str) and name.lower() in _CI_INDICATORS:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# parse_test_coverage
+# ---------------------------------------------------------------------------
+
+# (a) Static shields.io badge embedding the number:
+#   https://img.shields.io/badge/coverage-87%25-green   (%25 is URL-encoded %)
+#   https://img.shields.io/badge/coverage-87%-green     (literal %)
+#   alt-text form: coverage-87%
+_SHIELDS_COVERAGE_RE = re.compile(
+    r"coverage[-_](\d+)(?:%25|%)",
+    re.IGNORECASE,
+)
+
+# (b) Plain-text: "coverage: 87%" / "test coverage: 87%"
+_TEXT_COVERAGE_RE = re.compile(
+    r"(?:test\s+)?coverage\s*:\s*(\d+)\s*%",
+    re.IGNORECASE,
+)
+
+
+def parse_test_coverage(readme: str | None) -> str | None:
+    """Extract a static test-coverage percentage from *readme*.
+
+    Returns the percentage as a string like ``"87%"`` when found, or
+    ``None`` when no static number appears in the README (dynamic
+    badges — codecov/coveralls URLs without an embedded number — also
+    return ``None``).
+
+    Search order:
+    1. shields.io badge with embedded number (``coverage-87%25`` or
+       ``coverage-87%`` in the image URL or alt-text).
+    2. Plain-text pattern (``coverage: 87%`` / ``test coverage: 87%``).
+    """
+    if not isinstance(readme, str) or not readme:
+        return None
+
+    m = _SHIELDS_COVERAGE_RE.search(readme)
+    if m:
+        return f"{m.group(1)}%"
+
+    m = _TEXT_COVERAGE_RE.search(readme)
+    if m:
+        return f"{m.group(1)}%"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# parse_docker_hub_url
+# ---------------------------------------------------------------------------
+
+# Direct Docker Hub URL: https://hub.docker.com/r/<ns>/<name>
+_DOCKERHUB_URL_RE = re.compile(
+    r"https://hub\.docker\.com/r/([\w.-]+/[\w.-]+?)(?:[/\s\"')>]|$)",
+    re.IGNORECASE,
+)
+
+# docker pull <ns>/<name>[:<tag>]
+# docker run [opts] <ns>/<name>[:<tag>]
+_DOCKER_PULL_RUN_RE = re.compile(
+    r"docker\s+(?:pull\s+|run\s+(?:\S+\s+)*)([\w.-]+/[\w.-]+?)(?::[^\s\"'`]+)?(?:\s|$|[\"'`])",
+    re.IGNORECASE,
+)
+
+# Compose image: line: "image: ns/name[:tag]"
+_COMPOSE_IMAGE_RE = re.compile(
+    r"^\s*image\s*:\s*([\w.-]+/[\w.-]+?)(?::[^\s]+)?\s*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def _is_official_image(namespace: str) -> bool:
+    """Return True for single-component names (no slash) — Docker Hub
+    official / library images that don't have a proper namespace."""
+    return "/" not in namespace
+
+
+def _canonicalize(ns_name: str) -> str:
+    """Return the canonical hub.docker.com URL for *ns_name* (``ns/repo``)."""
+    return f"https://hub.docker.com/r/{ns_name}"
+
+
+def _docker_hub_url_from_readme(readme: str) -> str | None:
+    """Return the first Docker Hub URL found in *readme*, or None."""
+    m = _DOCKERHUB_URL_RE.search(readme)
+    if m:
+        ns_name = m.group(1).rstrip("/")
+        if not _is_official_image(ns_name):
+            return f"https://hub.docker.com/r/{ns_name}"
+    for m in _DOCKER_PULL_RUN_RE.finditer(readme):
+        ns_name = m.group(1).rstrip("/")
+        if not _is_official_image(ns_name):
+            return _canonicalize(ns_name)
+    return None
+
+
+def _docker_hub_url_from_aux_files(aux_files: dict[str, Any]) -> str | None:
+    """Return the first Docker Hub image ref found in docker/compose aux-files."""
+    for filename, content in aux_files.items():
+        if not isinstance(filename, str) or not isinstance(content, str):
+            continue
+        lower = filename.lower()
+        if "docker" in lower or "compose" in lower or lower == "dockerfile":
+            for m in _COMPOSE_IMAGE_RE.finditer(content):
+                ns_name = m.group(1).rstrip("/")
+                if not _is_official_image(ns_name):
+                    return _canonicalize(ns_name)
+    return None
+
+
+def parse_docker_hub_url(readme: str | None, aux_files: dict[str, Any] | None) -> str | None:
+    """Extract a Docker Hub URL from *readme* and, optionally, aux-files.
+
+    Tries (in order):
+    1. Direct ``https://hub.docker.com/r/<ns>/<name>`` link in readme.
+    2. ``docker pull <ns>/<name>`` or ``docker run … <ns>/<name>`` in readme.
+    3. ``image: <ns>/<name>`` in a Dockerfile/compose file in *aux_files*.
+
+    Returns the canonical ``https://hub.docker.com/r/<ns>/<name>`` form,
+    or ``None`` when nothing confident is found.  Official images without
+    a namespace (e.g. ``docker pull python``) are skipped.
+    """
+    if isinstance(readme, str) and readme:
+        result = _docker_hub_url_from_readme(readme)
+        if result:
+            return result
+    if isinstance(aux_files, dict):
+        return _docker_hub_url_from_aux_files(aux_files)
+    return None

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -12,6 +12,10 @@ from src.v2.agents.models import (
     generate_uuid,
     validate_permissive,
 )
+from src.v2.agents.rule_based._repo_signals import (
+    parse_docker_hub_url,
+    parse_test_coverage,
+)
 from src.v2.canonicalization.github import github_repo_iri, github_user_iri
 from src.v2.parsers.citation_cff import parse_citation_cff
 from src.v2.parsers.publiccode import parse_publiccode
@@ -242,6 +246,36 @@ async def _maybe_await(value: Any) -> Any:
     return value
 
 
+_RELEASES_CAP = 100
+
+
+def _thin_releases(releases: Any) -> list[dict[str, Any]] | None:
+    """Return a capped, thinned list of release dicts from the raw GitHub
+    payload, or ``None`` when the input is absent/empty.
+
+    Each output dict carries only the four fields useful for downstream
+    release-frequency analytics: ``version`` (tag_name), ``name``,
+    ``published_at``, and ``url`` (html_url). The list is kept
+    newest-first (as returned by GitHub) and capped at
+    ``_RELEASES_CAP`` entries.
+    """
+    if not isinstance(releases, list) or not releases:
+        return None
+    out: list[dict[str, Any]] = []
+    for rel in releases[:_RELEASES_CAP]:
+        if not isinstance(rel, dict):
+            continue
+        out.append(
+            {
+                "version": rel.get("tag_name"),
+                "name": rel.get("name"),
+                "published_at": rel.get("published_at"),
+                "url": rel.get("html_url"),
+            },
+        )
+    return out or None
+
+
 # Keyword sets for `pulse:repositoryType` classification. Order matters: the
 # first matching set wins, so the more-specific categories come first.
 _REPO_TYPE_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
@@ -328,6 +362,7 @@ class RepositoryAgentV2:
         languages: dict[str, Any]
 
         aux_files: dict[str, str]
+        readme_content: str = ""
         if reuse_gathered_context and isinstance(repository_context, dict):
             metadata_candidate = repository_context.get("metadata")
             repository = metadata_candidate if isinstance(metadata_candidate, dict) else {}
@@ -344,6 +379,10 @@ class RepositoryAgentV2:
 
             aux_files_candidate = repository_context.get("aux_files")
             aux_files = aux_files_candidate if isinstance(aux_files_candidate, dict) else {}
+
+            readme_candidate = repository_context.get("readme_content")
+            if isinstance(readme_candidate, str):
+                readme_content = readme_candidate
         else:
             repository = providers.github.get_repository(full_name)
             contributors = providers.github.get_contributors(full_name)
@@ -356,6 +395,7 @@ class RepositoryAgentV2:
             "contributors": contributors,
             "languages": languages,
             "aux_files": aux_files,
+            "readme_content": readme_content,
         }
 
     async def _default_structured_output(  # noqa: C901
@@ -366,6 +406,7 @@ class RepositoryAgentV2:
     ) -> dict[str, Any]:
         repository = compiled_context["repository"]
         full_name = str(repository.get("full_name") or compiled_context["full_name"])
+        readme_content: str = compiled_context.get("readme_content") or ""
         contributors = compiled_context.get("contributors", [])
         languages = compiled_context.get("languages", {})
 
@@ -507,15 +548,30 @@ class RepositoryAgentV2:
             "_citation_cff": _resolve_citation_cff_payload(
                 compiled_context.get("aux_files"),
             ),
-            # Published releases + GHCR container (Docker) images, fetched
-            # by the context_gather stage and carried on the repository
-            # metadata. Layer-1 internal fields: the Pulse v2.1.2 ontology
-            # has no predicate for software releases or container images
-            # (v1 had a commented-out `hasSoftwareImage`), so they ride
-            # under the `_` convention until a v3.0.0 enrichment stage
-            # promotes them to canonical `schema:`/`pulse:` terms.
-            "_releases": (repository.get("releases") or None),
+            # Published releases (thinned, newest-first, capped at
+            # _RELEASES_CAP) + GHCR container (Docker) images. Layer-1
+            # internal fields until a v3.0.0 enrichment stage promotes
+            # them to canonical `schema:`/`pulse:` terms.
+            "_releases": _thin_releases(repository.get("releases")),
+            "_latest_version": (
+                (repository.get("releases") or [{}])[0].get("tag_name")
+                if isinstance(repository.get("releases"), list) and repository["releases"]
+                else None
+            ),
             "_container_images": (repository.get("container_images") or None),
+            # CI presence — detected from the repo root listing by
+            # context_gather and stored in repository_metadata["has_ci"].
+            # None when the listing was unavailable.
+            "_has_ci": repository.get("has_ci"),
+            # Test-coverage percentage parsed from the README (regex only;
+            # LLM fallback is a separate later phase). None when not found.
+            "_test_coverage": parse_test_coverage(readme_content),
+            # Docker Hub URL parsed from README + aux-files. None when
+            # no confident match is found.
+            "_docker_hub_url": parse_docker_hub_url(
+                readme_content,
+                compiled_context.get("aux_files"),
+            ),
         }
 
     async def _default_repository_classifier(

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -246,34 +246,6 @@ async def _maybe_await(value: Any) -> Any:
     return value
 
 
-_RELEASES_CAP = 100
-
-
-def _thin_releases(releases: Any) -> list[dict[str, Any]] | None:
-    """Return a capped, thinned list of release dicts from the raw GitHub
-    payload, or ``None`` when the input is absent/empty.
-
-    Each output dict carries only the four fields useful for downstream
-    release-frequency analytics: ``version`` (tag_name), ``name``,
-    ``published_at``, and ``url`` (html_url). The list is kept
-    newest-first (as returned by GitHub) and capped at
-    ``_RELEASES_CAP`` entries.
-    """
-    if not isinstance(releases, list) or not releases:
-        return None
-    out: list[dict[str, Any]] = []
-    for rel in releases[:_RELEASES_CAP]:
-        if not isinstance(rel, dict):
-            continue
-        out.append(
-            {
-                "version": rel.get("tag_name"),
-                "name": rel.get("name"),
-                "published_at": rel.get("published_at"),
-                "url": rel.get("html_url"),
-            },
-        )
-    return out or None
 
 
 # Keyword sets for `pulse:repositoryType` classification. Order matters: the
@@ -548,11 +520,11 @@ class RepositoryAgentV2:
             "_citation_cff": _resolve_citation_cff_payload(
                 compiled_context.get("aux_files"),
             ),
-            # Published releases (thinned, newest-first, capped at
-            # _RELEASES_CAP) + GHCR container (Docker) images. Layer-1
-            # internal fields until a v3.0.0 enrichment stage promotes
-            # them to canonical `schema:`/`pulse:` terms.
-            "_releases": _thin_releases(repository.get("releases")),
+            # Published releases (raw, newest-first) + GHCR container
+            # (Docker) images. Layer-1 internal fields until a v3.0.0
+            # enrichment stage promotes them to canonical `schema:`/`pulse:`
+            # terms. `_latest_version` is the newest release's tag.
+            "_releases": (repository.get("releases") or None),
             "_latest_version": (
                 (repository.get("releases") or [{}])[0].get("tag_name")
                 if isinstance(repository.get("releases"), list) and repository["releases"]

--- a/src/v2/ingest/providers/base.py
+++ b/src/v2/ingest/providers/base.py
@@ -154,6 +154,18 @@ class GitHubProvider(BaseProvider, ABC):
         del full_name
         return {}
 
+    def get_repository_root_entries(self, full_name: str) -> list[str] | None:
+        """Return the names of all entries at the repository root, or None on failure.
+
+        Used to detect CI configuration files (.github, .travis.yml, etc.)
+        without fetching their contents. Default returns None so providers
+        that don't expose directory listings (test fakes, partial mocks) need
+        not stub this. Must not raise on absence — only transport-level
+        failures are exceptional; return None instead.
+        """
+        del full_name
+        return None
+
     def get_repository_releases(self, full_name: str) -> list[dict[str, Any]]:
         """Return published releases for ``owner/repo``, newest first.
 

--- a/src/v2/ingest/providers/github_provider.py
+++ b/src/v2/ingest/providers/github_provider.py
@@ -1418,6 +1418,56 @@ class RealGitHubProvider(GitHubProvider):
             label=f"github.get_repository_aux_files({full_name})",
         )
 
+    def get_repository_root_entries(self, full_name: str) -> list[str] | None:
+        """Return the names of ALL entries (files and directories) at the
+        repository root, or ``None`` on failure.
+
+        Uses the same ``GET /repos/{owner}/{repo}/contents/`` endpoint as
+        ``get_repository_aux_files`` but returns the raw name list instead
+        of fetching file contents.  The result is cached with the same TTL
+        as other per-repo calls.
+        """
+
+        def _fetch() -> list[str] | None:
+            url = f"https://api.github.com/repos/{full_name}/contents/"
+            try:
+                response = self._run_with_rate_limit(
+                    lambda: requests.get(url, headers=_github_auth_headers(), timeout=15),
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("github root-listing failed for %s", full_name)
+                return None
+            if response.status_code != 200:
+                logger.info(
+                    "github root-listing returned %d for %s",
+                    response.status_code,
+                    full_name,
+                )
+                return None
+            try:
+                payload = response.json()
+            except ValueError:
+                logger.exception("github root-listing not JSON for %s", full_name)
+                return None
+            if not isinstance(payload, list):
+                return None
+            return [
+                item["name"]
+                for item in payload
+                if isinstance(item, dict) and isinstance(item.get("name"), str)
+            ]
+
+        if self._cache is None:
+            return _fetch()
+        key = ProviderCache.make_key(
+            "github", "get_repository_root_entries", full_name=full_name
+        )
+        return self._cache.get_or_set(
+            key,
+            _fetch,
+            label=f"github.get_repository_root_entries({full_name})",
+        )
+
     def get_commit_bookends(
         self,
         full_name: str,

--- a/src/v2/pipeline/stages/context_gather.py
+++ b/src/v2/pipeline/stages/context_gather.py
@@ -5,6 +5,7 @@ import os
 import re
 from typing import TYPE_CHECKING, Any
 
+from src.v2.agents.rule_based._repo_signals import detect_has_ci
 from src.v2.pipeline.stages.models import ContextBundle
 
 
@@ -356,6 +357,17 @@ def _optional_repository_context(
             f"Repository container-images lookup failed for {full_name}: {exc}",
         )
 
+    # CI detection — list the repo root once and check for known CI
+    # indicator files / directories. Best-effort: None on failure so the
+    # pipeline never breaks over a missing listing.
+    try:
+        root_entries = providers.github.get_repository_root_entries(full_name)
+        repository_metadata["has_ci"] = detect_has_ci(root_entries)
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"Repository root-listing (has_ci) failed for {full_name}: {exc}",
+        )
+
     return {
         "full_name": full_name,
         "metadata": repository_metadata,
@@ -455,6 +467,34 @@ async def gather_context(  # noqa: C901, PLR0915
                 f"Repository aux-files lookup failed for {full_name}: {exc}",
             )
             aux_files = {}
+
+        # Releases + container images (best-effort; same as
+        # _optional_repository_context above).
+        try:
+            releases = providers.github.get_repository_releases(full_name)
+            if isinstance(releases, list) and releases:
+                repository_metadata["releases"] = releases
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(
+                f"Repository releases lookup failed for {full_name}: {exc}",
+            )
+        try:
+            container_images = providers.github.get_repository_container_images(full_name)
+            if isinstance(container_images, list) and container_images:
+                repository_metadata["container_images"] = container_images
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(
+                f"Repository container-images lookup failed for {full_name}: {exc}",
+            )
+
+        # CI detection (best-effort; None on provider failure).
+        try:
+            root_entries = providers.github.get_repository_root_entries(full_name)
+            repository_metadata["has_ci"] = detect_has_ci(root_entries)
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(
+                f"Repository root-listing (has_ci) failed for {full_name}: {exc}",
+            )
 
         context["repository"] = {
             "full_name": full_name,

--- a/tests/v2/test_repo_enrichment_fields.py
+++ b/tests/v2/test_repo_enrichment_fields.py
@@ -242,11 +242,13 @@ def test_repository_agent_emits_releases_and_latest_version() -> None:
     releases = raw["_releases"]
     assert isinstance(releases, list)
     assert len(releases) == len(_STUB_RELEASES)
+    # _releases is the raw GitHub releases payload (unchanged contract);
+    # _latest_version is the derived addition.
     first = releases[0]
-    assert first["version"] == "v2.1.0"
+    assert first["tag_name"] == "v2.1.0"
     assert first["name"] == "Version 2.1.0"
     assert first["published_at"] == "2024-03-01T12:00:00Z"
-    assert first["url"] == "https://github.com/acme/tool/releases/tag/v2.1.0"
+    assert first["html_url"] == "https://github.com/acme/tool/releases/tag/v2.1.0"
 
 
 def test_repository_agent_releases_none_when_absent() -> None:

--- a/tests/v2/test_repo_enrichment_fields.py
+++ b/tests/v2/test_repo_enrichment_fields.py
@@ -1,0 +1,420 @@
+"""Tests for v2 repository enrichment fields (gme-internal).
+
+Covers:
+  - parse_test_coverage: static shields badge, plain text, dynamic badge (None), empty (None)
+  - parse_docker_hub_url: direct URL, docker pull, no ref, official single-name image
+  - detect_has_ci: root listing with .github → True; README-only → False; .gitlab-ci.yml → True
+  - entity-level: RepositoryAgentV2 emits _has_ci, _test_coverage, _docker_hub_url,
+    _latest_version, and _releases when stub context carries the right data.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from src.v2.agents import ProviderSet, RepositoryAgentV2
+from src.v2.agents.rule_based._repo_signals import (
+    detect_has_ci,
+    parse_docker_hub_url,
+    parse_test_coverage,
+)
+from src.v2.ingest.providers.mock_github import MockGitHubProvider
+
+# ---------------------------------------------------------------------------
+# parse_test_coverage
+# ---------------------------------------------------------------------------
+
+
+def test_parse_test_coverage_static_shields_badge_percent25() -> None:
+    readme = "![cov](https://img.shields.io/badge/coverage-87%25-green)"
+    assert parse_test_coverage(readme) == "87%"
+
+
+def test_parse_test_coverage_static_shields_badge_percent_literal() -> None:
+    readme = "![cov](https://img.shields.io/badge/coverage-92%-brightgreen)"
+    assert parse_test_coverage(readme) == "92%"
+
+
+def test_parse_test_coverage_plain_text_coverage_colon() -> None:
+    readme = "The project has coverage: 92% according to the CI report."
+    assert parse_test_coverage(readme) == "92%"
+
+
+def test_parse_test_coverage_plain_text_test_coverage() -> None:
+    readme = "test coverage: 75%\nSee the CI dashboard for details."
+    assert parse_test_coverage(readme) == "75%"
+
+
+def test_parse_test_coverage_dynamic_codecov_badge_returns_none() -> None:
+    # Dynamic badge — no number embedded in the README text
+    readme = (
+        "[![codecov](https://codecov.io/gh/owner/repo/branch/main/graph/badge.svg)]"
+        "(https://codecov.io/gh/owner/repo)"
+    )
+    assert parse_test_coverage(readme) is None
+
+
+def test_parse_test_coverage_empty_returns_none() -> None:
+    assert parse_test_coverage("") is None
+
+
+def test_parse_test_coverage_none_returns_none() -> None:
+    assert parse_test_coverage(None) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# parse_docker_hub_url
+# ---------------------------------------------------------------------------
+
+
+def test_parse_docker_hub_url_direct_hub_link() -> None:
+    readme = "See https://hub.docker.com/r/acme/tool for the image."
+    assert parse_docker_hub_url(readme, None) == "https://hub.docker.com/r/acme/tool"
+
+
+def test_parse_docker_hub_url_docker_pull() -> None:
+    readme = "Install with `docker pull acme/tool`."
+    assert parse_docker_hub_url(readme, None) == "https://hub.docker.com/r/acme/tool"
+
+
+def test_parse_docker_hub_url_no_docker_ref_returns_none() -> None:
+    readme = "No docker info here. Just plain text."
+    assert parse_docker_hub_url(readme, None) is None
+
+
+def test_parse_docker_hub_url_official_single_name_returns_none() -> None:
+    # Official images (no namespace) must NOT produce a URL
+    readme = "Run `docker pull python` to get started."
+    assert parse_docker_hub_url(readme, None) is None
+
+
+def test_parse_docker_hub_url_docker_run_image_ref() -> None:
+    readme = "Example: docker run acme/tool:latest"
+    assert parse_docker_hub_url(readme, None) == "https://hub.docker.com/r/acme/tool"
+
+
+def test_parse_docker_hub_url_strips_tag() -> None:
+    readme = "docker pull acme/my-image:v1.2.3"
+    assert parse_docker_hub_url(readme, None) == "https://hub.docker.com/r/acme/my-image"
+
+
+def test_parse_docker_hub_url_compose_image_line() -> None:
+    aux_files = {"docker-compose.yml": "services:\n  app:\n    image: acme/tool:latest\n"}
+    assert parse_docker_hub_url("", aux_files) == "https://hub.docker.com/r/acme/tool"
+
+
+def test_parse_docker_hub_url_empty_returns_none() -> None:
+    assert parse_docker_hub_url("", None) is None
+
+
+# ---------------------------------------------------------------------------
+# detect_has_ci
+# ---------------------------------------------------------------------------
+
+
+def test_detect_has_ci_github_actions_dir() -> None:
+    assert detect_has_ci([".github", "README.md", "src"]) is True
+
+
+def test_detect_has_ci_readme_only() -> None:
+    assert detect_has_ci(["README.md", "src", "setup.py"]) is False
+
+
+def test_detect_has_ci_gitlab_ci_yml() -> None:
+    assert detect_has_ci([".gitlab-ci.yml", "README.md"]) is True
+
+
+def test_detect_has_ci_travis_yml() -> None:
+    assert detect_has_ci([".travis.yml"]) is True
+
+
+def test_detect_has_ci_circleci_dir() -> None:
+    assert detect_has_ci([".circleci", "README.md"]) is True
+
+
+def test_detect_has_ci_azure_pipelines() -> None:
+    assert detect_has_ci(["azure-pipelines.yml", "README.md"]) is True
+
+
+def test_detect_has_ci_jenkinsfile() -> None:
+    assert detect_has_ci(["Jenkinsfile"]) is True
+
+
+def test_detect_has_ci_drone_yml() -> None:
+    assert detect_has_ci([".drone.yml"]) is True
+
+
+def test_detect_has_ci_bitbucket_pipelines() -> None:
+    assert detect_has_ci(["bitbucket-pipelines.yml"]) is True
+
+
+def test_detect_has_ci_woodpecker_yml() -> None:
+    assert detect_has_ci([".woodpecker.yml"]) is True
+
+
+def test_detect_has_ci_case_insensitive() -> None:
+    assert detect_has_ci([".TRAVIS.YML"]) is True
+
+
+def test_detect_has_ci_none_returns_none() -> None:
+    assert detect_has_ci(None) is None
+
+
+def test_detect_has_ci_empty_list_returns_false() -> None:
+    assert detect_has_ci([]) is False
+
+
+# ---------------------------------------------------------------------------
+# Entity-level test: RepositoryAgentV2 emits the 4 new internal fields
+# ---------------------------------------------------------------------------
+
+_STUB_RELEASES = [
+    {
+        "tag_name": "v2.1.0",
+        "name": "Version 2.1.0",
+        "published_at": "2024-03-01T12:00:00Z",
+        "html_url": "https://github.com/acme/tool/releases/tag/v2.1.0",
+    },
+    {
+        "tag_name": "v2.0.0",
+        "name": "Version 2.0.0",
+        "published_at": "2024-01-15T08:00:00Z",
+        "html_url": "https://github.com/acme/tool/releases/tag/v2.0.0",
+    },
+]
+
+_README_WITH_SIGNALS = (
+    "# My Tool\n"
+    "![coverage](https://img.shields.io/badge/coverage-87%25-green)\n"
+    "Pull image: docker pull acme/tool\n"
+    "Great software!\n"
+)
+
+
+def _make_stub_context(
+    *,
+    releases: list[dict[str, Any]] | None = None,
+    readme_content: str = "",
+    has_ci: bool | None = None,
+    aux_files: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build a repository_context dict as the orchestrator/gather_context would."""
+    metadata: dict[str, Any] = {
+        "name": "tool",
+        "full_name": "acme/tool",
+        "owner": {"login": "acme", "type": "Organization"},
+        "created_at": "2023-01-01T00:00:00Z",
+        "license": {"spdx_id": "MIT"},
+        "fork": False,
+        "source": {"full_name": None},
+    }
+    if releases is not None:
+        metadata["releases"] = releases
+    if has_ci is not None:
+        metadata["has_ci"] = has_ci
+
+    return {
+        "full_name": "acme/tool",
+        "metadata": metadata,
+        "readme_content": readme_content,
+        "contributors": [{"login": "alice"}],
+        "languages": {"Python": 1},
+        "aux_files": aux_files or {},
+    }
+
+
+def test_repository_agent_emits_releases_and_latest_version() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(releases=_STUB_RELEASES),
+            },
+            providers,
+        ),
+    )
+
+    raw = result.raw_output
+    assert raw["_latest_version"] == "v2.1.0"
+    releases = raw["_releases"]
+    assert isinstance(releases, list)
+    assert len(releases) == len(_STUB_RELEASES)
+    first = releases[0]
+    assert first["version"] == "v2.1.0"
+    assert first["name"] == "Version 2.1.0"
+    assert first["published_at"] == "2024-03-01T12:00:00Z"
+    assert first["url"] == "https://github.com/acme/tool/releases/tag/v2.1.0"
+
+
+def test_repository_agent_releases_none_when_absent() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(releases=None),
+            },
+            providers,
+        ),
+    )
+
+    raw = result.raw_output
+    assert raw["_latest_version"] is None
+    assert raw["_releases"] is None
+
+
+def test_repository_agent_emits_test_coverage_from_readme() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(
+                    readme_content=_README_WITH_SIGNALS,
+                ),
+            },
+            providers,
+        ),
+    )
+
+    assert result.raw_output["_test_coverage"] == "87%"
+
+
+def test_repository_agent_test_coverage_none_when_no_badge() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(readme_content="# No coverage here"),
+            },
+            providers,
+        ),
+    )
+
+    assert result.raw_output["_test_coverage"] is None
+
+
+def test_repository_agent_emits_docker_hub_url_from_readme() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(
+                    readme_content=_README_WITH_SIGNALS,
+                ),
+            },
+            providers,
+        ),
+    )
+
+    assert result.raw_output["_docker_hub_url"] == "https://hub.docker.com/r/acme/tool"
+
+
+def test_repository_agent_docker_hub_url_none_when_absent() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(readme_content="# No docker here"),
+            },
+            providers,
+        ),
+    )
+
+    assert result.raw_output["_docker_hub_url"] is None
+
+
+def test_repository_agent_emits_has_ci_true() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(has_ci=True),
+            },
+            providers,
+        ),
+    )
+
+    assert result.raw_output["_has_ci"] is True
+
+
+def test_repository_agent_emits_has_ci_false() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(has_ci=False),
+            },
+            providers,
+        ),
+    )
+
+    assert result.raw_output["_has_ci"] is False
+
+
+def test_repository_agent_has_ci_none_when_not_in_metadata() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(),
+            },
+            providers,
+        ),
+    )
+
+    # has_ci not set in metadata → should be None
+    assert result.raw_output["_has_ci"] is None
+
+
+def test_repository_agent_all_enrichment_fields_combined() -> None:
+    """Smoke test: all 4 enrichment fields present in a single run."""
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(
+                    releases=_STUB_RELEASES,
+                    readme_content=_README_WITH_SIGNALS,
+                    has_ci=True,
+                ),
+            },
+            providers,
+        ),
+    )
+
+    raw = result.raw_output
+    assert raw["_has_ci"] is True
+    assert raw["_test_coverage"] == "87%"
+    assert raw["_docker_hub_url"] == "https://hub.docker.com/r/acme/tool"
+    assert raw["_latest_version"] == "v2.1.0"
+    assert isinstance(raw["_releases"], list)
+    assert len(raw["_releases"]) == len(_STUB_RELEASES)


### PR DESCRIPTION
Four developer-requested repository enrichment fields, surfaced as `gme-internal:` JSON-LD fields (the existing `_`-prefixed-field mechanism; stripped unless `?include_internal_fields=true`).

- **`gme-internal:hasCi`** (bool) — deterministic: a new cached `get_repository_root_entries` provider call + `detect_has_ci` over the root listing (`.github`, `.gitlab-ci.yml`, `.travis.yml`, `.circleci`, `Jenkinsfile`, …).
- **`gme-internal:testCoverage`** — `parse_test_coverage` regexes the README for static shields coverage badges (`coverage-87%`) + `coverage: N%` text (dynamic codecov/coveralls badges carry no number → null; the LLM fallback is Phase 2).
- **`gme-internal:dockerHubUrl`** — `parse_docker_hub_url` finds `hub.docker.com/r/<ns>/<name>` / `docker pull <ns>/<name>` in the README/Dockerfile, canonicalized (official single-name images skipped).
- **`gme-internal:latestVersion`** — newest release tag. `_releases` keeps its existing raw contract (a self-review fix: an earlier reshape broke `test_agent_stamps_releases_and_container_images`; reverted to raw + added only latestVersion). Release dates → release-frequency downstream.

New helper module `src/v2/agents/rule_based/_repo_signals.py`; wiring in `context_gather.py` + `repository_agent.py`. Best-effort throughout (None on missing data; mock providers unaffected via the `base.py` default).

Tests: `tests/v2/test_repo_enrichment_fields.py` (38) + the existing pipeline suite. Full `tests/v2/` gate: **1452 passed**.

Phase 2 (the LLM README enrichment: coverage agent fallback + `gme-internal:hasDocumentation`) follows.