### PR TITLE
refactor(v2): rename gme-internal:package_versions → package_tags

### DIFF
--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -280,18 +280,19 @@ def summarize_packages(container_images: Any) -> dict[str, Any]:
     * ``package_count``            — number of linked container packages (int)
     * ``package_names``            — package names (list → repeated triples)
     * ``package_image_refs``       — pullable ``ghcr.io/owner/name`` refs (list)
-    * ``package_versions``         — distinct version tags across all packages
-                                     (list → repeated triples)
+    * ``package_tags``             — distinct image tags across all packages
+                                     (list → repeated triples). GHCR calls
+                                     these *tags* (``metadata.container.tags``).
     * ``latest_package_updated_at`` — most recent ``updated_at`` (ISO 8601)
 
-    Per-package version detail stays in the raw ``_container_images`` payload.
+    Per-package tag detail stays in the raw ``_container_images`` payload.
     The five keys are *always* present (``None`` when there is no package data).
     """
     out: dict[str, Any] = {
         "package_count": None,
         "package_names": None,
         "package_image_refs": None,
-        "package_versions": None,
+        "package_tags": None,
         "latest_package_updated_at": None,
     }
     if not isinstance(container_images, list):
@@ -302,14 +303,14 @@ def summarize_packages(container_images: Any) -> dict[str, Any]:
     refs = [c["image"] for c in images if isinstance(c.get("image"), str) and c["image"]]
     out["package_names"] = names or None
     out["package_image_refs"] = refs or None
-    versions = sorted({
+    tags = sorted({
         tag
         for c in images
         if isinstance(c.get("tags"), list)
         for tag in c["tags"]
         if isinstance(tag, str) and tag
     })
-    out["package_versions"] = versions or None
+    out["package_tags"] = tags or None
     updated = sorted(
         c["updated_at"]
         for c in images

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -548,7 +548,7 @@ class RepositoryAgentV2:
             # The raw `_container_images` list-of-objects collapses to empty
             # blank nodes on JSON-LD expansion (inner keys unmapped in
             # @context), so these single-value `gme-internal:package_count /
-            # package_names / package_image_refs / package_versions /
+            # package_names / package_image_refs / package_tags /
             # latest_package_updated_at` triples are what consumers query.
             # Always present (None when no package data). GHCR scope only —
             # needs the `read:packages` token scope, else reads None.

--- a/tests/v2/test_repo_enrichment_fields.py
+++ b/tests/v2/test_repo_enrichment_fields.py
@@ -380,7 +380,7 @@ def test_summarize_packages_counts_names_refs_versions_dates() -> None:
         "ghcr.io/sdsc-ordes/open-pulse-worker",
     ]
     # Distinct tags across all packages, sorted.
-    assert out["package_versions"] == ["latest", "v1.1.0", "v1.2.0"]
+    assert out["package_tags"] == ["latest", "v1.1.0", "v1.2.0"]
     # Latest updated_at across packages.
     assert out["latest_package_updated_at"] == "2024-04-01T10:00:00Z"
 
@@ -391,7 +391,7 @@ def test_summarize_packages_none_input_all_none() -> None:
         "package_count": None,
         "package_names": None,
         "package_image_refs": None,
-        "package_versions": None,
+        "package_tags": None,
         "latest_package_updated_at": None,
     }
 
@@ -400,7 +400,7 @@ def test_summarize_packages_empty_list_counts_zero() -> None:
     out = summarize_packages([])
     assert out["package_count"] == 0
     assert out["package_names"] is None
-    assert out["package_versions"] is None
+    assert out["package_tags"] is None
     assert out["latest_package_updated_at"] is None
 
 
@@ -426,7 +426,7 @@ def test_repository_agent_emits_flat_package_scalars() -> None:
         "ghcr.io/sdsc-ordes/open-pulse",
         "ghcr.io/sdsc-ordes/open-pulse-worker",
     ]
-    assert raw["_package_versions"] == ["latest", "v1.1.0", "v1.2.0"]
+    assert raw["_package_tags"] == ["latest", "v1.1.0", "v1.2.0"]
     assert raw["_latest_package_updated_at"] == "2024-04-01T10:00:00Z"
 
 
@@ -449,7 +449,7 @@ def test_repository_agent_package_scalars_none_when_absent() -> None:
     assert raw["_package_count"] is None
     assert raw["_package_names"] is None
     assert raw["_package_image_refs"] is None
-    assert raw["_package_versions"] is None
+    assert raw["_package_tags"] is None
     assert raw["_latest_package_updated_at"] is None
 
 


### PR DESCRIPTION
Quick naming fix on the package scalars from #136.

GHCR (and OCI registries generally) call these **tags**, not versions — the GitHub Packages API returns them under `metadata.container.tags`, the package page UI labels them "tags", and our own raw `_container_images[].tags` field already uses that name. Rename `gme-internal:package_versions` → `gme-internal:package_tags` for consistency with the source terminology.

The field is `gme-internal:` only and still reads "no data" until a re-extract, so there's no consumer migration to worry about. Tests updated; `tests/v2/test_repo_enrichment_fields.py` green (48 passed); no new ruff findings.