### PR TITLE
feat(deploy+docs): bootstrap index stores on server start + document GitLab family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,35 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
-_No changes yet._
+### Added
+
+- **GitLab index family** — nine new RAG stores
+  (`gitlab_{epfl,ethz,datascience}_{projects,groups,users}`) over the EPFL,
+  ETHZ, and Datascience self-hosted GitLab instances, built on a shared
+  `src/index/_gitlab_base/` engine (one REST v4 client + parallel
+  project/group/user pipelines). All nine are vector-backed, registered in the
+  federated layer, and appear in `GET /v2/manifest`. GitLab user records carry
+  no ORCID (GitLab exposes no verified-ORCID field). See
+  [`docs/gitlab-index.md`](docs/gitlab-index.md).
+- **HTTP ingest + search endpoints for the GitLab family** —
+  `POST /v2/indices/<name>/ingest` (full-instance crawl + embed, async job;
+  optional `limit`) and `POST /v2/indices/<name>/search` for all nine gitlab
+  stores, at parity with the other indices.
+- **Deploy-time index bootstrap** — the Gunicorn `on_starting` hook runs the
+  federated bootstrap once in the master process before workers fork, so every
+  index store exists with its schema before the first request. Idempotent and
+  best-effort; toggle with `INDEX_BOOTSTRAP_ON_START` (default `true`).
+- **LLM README enrichment** — a `repo_signals` refiner that reads the README to
+  populate `gme-internal:hasDocumentation` (documentation URLs) and fill the
+  test-coverage signal when the deterministic badge parse found none. Gated by
+  `V2_REPO_SIGNALS_AGENT_MODE` (`apply`/`shadow`/`off`).
+
+### Fixed
+
+- **Federated bootstrap `_LEAF_STORES`** — the gitlab `groups` (and now `users`)
+  leaf stores were missing from the leaf-opener allowlist and silently
+  bootstrapped as "skipped: no duckdb store"; all nine gitlab leaves now
+  bootstrap correctly.
 
 ## [3.0.0rc1] — Proposed — Identifier URL canonicalisation + per-entity RAG indices (breaking)
 

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -119,3 +119,35 @@ in-place VACUUM); the `.ro` snapshot is the compacted copy. Honours
 disk — e.g. pre-split monoliths `github.duckdb` / `huggingface.duckdb` /
 `communities.duckdb` sitting alongside the split stores — which are candidates
 for retirement once consumers point at the split ones.
+
+## 7. Deploy-time index bootstrap
+
+The serving image bootstraps every index DuckDB store **at startup** so the
+stores exist (with their schema) before the first request. The Gunicorn
+`on_starting` hook (`tools/config/gunicorn_conf.py`) calls
+`src.index._federated.bootstrap.bootstrap_all()` **once in the master process,
+before any worker forks** — so no two workers race to create the same file.
+
+- **Idempotent** — existing stores are left untouched; only missing ones are
+  created. Safe to run on every restart.
+- **Best-effort** — a bootstrap failure is logged (`index bootstrap on start
+  failed: …`) but never blocks the server from coming up. Per-store failures
+  are reported as `… store(s) not ready: {…}`.
+- **Auto-discovery** — every store under `src/index/*` is picked up, so newly
+  added indices (e.g. the GitLab family) are bootstrapped with no extra wiring.
+
+| Env | Default | Purpose |
+|---|---|---|
+| `INDEX_BOOTSTRAP_ON_START` | `true` | Set `false`/`0`/`no`/`off` to skip the startup bootstrap — e.g. when an init-container or a separate job provisions `$INDEX_DATA_DIR`. |
+
+Run the same thing by hand (local dev, CI, or to re-create a deleted store):
+
+```bash
+make bootstrap-index                          # all stores, idempotent
+python -m src.index._federated.bootstrap      # same thing
+python -m src.index._federated.bootstrap --only gitlab_epfl_users
+```
+
+Bootstrap only **creates empty schema'd stores** — it does not ingest or embed.
+Populate a store with its ingest/embed CLI or the
+`POST /v2/indices/<name>/ingest` endpoint.

