### PR TITLE
feat(v2): flat package scalars for Container distribution (gme-internal:package_*)

### DIFF
--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -265,3 +265,56 @@ def summarize_releases(releases: Any) -> dict[str, Any]:
         out["first_release_date"] = dates[0]
         out["latest_release_date"] = dates[-1]
     return out
+
+
+def summarize_packages(container_images: Any) -> dict[str, Any]:
+    """Reduce the raw GHCR container-package list to flat, RDF-friendly scalars.
+
+    Like ``_releases``, the raw ``_container_images`` list-of-objects
+    (``{name, image, tags, updated_at, …}``) collapses to empty blank nodes on
+    JSON-LD expansion (inner keys unmapped in the ``@context``), so it is
+    unusable as triples. This derives the flat values a "Container
+    distribution" / package consumer needs, each emitting clean
+    ``gme-internal:`` triples:
+
+    * ``package_count``            — number of linked container packages (int)
+    * ``package_names``            — package names (list → repeated triples)
+    * ``package_image_refs``       — pullable ``ghcr.io/owner/name`` refs (list)
+    * ``package_versions``         — distinct version tags across all packages
+                                     (list → repeated triples)
+    * ``latest_package_updated_at`` — most recent ``updated_at`` (ISO 8601)
+
+    Per-package version detail stays in the raw ``_container_images`` payload.
+    The five keys are *always* present (``None`` when there is no package data).
+    """
+    out: dict[str, Any] = {
+        "package_count": None,
+        "package_names": None,
+        "package_image_refs": None,
+        "package_versions": None,
+        "latest_package_updated_at": None,
+    }
+    if not isinstance(container_images, list):
+        return out
+    images = [c for c in container_images if isinstance(c, dict)]
+    out["package_count"] = len(images)
+    names = [c["name"] for c in images if isinstance(c.get("name"), str) and c["name"]]
+    refs = [c["image"] for c in images if isinstance(c.get("image"), str) and c["image"]]
+    out["package_names"] = names or None
+    out["package_image_refs"] = refs or None
+    versions = sorted({
+        tag
+        for c in images
+        if isinstance(c.get("tags"), list)
+        for tag in c["tags"]
+        if isinstance(tag, str) and tag
+    })
+    out["package_versions"] = versions or None
+    updated = sorted(
+        c["updated_at"]
+        for c in images
+        if isinstance(c.get("updated_at"), str) and c["updated_at"]
+    )
+    if updated:
+        out["latest_package_updated_at"] = updated[-1]
+    return out

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -15,6 +15,7 @@ from src.v2.agents.models import (
 from src.v2.agents.rule_based._repo_signals import (
     parse_docker_hub_url,
     parse_test_coverage,
+    summarize_packages,
     summarize_releases,
 )
 from src.v2.canonicalization.github import github_repo_iri, github_user_iri
@@ -543,6 +544,20 @@ class RepositoryAgentV2:
                 for k, v in summarize_releases(repository.get("releases")).items()
             },
             "_container_images": (repository.get("container_images") or None),
+            # Flat, RDF-friendly package scalars for "Container distribution".
+            # The raw `_container_images` list-of-objects collapses to empty
+            # blank nodes on JSON-LD expansion (inner keys unmapped in
+            # @context), so these single-value `gme-internal:package_count /
+            # package_names / package_image_refs / package_versions /
+            # latest_package_updated_at` triples are what consumers query.
+            # Always present (None when no package data). GHCR scope only —
+            # needs the `read:packages` token scope, else reads None.
+            **{
+                f"_{k}": v
+                for k, v in summarize_packages(
+                    repository.get("container_images"),
+                ).items()
+            },
             # CI presence — detected from the repo root listing by
             # context_gather and stored in repository_metadata["has_ci"].
             # None when the listing was unavailable.

--- a/tests/v2/test_repo_enrichment_fields.py
+++ b/tests/v2/test_repo_enrichment_fields.py
@@ -17,6 +17,7 @@ from src.v2.agents.rule_based._repo_signals import (
     detect_has_ci,
     parse_docker_hub_url,
     parse_test_coverage,
+    summarize_packages,
     summarize_releases,
 )
 from src.v2.ingest.providers.mock_github import MockGitHubProvider
@@ -184,6 +185,32 @@ _STUB_RELEASES = [
     },
 ]
 
