### PR TITLE
feat(v2): LLM README enrichment — gme-internal:hasDocumentation + test-coverage agent fallback

### DIFF
--- a/src/v2/agents/llm/refiners/repo_signals/__init__.py
+++ b/src/v2/agents/llm/refiners/repo_signals/__init__.py
@@ -1,0 +1,11 @@
+from src.v2.agents.llm.refiners.repo_signals.agent import (
+    RepoSignalsInput,
+    RepoSignalsPatch,
+    run_repo_signals,
+)
+
+__all__ = [
+    "RepoSignalsInput",
+    "RepoSignalsPatch",
+    "run_repo_signals",
+]

--- a/src/v2/agents/llm/refiners/repo_signals/agent.py
+++ b/src/v2/agents/llm/refiners/repo_signals/agent.py
@@ -1,0 +1,141 @@
+"""LLM refiner that extracts documentation URLs and coverage fallback from a README.
+
+Produces two ``gme-internal:`` repository fields:
+
+- ``gme-internal:hasDocumentation`` (via entity ``_documentation_urls``) —
+  a flat de-duped list of genuine project documentation URLs confirmed (or
+  newly found) by the LLM.
+
+- ``gme-internal:testCoverage`` (via entity ``_test_coverage``) — only used
+  as a **fallback** when the Phase-1 deterministic regex found nothing.
+
+Mirrors the ``ror_parent`` agent pattern: small typed input/output schemas,
+``_SYSTEM_PROMPT = load_prompt(...)``, and a runner that returns ``None``
+on failure (best-effort, never raises).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.v2.agents.llm._loader import load_prompt
+from src.v2.agents.llm.runtime import LLMRuntimeError, V2LLMRuntime
+
+logger = logging.getLogger(__name__)
+
+_PROMPTS_PACKAGE = "src.v2.agents.llm.refiners.repo_signals.prompts"
+_SYSTEM_PROMPT = load_prompt(_PROMPTS_PACKAGE, "system_prompt.md")
+
+_LLM_CALL_TIMEOUT_SECONDS = 60.0
+
+
+class RepoSignalsInput(BaseModel):
+    """Context for one README → documentation/coverage extraction call."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    repository_handle: str
+    readme_excerpt: str
+    candidate_documentation_urls: list[str] = Field(default_factory=list)
+
+
+class RepoSignalsPatch(BaseModel):
+    """LLM output: confirmed/found documentation URLs + optional coverage."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    documentation_urls: list[str] = Field(
+        default_factory=list,
+        description=(
+            "URLs that are project DOCUMENTATION (readthedocs, a docs site, "
+            "GitHub Pages docs, a wiki, an official manual) — NOT the repo "
+            "itself, badges, CI, or unrelated links."
+        ),
+    )
+    test_coverage: str | None = Field(
+        default=None,
+        description=(
+            "Test coverage as a percentage string like '87%' if the README "
+            "states a numeric coverage, else null."
+        ),
+    )
+
+
+async def run_repo_signals(
+    inp: RepoSignalsInput,
+    *,
+    llm_runtime: V2LLMRuntime | None = None,
+    llm_call_timeout_seconds: float = _LLM_CALL_TIMEOUT_SECONDS,
+) -> RepoSignalsPatch | None:
+    """Run the repo-signals LLM refiner. Returns ``None`` on any failure.
+
+    Best-effort: any exception leaves the caller's entity unchanged.
+    """
+    runtime = llm_runtime or V2LLMRuntime()
+    identifier = inp.repository_handle
+
+    import json  # noqa: PLC0415 — keep top-level imports lean for fast cold path
+
+    user_prompt = (
+        "Inspect the README excerpt and candidate URLs below. "
+        "Return the genuine documentation URLs for this project and "
+        "the numeric test-coverage percentage (if explicitly stated).\n\n"
+        "```json\n"
+        + json.dumps(inp.model_dump(by_alias=True), ensure_ascii=True, sort_keys=True)
+        + "\n```"
+    )
+
+    logger.info("%s — calling repo_signals LLM", identifier)
+    try:
+        llm_result = await asyncio.wait_for(
+            runtime.run_json_prompt(
+                system_prompt=_SYSTEM_PROMPT,
+                user_prompt=user_prompt,
+                output_type=RepoSignalsPatch,
+                tools=[],
+            ),
+            timeout=llm_call_timeout_seconds,
+        )
+    except TimeoutError:
+        logger.warning(
+            "%s — repo_signals LLM call timed out after %.1fs",
+            identifier,
+            llm_call_timeout_seconds,
+        )
+        return None
+    except LLMRuntimeError:
+        logger.warning("%s — repo_signals LLM runtime error", identifier, exc_info=True)
+        return None
+    except Exception:  # noqa: BLE001
+        logger.warning("%s — repo_signals unexpected error", identifier, exc_info=True)
+        return None
+
+    if isinstance(llm_result.payload, RepoSignalsPatch):
+        patch = llm_result.payload
+    else:
+        try:
+            patch = RepoSignalsPatch.model_validate(llm_result.payload)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "%s — repo_signals returned an unparseable payload; skipping",
+                identifier,
+            )
+            return None
+
+    logger.info(
+        "%s — repo_signals: doc_urls=%d coverage=%r",
+        identifier,
+        len(patch.documentation_urls),
+        patch.test_coverage,
+    )
+    return patch
+
+
+__all__ = [
+    "RepoSignalsInput",
+    "RepoSignalsPatch",
+    "run_repo_signals",
+]

--- a/src/v2/agents/llm/refiners/repo_signals/prompts/system_prompt.md
+++ b/src/v2/agents/llm/refiners/repo_signals/prompts/system_prompt.md
@@ -1,0 +1,36 @@
+You are a **repository documentation and coverage extractor**. You receive:
+
+- `repository_handle` — the GitHub `owner/repo` slug.
+- `readme_excerpt` — the first portion of the repository README.
+- `candidate_documentation_urls` — a list of URLs already extracted by a regex pass over the README. These are *candidates* that may or may not be genuine documentation.
+
+## Your task
+
+Return a JSON object with exactly two keys:
+
+### `documentation_urls`
+
+A list of URLs that are **genuine project documentation** — meaning a readthedocs site, a GitHub/GitLab Pages site serving docs, a GitBook, an official wiki, or a dedicated docs site for this project.
+
+Rules:
+- Include any candidate URL that is genuinely a documentation site for this project.
+- Add any additional doc URLs you find in the README that the regex missed.
+- **Exclude** the repository URL itself (`https://github.com/<owner>/<repo>`).
+- **Exclude** badge image URLs, CI service URLs (Travis, GitHub Actions, Codecov, Coveralls), npm/PyPI pages, and social/promotional links.
+- **Exclude** generic landing pages that merely mention the word "docs" but are not documentation (e.g. the readthedocs.org homepage itself).
+- Return an empty list `[]` when there are no genuine documentation URLs.
+
+### `test_coverage`
+
+The numeric test-coverage percentage as a string like `"87%"` — **only** when the README explicitly states a concrete percentage for test coverage. Return `null` otherwise (when coverage is not mentioned, when it is only shown via a dynamic badge without a number, or when the number is ambiguous).
+
+## Output format
+
+Return **only** a JSON object — no markdown fences, no commentary:
+
+```json
+{
+  "documentation_urls": ["https://…"],
+  "test_coverage": "87%" | null
+}
+```

--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -178,3 +178,47 @@ def parse_docker_hub_url(readme: str | None, aux_files: dict[str, Any] | None) -
     if isinstance(aux_files, dict):
         return _docker_hub_url_from_aux_files(aux_files)
     return None
+
+
+# ---------------------------------------------------------------------------
+# extract_doc_candidate_urls
+# ---------------------------------------------------------------------------
+
+# Patterns for documentation-hosting URLs:
+#   1. *.readthedocs.io  (any sub-path)
+#   2. *.github.io / *.gitlab.io  (GitHub/GitLab Pages)
+#   3. *.gitbook.io
+#   4. docs.<domain>  (e.g. docs.myproject.io)
+#   5. <any-host>/docs/<path>  (project site with /docs/ path)
+_DOC_URL_RE = re.compile(
+    r"https?://"
+    r"(?:"
+    r"[\w.-]+\.readthedocs\.io"         # readthedocs.io
+    r"|[\w.-]+\.(?:github|gitlab)\.io"  # GitHub/GitLab Pages
+    r"|[\w.-]+\.gitbook\.io"            # GitBook
+    r"|docs\.[\w.-]+"                   # docs.* subdomain
+    r"|[\w.-]+/docs/[\w./?#=&%-]*"      # /docs/ path (project site)
+    r")"
+    r"[^\s\"'<>]*",                     # rest of URL until whitespace/quote/tag
+    re.IGNORECASE,
+)
+
+
+def extract_doc_candidate_urls(readme: str | None) -> list[str]:
+    """Extract documentation-hosting URLs from *readme*.
+
+    Matches readthedocs.io, GitHub/GitLab Pages (*.github.io / *.gitlab.io),
+    GitBook (*.gitbook.io), docs.<domain> subdomains, and /docs/ paths on
+    project sites.  Returns a de-duped, order-preserving list (may be empty).
+    """
+    if not isinstance(readme, str) or not readme:
+        return []
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for match in _DOC_URL_RE.finditer(readme):
+        url = match.group(0).rstrip(".,;:)")  # strip common trailing punctuation
+        if url not in seen:
+            seen.add(url)
+            result.append(url)
+    return result

--- a/src/v2/pipeline/stages/refine_with_llm.py
+++ b/src/v2/pipeline/stages/refine_with_llm.py
@@ -18,14 +18,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import requests
+import re
 from copy import deepcopy
 from dataclasses import dataclass, field
 from time import perf_counter
 from typing import Any
 from uuid import uuid4
 
-import re
+import requests
 
 from src.v2.agents.llm.agent_tools.graph_neighbors import make_get_entity_neighbors_tool
 from src.v2.agents.llm.refiners import (
@@ -45,18 +45,23 @@ from src.v2.agents.llm.refiners.discovery import (
     DiscoveryRefinerAgent,
     DiscoveryRefinerInput,
 )
-from src.v2.agents.llm.refiners.rescue import (
-    RescueCandidate,
-    RescueRefinerAgent,
-    RescueRefinerInput,
-)
 from src.v2.agents.llm.refiners.org_resolver import (
     OrgResolverAgent,
     OrgResolverInput,
     OrgResolverPatch,
     UnresolvedOrg,
 )
+from src.v2.agents.llm.refiners.repo_signals.agent import (
+    RepoSignalsInput,
+    run_repo_signals,
+)
+from src.v2.agents.llm.refiners.rescue import (
+    RescueCandidate,
+    RescueRefinerAgent,
+    RescueRefinerInput,
+)
 from src.v2.agents.llm.runtime import LLMRuntimeError
+from src.v2.agents.rule_based._repo_signals import extract_doc_candidate_urls
 from src.v2.api_models.enums import OrganizationTypeV2
 from src.v2.ingest.providers.epfl_graph_rag import EpflGraphRagProvider
 from src.v2.parsers.citation_cff import parse_citation_cff
@@ -1089,6 +1094,7 @@ def _query_communities_index(query: str) -> list[dict[str, Any]]:
         return []
     try:
         import duckdb  # noqa: PLC0415
+
         from src.index.zenodo_communities.paths import duckdb_path  # noqa: PLC0415
     except Exception:  # noqa: BLE001
         return []
@@ -1230,6 +1236,7 @@ async def _gather_federated_evidence(
         """
         try:
             import duckdb  # noqa: PLC0415 — local import keeps the cold-path cost out of the hot path