--- a/docs/gitlab-index.md
+++ b/docs/gitlab-index.md
@@ -1,0 +1,217 @@
+# GitLab Index
+
+A family of **9 standalone RAG indices** over three self-hosted GitLab
+instances — EPFL, ETH Zurich, and the Swiss Data Science Center — covering
+their **projects**, **groups**, and **users**. All 9 share one engine at
+[`src/index/_gitlab_base/`](https://github.com/Imaging-Plaza/git-metadata-extractor/tree/main/src/index/_gitlab_base);
+the thin per-instance leaves live at `src/index/gitlab_<instance>_<type>/`.
+
+> **Two complementary views.** The federated layer
+> ([`federated-search.md`](federated-search.md)) is the agent- and
+> cross-index-facing surface. *This* page documents the per-store
+> direct-access surfaces — the CLI entry points and the HTTP
+> ingest + search endpoints — for analysts and scripts that target a single
+> store.
+
+## What it indexes
+
+Each of the 9 stores is vector-backed (its own Qdrant collection),
+`surface_as_source=True`, and registered in the federated layer, so all 9
+appear in `GET /v2/manifest` and in federated search / lookup.
+
+| Store | Host | Entity type | Qdrant collection |
+|---|---|---|---|
+| `gitlab_epfl_projects` | `gitlab.epfl.ch` | project | `gitlab_epfl_projects` |
+| `gitlab_epfl_groups` | `gitlab.epfl.ch` | group | `gitlab_epfl_groups` |
+| `gitlab_epfl_users` | `gitlab.epfl.ch` | user | `gitlab_epfl_users` |
+| `gitlab_ethz_projects` | `gitlab.ethz.ch` | project | `gitlab_ethz_projects` |
+| `gitlab_ethz_groups` | `gitlab.ethz.ch` | group | `gitlab_ethz_groups` |
+| `gitlab_ethz_users` | `gitlab.ethz.ch` | user | `gitlab_ethz_users` |
+| `gitlab_datascience_projects` | `gitlab.datascience.ch` | project | `gitlab_datascience_projects` |
+| `gitlab_datascience_groups` | `gitlab.datascience.ch` | group | `gitlab_datascience_groups` |
+| `gitlab_datascience_users` | `gitlab.datascience.ch` | user | `gitlab_datascience_users` |
+
+## The shared `_gitlab_base` engine
+
+All three instances speak the same GitLab REST v4 API, so the crawl logic
+lives once in `src/index/_gitlab_base/`:
+
+- One `GitLabClient` — wraps the REST v4 endpoints (`/projects`, `/groups`,
+  `/users`), follows `X-Next-Page` pagination, and retries on `429` / `5xx`.
+- Three parallel pipelines — `project_*`, `group_*`, `user_*` — each with its
+  own `schema.sql`, store, ingest, embed, and retrieval modules.
+
+A per-instance leaf (`src/index/gitlab_<instance>_<type>/`) is a thin wrapper
+that binds the shared pipeline to one host + one entity type. Each leaf
+exposes the standard programmatic surface:
+
+```python
+run_ingest(limit=None)   # full-instance crawl (omit limit to crawl everything)
+run_embed(limit=None)    # embed un-embedded rows
+search(query, top_k, candidate_k, filter_payload)
+```
+
+### Authentication for the source
+
+Public listings on all three instances work **unauthenticated**, so no token
+is required to bootstrap or crawl. Supplying a source token raises the
+rate limit and can widen visibility:
+
+| Env | Instance |
+|---|---|
+| `GITLAB_EPFL_TOKEN` | `gitlab.epfl.ch` |
+| `GITLAB_ETHZ_TOKEN` | `gitlab.ethz.ch` |
+| `GITLAB_DATASCIENCE_TOKEN` | `gitlab.datascience.ch` |
+
+(As with every index, `RCP_TOKEN` is required for the embed + search steps.)
+
+## Canonical id shapes
+
+Every record's `id` is a canonical URL (`id_shape="url"`):
+
+| Entity type | Canonical id |
+|---|---|
+| project | `https://<host>/<full_path>` |
+| group | `https://<host>/groups/<full_path>` |
+| user | `https://<host>/<username>` |
+
+## User records — no ORCID (important caveat)
+
+The user stores carry these fields: `username`, `name`, `bio`, `location`,
+`organization`, `job_title`, `public_email`, `website_url`, `linkedin`,
+`twitter`, `avatar_url`, `web_url`, `raw`.
+
+**Unlike the GitHub users index, GitLab exposes no verified ORCID
+property**, so the GitLab user stores carry **no ORCID**. Treat the GitLab
+users index as a **people / contact** index, and resolve ORCID separately via
+the `orcid` / `github_users` indices.
+
+## Bootstrap, ingest, embed
+
+### Deploy-time bootstrap (automatic)
+
+The 9 GitLab leaf stores are auto-discovered by the federated bootstrap, so
+their DuckDB files exist (with schema applied) **before the first request** —
+the Gunicorn `on_starting` hook in `tools/config/gunicorn_conf.py` runs the
+bootstrap once in the master process before workers fork. It is idempotent
+(existing stores untouched) and best-effort (a failure is logged, never blocks
+server start). Toggle with `INDEX_BOOTSTRAP_ON_START` (default `true`; set
+`false`/`0`/`no`/`off` to skip — e.g. when an init-container provisions the
+data dir). See the
+[Bootstrap on deploy](rag-indices.md#bootstrap-on-deploy) note and the
+[operations runbook](OPERATIONS_RUNBOOK.md#7-deploy-time-index-bootstrap).
+
+Manual equivalents:
+
+```bash
+make bootstrap-index                          # all stores, idempotent, empty
+python -m src.index._federated.bootstrap      # same thing
+```
+
+### CLI / programmatic ingest + embed
+
+Each leaf exposes `run_ingest` / `run_embed` / `search`:
+
+```python
+from src.index.gitlab_epfl_users.ingest import run_ingest
+from src.index.gitlab_epfl_users.embed import run_embed
+from src.index.gitlab_epfl_users.retrieval import search
+
+run_ingest(limit=50)     # smoke test: cap the crawl
+run_ingest()             # full-instance crawl (no cap)
+run_embed()              # embed new rows (idempotent)
+
+hits = search("computer vision researcher", top_k=5,
+              candidate_k=None, filter_payload=None)
+```
+
+## HTTP API
+
+Every one of the 9 stores exposes the standard index ingest + search routes
+under `/v2/indices/<name>/…`. All index endpoints require the same bearer
+token as the rest of `/v2` (see the
+[Authentication](v2-api-reference.md#authentication) section of the v2 API
+reference).
+
+### `POST /v2/indices/<name>/ingest`
+
+Body — optional cap; omit (or send `null`) to crawl the whole public instance:
+
+```json
+{ "limit": 100 }
+```
+
+Returns `202 Accepted` with an `IndexIngestJobAccepted`:
+
+```json
+{
+  "job_id": "…",
+  "index_name": "gitlab_epfl_users",
+  "status": "pending",
+  "status_url": "/v2/indices/jobs/…",
+  "submitted_at": "…"
+}
+```
+
+The job runs a full-instance crawl and then embeds. Poll
+`GET /v2/indices/jobs/{job_id}` for status.
+
+### `POST /v2/indices/<name>/search`
+
+Body is an `IndexSearchRequest`:
+
+```json
+{
+  "query": "computer vision researcher",
+  "top_k": 10,
+  "candidate_k": null,
+  "filter_payload": null,
+  "target": null
+}
+```
+
+Returns an `IndexSearchResponse` `{index_name, target, query, hits[]}`. These
+stores are single-entity, so `target` is ignored.
+
+### Worked example — `gitlab_epfl_users`
+
+```bash
+# Ingest (cap at 100 for a smoke test; omit "limit" for a full crawl)
+curl -s -X POST https://<host>/v2/indices/gitlab_epfl_users/ingest \
+     -H "Authorization: Bearer $API_TOKEN" \
+     -H 'content-type: application/json' \
+     -d '{"limit": 100}'
+# → 202 {"job_id":"…","index_name":"gitlab_epfl_users","status":"pending",
+#        "status_url":"/v2/indices/jobs/…","submitted_at":"…"}
+
+# Poll the job
+curl -s https://<host>/v2/indices/jobs/<job_id> \
+     -H "Authorization: Bearer $API_TOKEN"
+
+# Search
+curl -s -X POST https://<host>/v2/indices/gitlab_epfl_users/search \
+     -H "Authorization: Bearer $API_TOKEN" \
+     -H 'content-type: application/json' \
+     -d '{"query":"computer vision researcher","top_k":5}'
+```
+
+Swap the store name in the path for any of the other 8 (e.g.
+`gitlab_ethz_projects`, `gitlab_datascience_groups`) — the contract is
+identical.
+
+## Federated layer + manifest
+
+All 9 stores are registered in the federated layer, so they:
+
+- appear in `GET /v2/manifest`, and
+- participate in federated search / lookup — `gme-search` fans a query out
+  across them alongside every other index, and `gme-entity` recognises a
+  canonical GitLab URL (project / group / user) and routes it to the right
+  store.
+
+```bash
+just gme-search "Swiss data science project" --top-k 10
+just gme-entity https://gitlab.epfl.ch/<username>
+```
+
+See [`federated-search.md`](federated-search.md) for the federated design.

--- a/docs/rag-indices.md
+++ b/docs/rag-indices.md
@@ -30,6 +30,7 @@ The federated layer never shares state — it just orchestrates.
 | **RenkuLab** | renkulab.io/api/data | [`src/index/renkulab/`](https://github.com/Imaging-Plaza/git-metadata-extractor/tree/main/src/index/renkulab) | `renku-*` | ✅ | ✅ | Projects, groups, users, data connectors hosted by SDSC RenkuLab |
 | **EPFL Graph (disciplines)** | graphai.epfl.ch /ontology/* | [`src/index/epfl_graph/`](https://github.com/Imaging-Plaza/git-metadata-extractor/tree/main/src/index/epfl_graph) | `epfl-graph-*` | ✅ | ✅ (`search_epfl_graph_disciplines`) | Curated EPFL Graph academic-discipline ontology (~2226 categories, depth 1..5) backed by anchor Wikipedia articles |
 | **SWISSUbase** | swissubase.ch | [`src/index/swissubase/`](https://github.com/Imaging-Plaza/git-metadata-extractor/tree/main/src/index/swissubase) | `swissubase-*` | ✅ | ✅ (`search_swissubase_rag`) | Swiss social-science research-data platform: studies, datasets, persons, institutions. Ingest is Selenium-driven (no public REST API; per-`studyVersionId` enumeration to dodge the search-window cap). Default scope embeds only EPFL / ETHZ / SDSC-affiliated studies. |
+| **GitLab** (EPFL / ETHZ / Datascience) | gitlab.epfl.ch · gitlab.ethz.ch · gitlab.datascience.ch | [`src/index/_gitlab_base/`](https://github.com/Imaging-Plaza/git-metadata-extractor/tree/main/src/index/_gitlab_base) + `gitlab_<instance>_<type>/` leaves | (per-CLI) | ✅ | (via federated) | 9 stores — **projects**, **groups**, **users** per instance. People records carry no ORCID (GitLab has no verified-ORCID field). See [GitLab Index](gitlab-index.md). |
 | **Federated** | wraps all above | [`src/index/_federated/`](https://github.com/Imaging-Plaza/git-metadata-extractor/tree/main/src/index/_federated) | `gme-*` | — | ✅ (`search_federated_rag`, `lookup_entity_federated`) | one query → all indices in parallel |
 
 > **Support index (no RAG layer).** The [Communities index](communities-index.md)
@@ -50,6 +51,34 @@ Every index built on the post-2026-05-01 pattern uses:
 - **Auth**: `RCP_TOKEN` (required for embed + rerank); per-index source tokens (`HF_TOKEN`, `GME_GITHUB_TOKEN`, `INFOSCIENCE_TOKEN`, etc.) where the upstream API requires them.
 
 The `ror` index is a partial outlier (no DuckDB layer; flat catalog of orgs in Qdrant + a JSONL dump for lexical lookup). The `infoscience` legacy chunks live alongside the new schema.
+
+### Bootstrap on deploy
+
+Stores are created and schema-applied by the **federated bootstrap**
+(`src/index/_federated/bootstrap.py`), which auto-discovers every store under
+`src/index/*` — so a newly added index needs no wiring to be bootstrapped.
+
+On a deployed microservice this runs **automatically at startup**: the Gunicorn
+`on_starting` hook (`tools/config/gunicorn_conf.py`) calls `bootstrap_all()`
+once in the master process **before any worker forks**, so every DuckDB store
+exists with its schema applied before the first request — and N workers never
+race to create the same file. The bootstrap is **idempotent** (existing stores
+are left untouched) and **best-effort** (a failure is logged but never blocks
+the server from coming up).
+
+| Env | Default | Purpose |
+|---|---|---|
+| `INDEX_BOOTSTRAP_ON_START` | `true` | Set `false`/`0`/`no`/`off` to skip the startup bootstrap — e.g. when an init-container or a separate job provisions the data dir. |
+
+Manual equivalents (local dev, CI, or re-runs):
+
+```bash
+make bootstrap-index                                    # all stores, idempotent
+python -m src.index._federated.bootstrap --only gitlab_epfl_users
+```
+
+See the [operations runbook](OPERATIONS_RUNBOOK.md#7-deploy-time-index-bootstrap)
+for the operational view.
 
 ## Per-index quickstart
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Communities Index: communities-index.md
       - EPFL Graph Disciplines: epfl-graph-disciplines.md
       - SWISSUbase Index: swissubase-index.md
+      - GitLab Index: gitlab-index.md
       - V2 Agent RAG Tools: v2-rag-tools.md
       - Concept Tagging Stage: concept-tagging.md
       - Roadmap: ROADMAP.md

--- a/tools/config/gunicorn_conf.py
+++ b/tools/config/gunicorn_conf.py
@@ -48,6 +48,49 @@ errorlog = "-"  # Log to stderr
 loglevel = os.getenv("LOG_LEVEL", "info")
 
 
+def _bootstrap_on_start_enabled() -> bool:
+    """Whether to create + schema-bootstrap every index store at server start.
+
+    Defaults to on. Set ``INDEX_BOOTSTRAP_ON_START=false`` (or ``0``/``no``)
+    to skip — e.g. when the index data dir is provisioned by a separate
+    job/init-container and the serving process should not touch it.
+    """
+    raw = os.getenv("INDEX_BOOTSTRAP_ON_START", "true").strip().lower()
+    return raw not in {"false", "0", "no", "off"}
+
+
+def on_starting(server):
+    """Called once in the Gunicorn master before any worker is forked.
+
+    Running the federated bootstrap here (rather than per-worker) means every
+    index DuckDB store — including newly added stores, which are auto-discovered
+    from ``src/index/*`` — exists with its schema applied before the first
+    request, with no risk of N workers racing to create the same file. The
+    bootstrap is idempotent (existing stores are left untouched) and best-effort:
+    a failure is logged but never blocks the server from coming up.
+    """
+    if not _bootstrap_on_start_enabled():
+        server.log.info("index bootstrap on start disabled; skipping")
+        return
+    try:
+        from src.index._federated.bootstrap import bootstrap_all  # noqa: PLC0415
+
+        results = bootstrap_all()
+    except Exception as exc:  # noqa: BLE001 — never block server start on bootstrap
+        server.log.warning("index bootstrap on start failed: %s", exc)
+        return
+    created = sum(1 for s in results.values() if s == "created")
+    existed = sum(1 for s in results.values() if s == "exists")
+    errored = {n: s for n, s in results.items() if s not in {"created", "exists"}}
+    server.log.info(
+        "index bootstrap on start: %d stores (created=%d, existing=%d)",
+        len(results), created, existed,
+    )
+    if errored:
+        server.log.warning("index bootstrap on start: %d store(s) not ready: %s",
+                           len(errored), errored)
+
+
 def post_fork(server, worker):
     """
     Called just after a worker has been forked.


### PR DESCRIPTION
## Summary
Two follow-ups to the GitLab index work: (1) make the deployed microservice bootstrap its index stores automatically, and (2) document the GitLab family + the bootstrap behaviour.

## Deploy-time bootstrap
The container entrypoint (`gunicorn src.api:app`) previously never bootstrapped the index stores — they were only created manually via `make bootstrap-index`. This adds an `on_starting` hook in `tools/config/gunicorn_conf.py` that runs `bootstrap_all()` **once in the Gunicorn master before any worker forks**, so every index DuckDB store (auto-discovered from `src/index/*`, including the new gitlab stores) exists with its schema applied before the first request — and N workers never race to create the same file.

- **Idempotent** — existing stores untouched.
- **Best-effort** — a failure is logged, never blocks server start.
- **Toggle** — `INDEX_BOOTSTRAP_ON_START` (default `true`; `false`/`0`/`no`/`off` to skip, e.g. when an init-container provisions the data dir).

Smoke-tested: the hook creates all 31 discovered stores (incl. the 3 gitlab users stores) into a temp data dir with zero errors.

## Docs
- **New `docs/gitlab-index.md`** (added to nav): the 9-store family table, the shared `_gitlab_base` engine, canonical id shapes, the **no-ORCID caveat**, bootstrap/ingest/embed, the HTTP ingest + search endpoints with `curl` examples, and how it surfaces in `/v2/manifest` + federated search.
- **`rag-indices.md`**: GitLab inventory row + a **"Bootstrap on deploy"** section.
- **`OPERATIONS_RUNBOOK.md`**: new section *7. Deploy-time index bootstrap*.
- **`CHANGELOG.md`**: `[Unreleased]` entries (gitlab family, HTTP endpoints, deploy bootstrap, LLM README enrichment; the `_LEAF_STORES` fix).

## Verification
- `ruff check tools/config/gunicorn_conf.py` → clean.
- `tests/index/_federated/test_bootstrap.py` → 4 passed.
- `mkdocs build --strict` adds **zero new warnings**. Note: the strict build already aborts on `develop` due to **4 pre-existing** broken-link warnings in unrelated files (`v2-pipeline.md`, `epfl-graph-disciplines.md`) — out of scope here; flagged separately.