+_STUB_CONTAINER_IMAGES = [
+    {
+        "name": "open-pulse",
+        "image": "ghcr.io/sdsc-ordes/open-pulse",
+        "visibility": "public",
+        "linked_repository": "sdsc-ordes/open-pulse",
+        "match": "repository",
+        "tags": ["latest", "v1.2.0", "v1.1.0"],
+        "updated_at": "2024-04-01T10:00:00Z",
+        "created_at": "2024-01-01T10:00:00Z",
+        "html_url": "https://github.com/sdsc-ordes/open-pulse/pkgs/container/open-pulse",
+    },
+    {
+        "name": "open-pulse-worker",
+        "image": "ghcr.io/sdsc-ordes/open-pulse-worker",
+        "visibility": "public",
+        "linked_repository": "sdsc-ordes/open-pulse",
+        "match": "repository",
+        "tags": ["v1.2.0"],
+        "updated_at": "2024-02-15T10:00:00Z",
+        "created_at": "2024-02-01T10:00:00Z",
+        "html_url": "https://github.com/sdsc-ordes/open-pulse/pkgs/container/open-pulse-worker",
+    },
+]
+
+
 _README_WITH_SIGNALS = (
     "# My Tool\n"
     "![coverage](https://img.shields.io/badge/coverage-87%25-green)\n"
@@ -195,6 +222,7 @@ _README_WITH_SIGNALS = (
 def _make_stub_context(
     *,
     releases: list[dict[str, Any]] | None = None,
+    container_images: list[dict[str, Any]] | None = None,
     readme_content: str = "",
     has_ci: bool | None = None,
     aux_files: dict[str, str] | None = None,
@@ -211,6 +239,8 @@ def _make_stub_context(
     }
     if releases is not None:
         metadata["releases"] = releases
+    if container_images is not None:
+        metadata["container_images"] = container_images
     if has_ci is not None:
         metadata["has_ci"] = has_ci
 
@@ -334,6 +364,93 @@ def test_repository_agent_emits_flat_release_scalars() -> None:
     assert raw["_release_count"] == len(_STUB_RELEASES)
     assert raw["_first_release_date"] == "2024-01-15T08:00:00Z"
     assert raw["_latest_release_date"] == "2024-03-01T12:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# summarize_packages — flat package scalars for "Container distribution"
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_packages_counts_names_refs_versions_dates() -> None:
+    out = summarize_packages(_STUB_CONTAINER_IMAGES)
+    assert out["package_count"] == len(_STUB_CONTAINER_IMAGES)
+    assert out["package_names"] == ["open-pulse", "open-pulse-worker"]
+    assert out["package_image_refs"] == [
+        "ghcr.io/sdsc-ordes/open-pulse",
+        "ghcr.io/sdsc-ordes/open-pulse-worker",
+    ]
+    # Distinct tags across all packages, sorted.
+    assert out["package_versions"] == ["latest", "v1.1.0", "v1.2.0"]
+    # Latest updated_at across packages.
+    assert out["latest_package_updated_at"] == "2024-04-01T10:00:00Z"
+
+
+def test_summarize_packages_none_input_all_none() -> None:
+    out = summarize_packages(None)
+    assert out == {
+        "package_count": None,
+        "package_names": None,
+        "package_image_refs": None,
+        "package_versions": None,
+        "latest_package_updated_at": None,
+    }
+
+
+def test_summarize_packages_empty_list_counts_zero() -> None:
+    out = summarize_packages([])
+    assert out["package_count"] == 0
+    assert out["package_names"] is None
+    assert out["package_versions"] is None
+    assert out["latest_package_updated_at"] is None
+
+
+def test_repository_agent_emits_flat_package_scalars() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(
+                    container_images=_STUB_CONTAINER_IMAGES,
+                ),
+            },
+            providers,
+        ),
+    )
+
+    raw = result.raw_output
+    assert raw["_package_count"] == len(_STUB_CONTAINER_IMAGES)
+    assert raw["_package_image_refs"] == [
+        "ghcr.io/sdsc-ordes/open-pulse",
+        "ghcr.io/sdsc-ordes/open-pulse-worker",
+    ]
+    assert raw["_package_versions"] == ["latest", "v1.1.0", "v1.2.0"]
+    assert raw["_latest_package_updated_at"] == "2024-04-01T10:00:00Z"
+
+
+def test_repository_agent_package_scalars_none_when_absent() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(container_images=None),
+            },
+            providers,
+        ),
+    )
+
+    raw = result.raw_output
+    assert raw["_container_images"] is None
+    assert raw["_package_count"] is None
+    assert raw["_package_names"] is None
+    assert raw["_package_image_refs"] is None
+    assert raw["_package_versions"] is None
+    assert raw["_latest_package_updated_at"] is None
 
 
 def test_repository_agent_emits_test_coverage_from_readme() -> None:


### PR DESCRIPTION
## Why
Companion to #135 (releases). GHCR container packages — e.g. `https://github.com/sdsc-ordes/open-pulse/pkgs/container/open-pulse` — are captured into `_container_images` (a list of `{name, image, tags, updated_at, html_url, …}` objects), but its inner keys aren't mapped in the JSON-LD `@context`, so each package **collapses to an empty blank node** on RDF expansion. Packages had data but **zero queryable triples** — the same problem releases had.

## What
New `summarize_packages()` in `_repo_signals.py`, wired into `repository_agent.py` beside `_container_images`:

| Field | JSON-LD term | Shape |
|---|---|---|
| `_package_count` | `gme-internal:package_count` | int |
| `_package_names` | `gme-internal:package_names` | list → repeated triples |
| `_package_image_refs` | `gme-internal:package_image_refs` | pullable `ghcr.io/owner/name` (list) |
| `_package_versions` | `gme-internal:package_versions` | distinct tags across packages, sorted (list) |
| `_latest_package_updated_at` | `gme-internal:latest_package_updated_at` | ISO 8601 |

Always present (None when no package data), mirroring the release scalars. Per-package version detail stays in the raw `_container_images` payload.

Verified live emission (`?include_internal_fields=true`):
```
gme-internal:package_count             = 1
gme-internal:package_names             = ["open-pulse"]
gme-internal:package_image_refs        = ["ghcr.io/sdsc-ordes/open-pulse"]
gme-internal:package_versions          = ["latest", "v1.2.0"]
gme-internal:latest_package_updated_at = "2024-04-01T10:00:00Z"
```

## Scope note
Packages = **GHCR container packages** today (requires the `read:packages` token scope; reads None without it) — that matches the `…/pkgs/container/…` example. Other GitHub Packages ecosystems (npm/PyPI/Maven/NuGet/RubyGems) are **not** captured yet; say the word if you want those too (each needs its own Packages-API query).

## Tests
3 unit + 2 agent-level (flat scalars present with packages; all-None when absent). Full `tests/v2/` green: **1485 passed, 1 skipped**. No new ruff findings.