### PR TITLE
feat(v2): flat release scalars for Release Frequency (gme-internal:release_count/first/latest)

### DIFF
--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -222,3 +222,46 @@ def extract_doc_candidate_urls(readme: str | None) -> list[str]:
             seen.add(url)
             result.append(url)
     return result
+
+
+# ---------------------------------------------------------------------------
+# Release frequency — flat scalars for `gme-internal:*`
+# ---------------------------------------------------------------------------
+
+
+def summarize_releases(releases: Any) -> dict[str, Any]:
+    """Reduce a raw release list to flat, RDF-friendly scalars.
+
+    The raw ``_releases`` list-of-objects (``{tag_name, published_at, …}``)
+    collapses to empty blank nodes on JSON-LD expansion (its inner keys are
+    not mapped in the ``@context``), so it is unusable as triples. This
+    derives the three flat values a "Release Frequency" consumer actually
+    needs — each emits as a single ``gme-internal:`` literal triple:
+
+    * ``release_count``       — number of releases
+    * ``first_release_date``  — earliest ``published_at`` (ISO 8601 string)
+    * ``latest_release_date`` — latest ``published_at`` (ISO 8601 string)
+
+    ``published_at`` is an ISO 8601 timestamp, so min/max is a plain string
+    compare (lexical == chronological). Releases missing ``published_at``
+    (e.g. drafts) are ignored for the date bounds but still counted. The
+    three keys are *always* present (``None`` when there is no release data),
+    mirroring the always-present ``_latest_version`` sibling.
+    """
+    out: dict[str, Any] = {
+        "release_count": None,
+        "first_release_date": None,
+        "latest_release_date": None,
+    }
+    if not isinstance(releases, list):
+        return out
+    out["release_count"] = len(releases)
+    dates = sorted(
+        r.get("published_at")
+        for r in releases
+        if isinstance(r, dict) and isinstance(r.get("published_at"), str) and r.get("published_at")
+    )
+    if dates:
+        out["first_release_date"] = dates[0]
+        out["latest_release_date"] = dates[-1]
+    return out

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -15,6 +15,7 @@ from src.v2.agents.models import (
 from src.v2.agents.rule_based._repo_signals import (
     parse_docker_hub_url,
     parse_test_coverage,
+    summarize_releases,
 )
 from src.v2.canonicalization.github import github_repo_iri, github_user_iri
 from src.v2.parsers.citation_cff import parse_citation_cff
@@ -530,6 +531,17 @@ class RepositoryAgentV2:
                 if isinstance(repository.get("releases"), list) and repository["releases"]
                 else None
             ),
+            # Flat, RDF-friendly release scalars for "Release Frequency".
+            # The raw `_releases` list-of-objects collapses to empty blank
+            # nodes on JSON-LD expansion (inner keys unmapped in @context),
+            # so these single-value `gme-internal:release_count /
+            # first_release_date / latest_release_date` triples are what
+            # downstream consumers actually query. Always present (None when
+            # no release data), like `_latest_version`.
+            **{
+                f"_{k}": v
+                for k, v in summarize_releases(repository.get("releases")).items()
+            },
             "_container_images": (repository.get("container_images") or None),
             # CI presence — detected from the repo root listing by
             # context_gather and stored in repository_metadata["has_ci"].

--- a/tests/v2/test_repo_enrichment_fields.py
+++ b/tests/v2/test_repo_enrichment_fields.py
@@ -17,6 +17,7 @@ from src.v2.agents.rule_based._repo_signals import (
     detect_has_ci,
     parse_docker_hub_url,
     parse_test_coverage,
+    summarize_releases,
 )
 from src.v2.ingest.providers.mock_github import MockGitHubProvider
 
@@ -268,6 +269,71 @@ def test_repository_agent_releases_none_when_absent() -> None:
     raw = result.raw_output
     assert raw["_latest_version"] is None
     assert raw["_releases"] is None