+
             from src.index.infoscience.paths import duckdb_path  # noqa: PLC0415
         except Exception:  # noqa: BLE001
             return
@@ -1591,17 +1598,17 @@ async def _run_org_resolver_pass(
 
     # Build the resolver toolset. Each guard mirrors the per-entity
     # refiner pattern: a missing index degrades silently.
-    from src.v2.agents.llm.agent_tools.ror_rag import (  # noqa: PLC0415
-        make_ror_rag_search_tool,
-    )
-    from src.v2.agents.llm.agent_tools.infoscience_rag import (  # noqa: PLC0415
-        make_infoscience_rag_search_tool,
-    )
     from src.v2.agents.llm.agent_tools.epfl_graph_rag import (  # noqa: PLC0415
         make_epfl_graph_rag_search_tool,
     )
     from src.v2.agents.llm.agent_tools.github_organization import (  # noqa: PLC0415
         make_github_organization_metadata_tool,
+    )
+    from src.v2.agents.llm.agent_tools.infoscience_rag import (  # noqa: PLC0415
+        make_infoscience_rag_search_tool,
+    )
+    from src.v2.agents.llm.agent_tools.ror_rag import (  # noqa: PLC0415
+        make_ror_rag_search_tool,
     )
     from src.v2.agents.llm.agent_tools.snsf_grants import (  # noqa: PLC0415
         make_search_snsf_grants_tool,
@@ -2166,6 +2173,124 @@ async def _run_discovery_pass(
     return (warnings, stats)
 
 
+# ---------------------------------------------------------------------------
+# Repo-signals LLM pass (Phase 2 README enrichment)
+# ---------------------------------------------------------------------------
+
+_REPO_SIGNALS_AGENT_MODE_ENV = "V2_REPO_SIGNALS_AGENT_MODE"
+
+
+def _repo_signals_agent_mode() -> str:
+    """Return the gated mode for the repo-signals LLM pass.
+
+    Values: ``apply`` (default), ``shadow``, ``off``.  Unknown values fall
+    back to ``apply``.
+    """
+    raw = (os.getenv(_REPO_SIGNALS_AGENT_MODE_ENV) or "apply").strip().lower()
+    return raw if raw in {"apply", "shadow", "off"} else "apply"
+
+
+async def _run_repo_signals_pass(  # noqa: C901, PLR0912
+    *,
+    repositories: list[dict[str, Any]],
+    gathered_context: dict[str, Any] | None,
+) -> list[str]:
+    """Run the LLM repo-signals refiner over every repository entity.
+
+    Mutates each repository entity **in place** when mode is ``apply``:
+    - Sets ``_documentation_urls`` to the de-duped list the LLM confirmed.
+    - Sets ``_test_coverage`` **only** when the entity's current value is
+      ``None`` (the deterministic Phase-1 regex result wins; LLM is a
+      fallback only).
+
+    In ``shadow`` mode the agent runs but the entity is left unchanged;
+    its proposed values are logged.
+
+    In ``off`` mode the agent is never called.
+
+    Returns a list of human-readable warning/log strings.
+    """
+    mode = _repo_signals_agent_mode()
+    if mode == "off" or not repositories:
+        return []
+
+    # Extract the README from gathered_context (same path as _build_repo_context_summary).
+    readme: str | None = None
+    if isinstance(gathered_context, dict):
+        repo_ctx = gathered_context.get("repository")
+        if isinstance(repo_ctx, dict):
+            readme_raw = repo_ctx.get("readme_content")
+            if isinstance(readme_raw, str) and readme_raw.strip():
+                readme = readme_raw
+
+    if not readme:
+        return []
+
+    readme_excerpt = readme[:README_CONTEXT_MAX_CHARS]
+    candidate_urls = extract_doc_candidate_urls(readme)
+
+    warnings: list[str] = []
+
+    for repo in repositories:
+        if not isinstance(repo, dict):
+            continue
+        handle = (
+            repo.get("pulse:githubRepositoryHandle")
+            or repo.get("schema:name")
+            or repo.get("id", "?")
+        )
+
+        refiner_input = RepoSignalsInput(
+            repository_handle=str(handle),
+            readme_excerpt=readme_excerpt,
+            candidate_documentation_urls=candidate_urls,
+        )
+
+        try:
+            patch = await run_repo_signals(refiner_input)
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(
+                f"repo_signals: unexpected error for {handle!r} — {exc}; skipping",
+            )
+            continue
+
+        if patch is None:
+            warnings.append(f"repo_signals: no patch returned for {handle!r}")
+            continue
+
+        if mode == "shadow":
+            warnings.append(
+                f"repo_signals [shadow] {handle!r}: would set "
+                f"_documentation_urls={patch.documentation_urls!r} "
+                f"_test_coverage={patch.test_coverage!r}",
+            )
+            continue
+
+        # apply mode — mutate the entity
+        if patch.documentation_urls:
+            # De-duped union: the agent's list is authoritative (it may have
+            # confirmed a subset of candidates + added new ones).
+            seen: set[str] = set()
+            deduped: list[str] = []
+            for url in patch.documentation_urls:
+                if url not in seen:
+                    seen.add(url)
+                    deduped.append(url)
+            repo["_documentation_urls"] = deduped
+            warnings.append(
+                f"repo_signals: set _documentation_urls={deduped!r} for {handle!r}",
+            )
+
+        if patch.test_coverage is not None and repo.get("_test_coverage") is None:
+            repo["_test_coverage"] = patch.test_coverage
+            warnings.append(
+                f"repo_signals: set _test_coverage={patch.test_coverage!r} "
+                f"(LLM fallback) for {handle!r}",
+            )
+
+    return warnings
+
+
 async def run_refine_with_llm_stage(  # noqa: PLR0913, PLR0915
     *,
     reconciled: ReconciledEntities,
@@ -2356,6 +2481,16 @@ async def run_refine_with_llm_stage(  # noqa: PLR0913, PLR0915
     )
     warnings.extend(discovery_warnings)
     by_type["discovery"] = discovery_stats
+
+    # Repo-signals pass (Phase 2): LLM confirms/extends documentation URLs
+    # and provides a test-coverage fallback when the deterministic regex
+    # found nothing.  Env-gated by V2_REPO_SIGNALS_AGENT_MODE
+    # (apply / shadow / off); default is apply.
+    repo_signals_warnings = await _run_repo_signals_pass(
+        repositories=repositories,
+        gathered_context=gathered_context,
+    )
+    warnings.extend(repo_signals_warnings)
 
     refined_count = sum(stats.get("refined", 0) for stats in by_type.values())
     skipped_count = sum(stats.get("skipped", 0) for stats in by_type.values())

--- a/tests/v2/test_repo_signals_refiner.py
+++ b/tests/v2/test_repo_signals_refiner.py
@@ -1,0 +1,289 @@
+"""Phase 2 — LLM README enrichment: repo_signals refiner tests.
+
+Covers:
+  - extract_doc_candidate_urls (unit tests, no LLM).
+  - Refiner wiring via the run_repo_signals_for_entity helper that
+    _run_repo_signals_pass calls: apply / shadow / off modes, the
+    deterministic-coverage-wins guard, and the no-README skip.
+
+No real LLM calls — the runner is monkeypatched to return a fixed patch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.v2.agents.rule_based._repo_signals import extract_doc_candidate_urls
+from src.v2.pipeline.stages.refine_with_llm import _run_repo_signals_pass
+
+
+# ---------------------------------------------------------------------------
+# 1. extract_doc_candidate_urls
+# ---------------------------------------------------------------------------
+
+
+def test_extract_doc_candidate_urls_basic() -> None:
+    readme = (
+        "See the docs at https://my-project.readthedocs.io/en/latest/\n"
+        "and the pages site at https://orgname.github.io/project/\n"
+        "or visit https://github.com/orgname/project (not a doc site)\n"
+    )
+    urls = extract_doc_candidate_urls(readme)
+    assert "https://my-project.readthedocs.io/en/latest/" in urls
+    assert "https://orgname.github.io/project/" in urls
+    # the bare github.com repo URL should NOT appear
+    assert not any("github.com/orgname/project" in u and "github.io" not in u for u in urls)
+
+
+def test_extract_doc_candidate_urls_deduped() -> None:
+    readme = (
+        "https://proj.readthedocs.io https://proj.readthedocs.io\n"
+        "https://proj.readthedocs.io/en/stable/\n"
+    )
+    urls = extract_doc_candidate_urls(readme)
+    seen = [u for u in urls if "readthedocs.io" in u]
+    assert len(seen) == len(set(seen)), "duplicates must be removed"
+
+
+def test_extract_doc_candidate_urls_none_readme() -> None:
+    assert extract_doc_candidate_urls(None) == []
+
+
+def test_extract_doc_candidate_urls_empty_readme() -> None:
+    assert extract_doc_candidate_urls("") == []
+
+
+def test_extract_doc_candidate_urls_gitbook() -> None:
+    readme = "Docs: https://myproject.gitbook.io/docs/"
+    urls = extract_doc_candidate_urls(readme)
+    assert "https://myproject.gitbook.io/docs/" in urls
+
+
+def test_extract_doc_candidate_urls_docs_subdomain() -> None:
+    readme = "Visit https://docs.myproject.io/guide for details."
+    urls = extract_doc_candidate_urls(readme)
+    assert "https://docs.myproject.io/guide" in urls
+
+
+def test_extract_doc_candidate_urls_gitlab_pages() -> None:
+    readme = "See https://myorg.gitlab.io/myproject/"
+    urls = extract_doc_candidate_urls(readme)
+    assert "https://myorg.gitlab.io/myproject/" in urls
+
+
+def test_extract_doc_candidate_urls_docs_path() -> None:
+    readme = "API reference: https://myproject.example.com/docs/api"
+    urls = extract_doc_candidate_urls(readme)
+    assert "https://myproject.example.com/docs/api" in urls
+
+
+def test_extract_doc_candidate_urls_no_doc_links() -> None:
+    readme = "[![Build](https://travis-ci.org/foo/bar.svg)](https://travis-ci.org/foo/bar)"
+    urls = extract_doc_candidate_urls(readme)
+    assert urls == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Refiner wiring — monkeypatched runner
+# ---------------------------------------------------------------------------
+
+
+class _FixedPatch:
+    """Minimal stand-in for RepoSignalsPatch."""
+
+    def __init__(
+        self,
+        documentation_urls: list[str] | None = None,
+        test_coverage: str | None = None,
+    ) -> None:
+        self.documentation_urls = documentation_urls or []
+        self.test_coverage = test_coverage
+
+
+_DOC_URLS = ["https://my-proj.readthedocs.io/en/latest/"]
+_FIXED_PATCH = _FixedPatch(documentation_urls=_DOC_URLS, test_coverage="80%")
+
+
+def _make_repo(
+    readme: str | None = "See https://my-proj.readthedocs.io/en/latest/",
+    test_coverage: str | None = None,
+    handle: str = "owner/repo",
+) -> dict[str, Any]:
+    entity: dict[str, Any] = {
+        "type": "schema:SoftwareSourceCode",
+        "id": f"https://github.com/{handle}",
+        "schema:name": "repo",
+        "_test_coverage": test_coverage,
+        "_documentation_urls": [],
+        "_readme_content": readme,
+    }
+    return entity
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+# --- apply mode ---
+
+
+def test_apply_sets_documentation_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("V2_REPO_SIGNALS_AGENT_MODE", "apply")
+    ran: list[int] = []
+
+    async def _stub_runner(inp: Any, **_kw: Any) -> _FixedPatch:
+        ran.append(1)
+        return _FIXED_PATCH
+
+    monkeypatch.setattr(
+        "src.v2.pipeline.stages.refine_with_llm.run_repo_signals",
+        _stub_runner,
+    )
+
+    repo = _make_repo()
+    _run(_run_repo_signals_pass(repositories=[repo], gathered_context=_gathered(repo)))
+    assert ran, "runner must have been called"
+    assert repo.get("_documentation_urls") == _DOC_URLS
+
+
+def test_apply_sets_test_coverage_when_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("V2_REPO_SIGNALS_AGENT_MODE", "apply")
+
+    async def _stub_runner(inp: Any, **_kw: Any) -> _FixedPatch:
+        return _FIXED_PATCH
+
+    monkeypatch.setattr(
+        "src.v2.pipeline.stages.refine_with_llm.run_repo_signals",
+        _stub_runner,
+    )
+
+    repo = _make_repo(test_coverage=None)
+    _run(_run_repo_signals_pass(repositories=[repo], gathered_context=_gathered(repo)))
+    assert repo.get("_test_coverage") == "80%"
+
+
+def test_apply_does_not_override_deterministic_coverage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deterministic hit from Phase 1 must NOT be overridden by the LLM."""
+    monkeypatch.setenv("V2_REPO_SIGNALS_AGENT_MODE", "apply")
+
+    async def _stub_runner(inp: Any, **_kw: Any) -> _FixedPatch:
+        return _FIXED_PATCH  # patch.test_coverage = "80%"
+
+    monkeypatch.setattr(
+        "src.v2.pipeline.stages.refine_with_llm.run_repo_signals",
+        _stub_runner,
+    )
+
+    repo = _make_repo(test_coverage="90%")  # Phase-1 deterministic result
+    _run(_run_repo_signals_pass(repositories=[repo], gathered_context=_gathered(repo)))
+    assert repo.get("_test_coverage") == "90%", "deterministic hit must not be overridden"
+
+
+# --- shadow mode ---
+
+
+def test_shadow_runs_agent_but_does_not_mutate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("V2_REPO_SIGNALS_AGENT_MODE", "shadow")
+    ran: list[int] = []
+
+    async def _stub_runner(inp: Any, **_kw: Any) -> _FixedPatch:
+        ran.append(1)
+        return _FIXED_PATCH
+
+    monkeypatch.setattr(
+        "src.v2.pipeline.stages.refine_with_llm.run_repo_signals",
+        _stub_runner,
+    )
+
+    repo = _make_repo()
+    _run(_run_repo_signals_pass(repositories=[repo], gathered_context=_gathered(repo)))
+    assert ran, "runner must have been called in shadow mode"
+    assert repo.get("_documentation_urls") == [], "entity must NOT be mutated in shadow mode"
+    assert repo.get("_test_coverage") is None
+
+
+# --- off mode ---
+
+
+def test_off_never_calls_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("V2_REPO_SIGNALS_AGENT_MODE", "off")
+    ran: list[int] = []
+
+    async def _stub_runner(inp: Any, **_kw: Any) -> _FixedPatch:
+        ran.append(1)
+        return _FIXED_PATCH
+
+    monkeypatch.setattr(
+        "src.v2.pipeline.stages.refine_with_llm.run_repo_signals",
+        _stub_runner,
+    )
+
+    repo = _make_repo()
+    _run(_run_repo_signals_pass(repositories=[repo], gathered_context=_gathered(repo)))
+    assert not ran, "runner must NOT be called in off mode"
+    assert repo.get("_documentation_urls") == []
+
+
+def test_default_mode_is_apply(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("V2_REPO_SIGNALS_AGENT_MODE", raising=False)
+    ran: list[int] = []
+
+    async def _stub_runner(inp: Any, **_kw: Any) -> _FixedPatch:
+        ran.append(1)
+        return _FIXED_PATCH
+
+    monkeypatch.setattr(
+        "src.v2.pipeline.stages.refine_with_llm.run_repo_signals",
+        _stub_runner,
+    )
+
+    repo = _make_repo()
+    _run(_run_repo_signals_pass(repositories=[repo], gathered_context=_gathered(repo)))
+    assert ran, "default mode is apply — runner must be called"
+    assert repo.get("_documentation_urls") == _DOC_URLS
+
+
+# --- no README ---
+
+
+def test_no_readme_skips_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("V2_REPO_SIGNALS_AGENT_MODE", "apply")
+    ran: list[int] = []
+
+    async def _stub_runner(inp: Any, **_kw: Any) -> _FixedPatch:
+        ran.append(1)
+        return _FIXED_PATCH
+
+    monkeypatch.setattr(
+        "src.v2.pipeline.stages.refine_with_llm.run_repo_signals",
+        _stub_runner,
+    )
+
+    repo = _make_repo(readme=None)
+    # gathered_context has no readme
+    _run(
+        _run_repo_signals_pass(
+            repositories=[repo],
+            gathered_context={"repository": {"readme_content": None}},
+        ),
+    )
+    assert not ran, "agent must be skipped when there is no README"
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _gathered(repo: dict[str, Any]) -> dict[str, Any]:
+    """Build a minimal gathered_context that mirrors refine_with_llm's shape."""
+    readme = repo.get("_readme_content")
+    return {
+        "repository": {
+            "readme_content": readme,
+            "metadata": {},
+        },
+    }


### PR DESCRIPTION
## Summary
Phase 2 of the developer-requested repo enrichment: an LLM refiner that reads the README to surface documentation URLs and fill the test-coverage signal when the deterministic badge parser came up empty.

- **`gme-internal:hasDocumentation`** — new internal field carrying one or more documentation URLs, produced by the `repo_signals` LLM refiner reading the repository README + rule-based candidate URLs.
- **Test-coverage agent fallback** — the refiner fills `_test_coverage` only when the deterministic badge parse (`parse_test_coverage`, Phase 1 / #130) returned None. Never overrides a deterministic value.

## How it works
- `extract_doc_candidate_urls(readme)` (rule-based, `_repo_signals.py`) pre-extracts candidate doc links to ground the agent.
- New refiner `src/v2/agents/llm/refiners/repo_signals/` (`agent.py` + `prompts/system_prompt.md`): `RepoSignalsInput(repository_handle, readme_excerpt, candidate_documentation_urls)` → `RepoSignalsPatch(documentation_urls, test_coverage)` (`extra="forbid"`).
- Wired into `refine_with_llm.py` as `_run_repo_signals_pass()`, gated by `V2_REPO_SIGNALS_AGENT_MODE` (`apply` default / `shadow` / `off`). Skips entirely when there is no README.
- `apply` → sets `_documentation_urls` (→ `gme-internal:hasDocumentation`) and fills `_test_coverage` when currently None; `shadow` → runs without mutation; `off` → skip.

## Tests
- 16 new tests in `tests/v2/test_repo_signals_refiner.py` (monkeypatched runner, no real LLM).
- Full `tests/v2/` gate green locally: **1468 passed, 1 skipped**.