+    # Flat release scalars are always present, None when no releases.
+    assert raw["_release_count"] is None
+    assert raw["_first_release_date"] is None
+    assert raw["_latest_release_date"] is None
+
+
+# ---------------------------------------------------------------------------
+# summarize_releases — flat release scalars for "Release Frequency"
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_releases_counts_and_date_bounds() -> None:
+    out = summarize_releases(_STUB_RELEASES)
+    assert out["release_count"] == len(_STUB_RELEASES)
+    # Bounds are min/max over published_at (independent of list order).
+    assert out["first_release_date"] == "2024-01-15T08:00:00Z"
+    assert out["latest_release_date"] == "2024-03-01T12:00:00Z"
+
+
+def test_summarize_releases_none_input_all_none() -> None:
+    out = summarize_releases(None)
+    assert out == {
+        "release_count": None,
+        "first_release_date": None,
+        "latest_release_date": None,
+    }
+
+
+def test_summarize_releases_empty_list_counts_zero_no_dates() -> None:
+    out = summarize_releases([])
+    assert out["release_count"] == 0
+    assert out["first_release_date"] is None
+    assert out["latest_release_date"] is None
+
+
+def test_summarize_releases_ignores_missing_published_at_for_bounds() -> None:
+    releases = [
+        {"tag_name": "v3", "published_at": "2024-05-01T00:00:00Z"},
+        {"tag_name": "draft"},  # no published_at → counted, ignored for bounds
+        {"tag_name": "v1", "published_at": "2024-02-01T00:00:00Z"},
+    ]
+    out = summarize_releases(releases)
+    assert out["release_count"] == len(releases)
+    assert out["first_release_date"] == "2024-02-01T00:00:00Z"
+    assert out["latest_release_date"] == "2024-05-01T00:00:00Z"
+
+
+def test_repository_agent_emits_flat_release_scalars() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(releases=_STUB_RELEASES),
+            },
+            providers,
+        ),
+    )
+
+    raw = result.raw_output
+    assert raw["_release_count"] == len(_STUB_RELEASES)
+    assert raw["_first_release_date"] == "2024-01-15T08:00:00Z"
+    assert raw["_latest_release_date"] == "2024-03-01T12:00:00Z"
 
 
 def test_repository_agent_emits_test_coverage_from_readme() -> None:


### PR DESCRIPTION
## Why
The raw `_releases` field (list of `{tag_name, published_at, …}` objects) is emitted under `gme-internal:releases`, but its inner keys are **not mapped in the JSON-LD `@context`** (there's no `@vocab`). So on RDF expansion each release collapses to an **empty blank node** — the per-release data is lost as triples, and "Release Frequency" consumers had nothing queryable. (List-of-strings like keywords work because they expand to repeated *literal* triples; list-of-dicts does not.)

This follows the codebase's established pattern (publiccode hoists flat scalars/list-of-strings to predicates; `gme-internal:has_ci` / `docker_hub_url` are clean scalar triples) rather than reshaping the context for nested nodes.

## What
New deterministic `summarize_releases()` in `_repo_signals.py`, wired into `repository_agent.py` alongside the existing `_latest_version`:

| Field | JSON-LD term | Shape |
|---|---|---|
| `_release_count` | `gme-internal:release_count` | int |
| `_first_release_date` | `gme-internal:first_release_date` | ISO 8601 string |
| `_latest_release_date` | `gme-internal:latest_release_date` | ISO 8601 string |

Count + min/max over `published_at` (ISO compare == chronological; releases missing `published_at` are counted but ignored for the date bounds). Always present (None when no release data), mirroring `_latest_version`. The raw `_releases` list is unchanged for consumers that want the full payload.

Verified live emission (`?include_internal_fields=true`):
```
gme-internal:release_count        = 2
gme-internal:first_release_date   = "2024-01-15T08:00:00Z"
gme-internal:latest_release_date  = "2024-03-01T12:00:00Z"
```
These read "no data" until a re-extract, same as `has_ci` / `docker_hub_url` / Issue Response Time — the plumbing is done.

## Tests
4 unit tests for `summarize_releases` (counts + date bounds, None input, empty list → count 0, missing-`published_at` handling) + 2 agent-level assertions (flat scalars present with releases; all-None when absent). Full `tests/v2/` green: **1480 passed, 1 skipped**. No new ruff findings.

## Note on the other fields
`gme-internal:has_ci` and `gme-internal:docker_hub_url` are **already wired** (scalar triples, set by `repository_agent.py`) — no change needed; they just need a re-extract to populate. `_documentation_urls` (list-of-strings) already comes through as repeated triples.