### PR TITLE
feat(v2): npm + PyPI package discovery (manifest-linked, flat gme-internal scalars)

### DIFF
--- a/docs/superpowers/specs/2026-06-07-npm-pypi-packages.md
+++ b/docs/superpowers/specs/2026-06-07-npm-pypi-packages.md
@@ -1,0 +1,121 @@
+# npm + PyPI package discovery (manifest-linked)
+
+**Date:** 2026-06-07
+**Branch:** `feat/npm-pypi-packages`
+**Goal:** Surface a repo's published **npm** and **PyPI** packages as flat
+`gme-internal:` triples — discovered by reading the repo's manifest for the
+package name, querying the public registry, and verifying the registry's
+declared repo URL points back to this repo.
+
+## Why
+GitHub Packages does not cover public npmjs.com (only `npm.pkg.github.com`) and
+has no PyPI support at all. So we query the registries directly and link by
+manifest name + back-reference verification. Mirrors the flat-scalar pattern of
+releases (#135) and GHCR packages (#136).
+
+## Existing facts to build on
+- `get_repository_aux_files(full_name)` already fetches `package.json`,
+  `pyproject.toml`, `setup.cfg`, `setup.py` (and others) into the `aux_files`
+  dict (`{filename: content}`), available in `context_gather` and passed to the
+  repository agent as `compiled_context["aux_files"]`.
+- `context_gather` already stores best-effort extras into `repository_metadata`
+  (`releases`, `container_images`, `has_ci`) which the repository agent reads via
+  `repository.get(...)` and emits as `_`-prefixed internal fields.
+- `ProviderSet` (`src/v2/agents/models.py`) is the DI bundle; real instances are
+  built in `src/v2/dependencies.py` (mock path ~L351, real paths ~L358/L445).
+- Flat-scalar pattern: `summarize_releases` / `summarize_packages` in
+  `_repo_signals.py`, splatted into the entity dict in `repository_agent.py`,
+  emitted as `gme-internal:*` by `jsonld_build.py` under `?include_internal_fields=true`.
+- Python 3.12 → `tomllib` is stdlib; `configparser` for setup.cfg.
+
+## Design
+
+### 1. Manifest name parsing — pure helpers in `_repo_signals.py`
+- `parse_npm_name(aux_files) -> str | None`: `json.loads(aux_files["package.json"])`,
+  return `name` (keep scoped names `@scope/pkg` intact). None on missing/malformed/
+  empty/`private: true`.
+- `parse_pypi_name(aux_files) -> str | None`: try `pyproject.toml` via `tomllib`
+  → `[project].name` then `[tool.poetry].name`; fallback `setup.cfg` via
+  `configparser` → `[metadata] name`. (Skip `setup.py` — unsafe to exec; a
+  conservative `name=["']...["']` regex is optional, low priority.) None when no
+  name found. Do NOT PEP503-normalise (PyPI accepts the project name as-is).
+- `repo_url_matches(candidate_url, full_name) -> bool`: normalise `candidate_url`
+  (strip `git+`, leading `git://`/`ssh://git@`/`git@github.com:`, trailing `.git`
+  and `/`, lowercase host) and return True iff it resolves to
+  `github.com/<full_name>` (case-insensitive on owner/repo). False on None/empty/
+  non-github/mismatch.
+
+### 2. Registry provider — `src/v2/ingest/providers/package_registry_provider.py` (NEW)
+`class PackageRegistryProvider` with an injectable `session` (a
+`requests.Session`-like with `.get(url, timeout=...)`; default `requests`) and
+optional `ProviderCache` (cache by method+name, like the github provider). Both
+methods are **best-effort**: return `None` on 404 / non-200 / parse / transport
+error; never raise.
+
+- `get_npm_package(name) -> dict | None` — GET `https://registry.npmjs.org/<name>`
+  (URL-encode scoped: `@scope/pkg` → `@scope%2Fpkg`). Extract:
+  - `name`
+  - `latest_version` ← `dist-tags.latest`
+  - `versions` ← sorted list of `versions` keys (cap ~200, log if truncated)
+  - `latest_release_date` ← `time[<latest_version>]` (ISO 8601)
+  - `repository_url` ← `repository.url` (top-level), else the latest version's
+    `repository.url`
+  - `registry_url` ← `https://www.npmjs.com/package/<name>`
+- `get_pypi_package(name) -> dict | None` — GET `https://pypi.org/pypi/<name>/json`.
+  Extract:
+  - `name` ← `info.name`
+  - `latest_version` ← `info.version`
+  - `versions` ← sorted list of `releases` keys (cap ~200)
+  - `latest_release_date` ← max `upload_time_iso_8601` across `releases[latest]`
+    (or `urls`)
+  - `repository_url` ← `info.project_urls` (`Source`/`Repository`/`Code`/`Homepage`,
+    in that priority), else `info.home_page`
+  - `registry_url` ← `https://pypi.org/project/<name>/`
+
+### 3. `context_gather` wiring
+After the aux-files block, gated on `providers.package_registry is not None`,
+best-effort (try/except → `warnings`):
+- `npm_name = parse_npm_name(aux_files)`; if set, `pkg = providers.package_registry
+  .get_npm_package(npm_name)`. Link policy:
+  - `repository_url` present AND `repo_url_matches(..., full_name)` → store with
+    `pkg["link"] = "verified"`.
+  - `repository_url` present AND mismatch → **drop** (false match; do not store).
+  - `repository_url` absent → store with `pkg["link"] = "name_only"`.
+  Store as `repository_metadata["npm_package"]`.
+- Same for `parse_pypi_name` → `get_pypi_package` → `repository_metadata["pypi_package"]`.
+
+### 4. `repository_agent.py` + `_repo_signals.py` flat scalars
+Add `summarize_registry_package(pkg) -> dict` in `_repo_signals.py` returning the
+always-present keys: `package` (name), `latest_version`, `versions` (list|None),
+`latest_release_date`, `registry_url`, `link` — all None when `pkg` is None/not a
+dict. In `repository_agent.py`, splat twice with prefixes:
+```python
+**{f"_npm_{k}": v for k, v in summarize_registry_package(repository.get("npm_package")).items()},
+**{f"_pypi_{k}": v for k, v in summarize_registry_package(repository.get("pypi_package")).items()},
+```
+→ emits `gme-internal:npm_package / npm_latest_version / npm_versions /
+npm_latest_release_date / npm_registry_url / npm_link` and the `pypi_*` mirror.
+
+### 5. `dependencies.py`
+Instantiate `PackageRegistryProvider` for the **real** ProviderSet paths, gated by
+env `V2_PACKAGE_REGISTRY_ENABLED` (default `true`; `false`/`0`/`no`/`off` → None).
+The mock path stays `package_registry=None` (mock extractions never hit network).
+Add `package_registry: Any | None = None` to `ProviderSet`.
+
+## Tests (`tests/v2/`)
+- `parse_npm_name` / `parse_pypi_name`: valid, scoped npm, poetry table, setup.cfg
+  fallback, missing, malformed, `private: true`.
+- `repo_url_matches`: `git+https://github.com/o/r.git`, `ssh://git@github.com/o/r`,
+  `https://github.com/o/r/`, case-insensitive, non-github → False, mismatch → False.
+- `PackageRegistryProvider` with an injected fake session returning canned npm +
+  PyPI JSON → asserts the thin dict (incl. versions/latest/date/repository_url).
+  404 → None. **No real network.**
+- `summarize_registry_package`: full dict, None input (all-None).
+- `context_gather`: fake `package_registry` provider → `npm_package`/`pypi_package`
+  populated; verified vs name_only; **mismatch dropped**.
+- `repository_agent`: emits flat `_npm_*` / `_pypi_*`; all-None when manifests
+  absent or provider None.
+
+## Gate
+Full `tests/v2/` green. No real network/LLM in tests (inject session / mock
+provider). Match house lint (ruff is not a CI gate; keep new files clean).

--- a/src/v2/agents/models.py
+++ b/src/v2/agents/models.py
@@ -172,6 +172,7 @@ class ProviderSet:
     orcid: ORCIDProvider | None = None
     infoscience: InfoscienceProvider | None = None
     ror: RORProvider | None = None
+    package_registry: Any | None = None
     infoscience_rag: Any | None = None
     ethz_research_collection_rag: Any | None = None
     huggingface_rag: Any | None = None

--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -9,11 +9,19 @@ Public surface
 parse_test_coverage(readme)  →  "87%" | None
 parse_docker_hub_url(readme, aux_files)  →  URL | None
 detect_has_ci(root_entries)  →  True | False | None
+parse_npm_name(aux_files)  →  "pkg" | "@scope/pkg" | None
+parse_pypi_name(aux_files)  →  "project-name" | None
+repo_url_matches(candidate_url, full_name)  →  True | False
+summarize_registry_package(pkg)  →  flat scalar dict (always-present keys)
 """
 from __future__ import annotations
 
+import configparser
+import json
 import re
 from typing import Any
+
+import tomllib
 
 # ---------------------------------------------------------------------------
 # _has_ci detection
@@ -318,4 +326,227 @@ def summarize_packages(container_images: Any) -> dict[str, Any]:
     )
     if updated:
         out["latest_package_updated_at"] = updated[-1]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# npm / PyPI registry package discovery — manifest name parsing + back-ref
+# ---------------------------------------------------------------------------
+
+# A normalised GitHub repo path needs at least owner + repo segments.
+_OWNER_REPO_SEGMENTS = 2
+
+
+def _aux_file_lookup(aux_files: Any, *names: str) -> str | None:
+    """Return the content of the first of *names* present in *aux_files*
+    (case-insensitive on the filename), else None.
+
+    ``aux_files`` keys may include a path prefix (e.g. ``.github/foo``); we
+    match on the basename so root manifests are found regardless of casing.
+    """
+    if not isinstance(aux_files, dict):
+        return None
+    wanted = {n.lower() for n in names}
+    for filename, content in aux_files.items():
+        if not isinstance(filename, str) or not isinstance(content, str):
+            continue
+        base = filename.rsplit("/", maxsplit=1)[-1].lower()
+        if base in wanted:
+            return content
+    return None
+
+
+def parse_npm_name(aux_files: Any) -> str | None:
+    """Extract the published npm package name from a repo's ``package.json``.
+
+    Returns the ``name`` field verbatim (scoped names ``@scope/pkg`` are kept
+    intact). Returns None when ``package.json`` is missing, malformed, has no
+    ``name``, or declares ``"private": true`` (private packages are never
+    published to the public registry).
+    """
+    content = _aux_file_lookup(aux_files, "package.json")
+    if content is None:
+        return None
+    try:
+        data = json.loads(content)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("private") is True:
+        return None
+    name = data.get("name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return None
+
+
+def _name_from_table(table: Any) -> str | None:
+    """Return a non-empty ``name`` string from a TOML table-like dict."""
+    if isinstance(table, dict):
+        name = table.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    return None
+
+
+def _pypi_name_from_pyproject(content: str) -> str | None:
+    """Extract the project name from ``pyproject.toml`` content.
+
+    Tries ``[project].name`` (PEP 621) then ``[tool.poetry].name``.
+    """
+    try:
+        data = tomllib.loads(content)
+    except (tomllib.TOMLDecodeError, ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    name = _name_from_table(data.get("project"))
+    if name:
+        return name
+    tool = data.get("tool")
+    poetry = tool.get("poetry") if isinstance(tool, dict) else None
+    return _name_from_table(poetry)
+
+
+def _pypi_name_from_setup_cfg(content: str) -> str | None:
+    """Extract ``[metadata] name`` from ``setup.cfg`` content."""
+    parser = configparser.ConfigParser()
+    try:
+        parser.read_string(content)
+    except configparser.Error:
+        return None
+    if parser.has_option("metadata", "name"):
+        name = parser.get("metadata", "name").strip()
+        if name:
+            return name
+    return None
+
+
+def parse_pypi_name(aux_files: Any) -> str | None:
+    """Extract the published PyPI project name from a repo's manifests.
+
+    Order of precedence:
+      1. ``pyproject.toml`` → ``[project].name`` (PEP 621)
+      2. ``pyproject.toml`` → ``[tool.poetry].name``
+      3. ``setup.cfg`` → ``[metadata] name``
+
+    ``setup.py`` is intentionally skipped — executing it is unsafe. The name
+    is returned as-declared (no PEP 503 normalisation; PyPI accepts the
+    project name as-is). Returns None when no name can be found.
+    """
+    pyproject = _aux_file_lookup(aux_files, "pyproject.toml")
+    if pyproject is not None:
+        name = _pypi_name_from_pyproject(pyproject)
+        if name:
+            return name
+
+    setup_cfg = _aux_file_lookup(aux_files, "setup.cfg")
+    if setup_cfg is not None:
+        return _pypi_name_from_setup_cfg(setup_cfg)
+    return None
+
+
+def repo_url_matches(candidate_url: Any, full_name: str) -> bool:
+    """Return True iff *candidate_url* resolves to ``github.com/<full_name>``.
+
+    Normalises the many shapes a registry's ``repository.url`` can take:
+    ``git+https://github.com/o/r.git``, ``ssh://git@github.com/o/r``,
+    ``git@github.com:o/r.git`` (scp-like), ``git://github.com/o/r``,
+    trailing ``.git`` / ``/``, and arbitrary host casing. Comparison on
+    owner/repo is case-insensitive. Returns False for None/empty, non-GitHub
+    hosts, or any owner/repo mismatch.
+    """
+    if not isinstance(candidate_url, str) or not candidate_url.strip():
+        return False
+    if not isinstance(full_name, str) or "/" not in full_name:
+        return False
+
+    url = candidate_url.strip()
+    # Strip a leading `git+` VCS-prefix (git+https://…, git+ssh://…).
+    if url.lower().startswith("git+"):
+        url = url[4:]
+
+    # scp-like syntax: git@github.com:owner/repo(.git)
+    scp_match = re.match(
+        r"^(?:ssh://)?git@([^/:]+):(.+)$", url, flags=re.IGNORECASE,
+    )
+    if scp_match:
+        host = scp_match.group(1).lower()
+        path = scp_match.group(2)
+    else:
+        # Strip known scheme prefixes, leaving host/path.
+        stripped = re.sub(
+            r"^(?:https?|ssh|git)://", "", url, flags=re.IGNORECASE,
+        )
+        # ssh://git@github.com/... — drop a leading userinfo (git@).
+        stripped = re.sub(r"^[^/@]+@", "", stripped)
+        if "/" not in stripped:
+            return False
+        host, path = stripped.split("/", maxsplit=1)
+        host = host.lower()
+
+    if host not in ("github.com", "www.github.com"):
+        # Only github.com (and its www. alias) count — reject lookalike
+        # subdomains like evil.github.com that would otherwise false-match.
+        return False
+
+    path = path.strip("/")
+    if path.lower().endswith(".git"):
+        path = path[: -len(".git")]
+    path = path.strip("/")
+    segments = [seg for seg in path.split("/") if seg]
+    if len(segments) < _OWNER_REPO_SEGMENTS:
+        return False
+    candidate_owner_repo = f"{segments[0]}/{segments[1]}"
+    return candidate_owner_repo.lower() == full_name.strip().strip("/").lower()
+
+
+def summarize_registry_package(pkg: Any) -> dict[str, Any]:
+    """Reduce a thin registry-package dict to flat, RDF-friendly scalars.
+
+    Mirrors ``summarize_releases`` / ``summarize_packages``: the keys are
+    *always* present (all None when *pkg* is None or not a dict) so the
+    splatted ``_npm_*`` / ``_pypi_*`` internal fields are stable. The thin
+    dict comes from ``PackageRegistryProvider`` and carries the published
+    package's name, latest version, full version list, latest release date,
+    registry (human) URL, and the back-reference link policy
+    (``verified`` / ``name_only``).
+
+    Emitted keys:
+      * ``package``              — published package/project name
+      * ``latest_version``       — newest published version string
+      * ``versions``             — list of all version strings (or None)
+      * ``latest_release_date``  — ISO 8601 date of the latest version
+      * ``registry_url``         — human-facing registry page URL
+      * ``link``                 — ``"verified"`` | ``"name_only"`` | None
+    """
+    out: dict[str, Any] = {
+        "package": None,
+        "latest_version": None,
+        "versions": None,
+        "latest_release_date": None,
+        "registry_url": None,
+        "link": None,
+    }
+    if not isinstance(pkg, dict):
+        return out
+    name = pkg.get("name")
+    if isinstance(name, str) and name:
+        out["package"] = name
+    latest = pkg.get("latest_version")
+    if isinstance(latest, str) and latest:
+        out["latest_version"] = latest
+    versions = pkg.get("versions")
+    if isinstance(versions, list) and versions:
+        out["versions"] = [v for v in versions if isinstance(v, str) and v] or None
+    date = pkg.get("latest_release_date")
+    if isinstance(date, str) and date:
+        out["latest_release_date"] = date
+    registry_url = pkg.get("registry_url")
+    if isinstance(registry_url, str) and registry_url:
+        out["registry_url"] = registry_url
+    link = pkg.get("link")
+    if isinstance(link, str) and link:
+        out["link"] = link
     return out

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -16,6 +16,7 @@ from src.v2.agents.rule_based._repo_signals import (
     parse_docker_hub_url,
     parse_test_coverage,
     summarize_packages,
+    summarize_registry_package,
     summarize_releases,
 )
 from src.v2.canonicalization.github import github_repo_iri, github_user_iri
@@ -556,6 +557,24 @@ class RepositoryAgentV2:
                 f"_{k}": v
                 for k, v in summarize_packages(
                     repository.get("container_images"),
+                ).items()
+            },
+            # Published npm / PyPI packages — discovered by context_gather
+            # from the manifest name + public-registry back-reference, stored
+            # as `npm_package` / `pypi_package`. Flat, RDF-friendly scalars
+            # (`gme-internal:npm_* / pypi_*`): package / latest_version /
+            # versions / latest_release_date / registry_url / link. Always
+            # present (all None when no manifest / provider disabled / drop).
+            **{
+                f"_npm_{k}": v
+                for k, v in summarize_registry_package(
+                    repository.get("npm_package"),
+                ).items()
+            },
+            **{
+                f"_pypi_{k}": v
+                for k, v in summarize_registry_package(
+                    repository.get("pypi_package"),
                 ).items()
             },
             # CI presence — detected from the repo root listing by

--- a/src/v2/dependencies.py
+++ b/src/v2/dependencies.py
@@ -57,6 +57,12 @@ from src.v2.ingest.providers.mock_github import MockGitHubProvider
 from src.v2.ingest.providers.mock_infoscience import MockInfoscienceProvider
 from src.v2.ingest.providers.mock_orcid import MockORCIDProvider
 from src.v2.ingest.providers.mock_ror import MockRORProvider
+from src.v2.ingest.providers.oamonitor_rag import (
+    OamonitorRagProvider,
+)
+from src.v2.ingest.providers.oamonitor_rag import (
+    build_default_provider as build_default_oamonitor_rag_provider,
+)
 from src.v2.ingest.providers.openalex_rag import (
     OpenAlexRagProvider,
 )
@@ -71,6 +77,7 @@ from src.v2.ingest.providers.orcid_rag import (
 from src.v2.ingest.providers.orcid_rag import (
     build_default_provider as build_default_orcid_rag_provider,
 )
+from src.v2.ingest.providers.package_registry_provider import PackageRegistryProvider
 from src.v2.ingest.providers.renkulab_rag import (
     RenkulabRagProvider,
 )
@@ -95,12 +102,6 @@ from src.v2.ingest.providers.swissubase_rag import (
 )
 from src.v2.ingest.providers.swissubase_rag import (
     build_default_provider as build_default_swissubase_rag_provider,
-)
-from src.v2.ingest.providers.oamonitor_rag import (
-    OamonitorRagProvider,
-)
-from src.v2.ingest.providers.oamonitor_rag import (
-    build_default_provider as build_default_oamonitor_rag_provider,
 )
 from src.v2.ingest.providers.zenodo_rag import (
     ZenodoRagProvider,
@@ -310,6 +311,20 @@ def _resolve_provider_cache(app_state: Any) -> ProviderCache | None:
     return cache
 
 
+def _resolve_package_registry_provider(
+    cache: ProviderCache | None,
+) -> PackageRegistryProvider | None:
+    """Build the npm/PyPI registry provider for the real ProviderSet path.
+
+    Gated by ``V2_PACKAGE_REGISTRY_ENABLED`` (default ``true``); the usual
+    falsey spellings (``false`` / ``0`` / ``no`` / ``off``) disable it and
+    return None so registry discovery is skipped entirely.
+    """
+    if not _is_truthy_env(os.getenv("V2_PACKAGE_REGISTRY_ENABLED", "true")):
+        return None
+    return PackageRegistryProvider(cache=cache)
+
+
 def _default_provider_set(  # noqa: PLR0913 — bundle-builder for ProviderSet
     *,
     use_mock_providers: bool,
@@ -364,6 +379,7 @@ def _default_provider_set(  # noqa: PLR0913 — bundle-builder for ProviderSet
         orcid=RealORCIDProvider(cache=cache, session=_optional_orcid_oauth_session()),
         infoscience=RealInfoscienceProvider(cache=cache),
         ror=RealRORProvider(cache=cache),
+        package_registry=_resolve_package_registry_provider(cache),
         **rag_kwargs,
     )
 
@@ -451,6 +467,7 @@ async def get_provider_set(request: Request) -> ProviderSet:
             else default_provider_set.infoscience
         ),
         ror=ror_provider if isinstance(ror_provider, RORProvider) else default_provider_set.ror,
+        package_registry=default_provider_set.package_registry,
         infoscience_rag=default_provider_set.infoscience_rag,
         ethz_research_collection_rag=default_provider_set.ethz_research_collection_rag,
         huggingface_rag=default_provider_set.huggingface_rag,

--- a/src/v2/ingest/providers/package_registry_provider.py
+++ b/src/v2/ingest/providers/package_registry_provider.py
@@ -1,0 +1,295 @@
+"""Public package-registry provider (npm + PyPI).
+
+GitHub Packages covers neither public npmjs.com nor PyPI, so to surface a
+repo's *published* packages we query the registries directly by the manifest
+name and verify the registry's declared repository URL back-references this
+repo (see ``context_gather`` for the link policy). This provider only does
+the network I/O + thin-dict extraction; name parsing and back-reference
+verification are pure helpers in ``_repo_signals.py``.
+
+Both ``get_npm_package`` / ``get_pypi_package`` are **best-effort**: they
+return ``None`` on 404 / non-200 / parse / transport error and NEVER raise,
+mirroring the github provider's release / container-image fetchers.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import quote
+
+import requests
+
+from src.v2.ingest.cache import ProviderCache
+
+logger = logging.getLogger(__name__)
+
+# Cap on the number of version strings carried in the thin dict. A handful of
+# long-lived packages publish thousands of versions; the flat
+# `gme-internal:*_versions` triple only needs a representative list.
+_MAX_VERSIONS = 200
+
+_REQUEST_TIMEOUT_SECONDS = 15
+
+_HTTP_OK = 200
+_HTTP_NOT_FOUND = 404
+
+
+class PackageRegistryProvider:
+    """Fetch thin published-package metadata from npmjs.com / PyPI.
+
+    ``session`` is any object exposing ``.get(url, timeout=...)`` returning a
+    requests-like response (``.status_code``, ``.json()``); it defaults to the
+    ``requests`` module so production code hits the live registries and tests
+    can inject a canned-response fake with no real network. ``cache`` is the
+    standard ``ProviderCache`` (optional) — responses are cached by
+    method + package name like the github provider.
+    """
+
+    def __init__(
+        self,
+        *,
+        session: Any | None = None,
+        cache: ProviderCache | None = None,
+    ) -> None:
+        self._session = session if session is not None else requests
+        self._cache = cache
+
+    # ------------------------------------------------------------------
+    # npm
+    # ------------------------------------------------------------------
+
+    def get_npm_package(self, name: str) -> dict[str, Any] | None:
+        """Fetch thin metadata for npm package *name* (scoped names ok).
+
+        GETs ``https://registry.npmjs.org/<name>`` (scoped ``@scope/pkg`` is
+        URL-encoded to ``@scope%2Fpkg``). Returns None on any failure.
+        """
+        if not isinstance(name, str) or not name.strip():
+            return None
+        name = name.strip()
+
+        def _fetch() -> dict[str, Any] | None:
+            # Scoped names contain a `/` that must be percent-encoded; the
+            # leading `@` is left intact (registry expects `@scope%2Fpkg`).
+            encoded = quote(name, safe="@")
+            url = f"https://registry.npmjs.org/{encoded}"
+            payload = self._get_json(url, subject=f"npm:{name}")
+            if not isinstance(payload, dict):
+                return None
+            return self._thin_npm(payload, name)
+
+        return self._cached(_fetch, method="get_npm_package", name=name)
+
+    @staticmethod
+    def _thin_npm(payload: dict[str, Any], name: str) -> dict[str, Any] | None:
+        pkg_name = payload.get("name")
+        pkg_name = pkg_name if isinstance(pkg_name, str) and pkg_name else name
+
+        dist_tags = payload.get("dist-tags")
+        latest_version = (
+            dist_tags.get("latest") if isinstance(dist_tags, dict) else None
+        )
+        latest_version = latest_version if isinstance(latest_version, str) else None
+
+        versions_obj = payload.get("versions")
+        versions: list[str] = []
+        if isinstance(versions_obj, dict):
+            versions = sorted(k for k in versions_obj if isinstance(k, str))
+        if len(versions) > _MAX_VERSIONS:
+            logger.info(
+                "npm package %s has %d versions; truncating to %d",
+                name, len(versions), _MAX_VERSIONS,
+            )
+            versions = versions[:_MAX_VERSIONS]
+
+        time_obj = payload.get("time")
+        latest_release_date = None
+        if isinstance(time_obj, dict) and latest_version:
+            candidate = time_obj.get(latest_version)
+            latest_release_date = candidate if isinstance(candidate, str) else None
+
+        repository_url = _extract_npm_repo_url(payload, latest_version)
+
+        return {
+            "name": pkg_name,
+            "latest_version": latest_version,
+            "versions": versions or None,
+            "latest_release_date": latest_release_date,
+            "repository_url": repository_url,
+            "registry_url": f"https://www.npmjs.com/package/{pkg_name}",
+        }
+
+    # ------------------------------------------------------------------
+    # PyPI
+    # ------------------------------------------------------------------
+
+    def get_pypi_package(self, name: str) -> dict[str, Any] | None:
+        """Fetch thin metadata for PyPI project *name*.
+
+        GETs ``https://pypi.org/pypi/<name>/json``. Returns None on failure.
+        """
+        if not isinstance(name, str) or not name.strip():
+            return None
+        name = name.strip()
+
+        def _fetch() -> dict[str, Any] | None:
+            encoded = quote(name, safe="")
+            url = f"https://pypi.org/pypi/{encoded}/json"
+            payload = self._get_json(url, subject=f"pypi:{name}")
+            if not isinstance(payload, dict):
+                return None
+            return self._thin_pypi(payload, name)
+
+        return self._cached(_fetch, method="get_pypi_package", name=name)
+
+    @staticmethod
+    def _thin_pypi(payload: dict[str, Any], name: str) -> dict[str, Any] | None:
+        info = payload.get("info") if isinstance(payload.get("info"), dict) else {}
+
+        pkg_name = info.get("name")
+        pkg_name = pkg_name if isinstance(pkg_name, str) and pkg_name else name
+
+        latest_version = info.get("version")
+        latest_version = latest_version if isinstance(latest_version, str) else None
+
+        releases_obj = payload.get("releases")
+        versions: list[str] = []
+        if isinstance(releases_obj, dict):
+            versions = sorted(k for k in releases_obj if isinstance(k, str))
+        if len(versions) > _MAX_VERSIONS:
+            logger.info(
+                "pypi project %s has %d versions; truncating to %d",
+                name, len(versions), _MAX_VERSIONS,
+            )
+            versions = versions[:_MAX_VERSIONS]
+
+        latest_release_date = _extract_pypi_latest_date(
+            payload, releases_obj, latest_version,
+        )
+        repository_url = _extract_pypi_repo_url(info)
+
+        return {
+            "name": pkg_name,
+            "latest_version": latest_version,
+            "versions": versions or None,
+            "latest_release_date": latest_release_date,
+            "repository_url": repository_url,
+            "registry_url": f"https://pypi.org/project/{pkg_name}/",
+        }
+
+    # ------------------------------------------------------------------
+    # shared helpers
+    # ------------------------------------------------------------------
+
+    def _get_json(self, url: str, *, subject: str) -> Any:
+        """GET *url* and return parsed JSON, or None on any failure."""
+        try:
+            response = self._session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+        except Exception:  # noqa: BLE001 — best-effort; never raise on transport error.
+            logger.info("package registry fetch failed: %s", subject)
+            return None
+        status = getattr(response, "status_code", None)
+        if status == _HTTP_NOT_FOUND:
+            return None
+        if status != _HTTP_OK:
+            logger.info(
+                "package registry fetch returned %s for %s", status, subject,
+            )
+            return None
+        try:
+            return response.json()
+        except ValueError:
+            logger.info("package registry response not JSON: %s", subject)
+            return None
+
+    def _cached(
+        self,
+        factory: Any,
+        *,
+        method: str,
+        name: str,
+    ) -> dict[str, Any] | None:
+        if self._cache is None:
+            return factory()
+        key = ProviderCache.make_key("package_registry", method, name=name)
+        return self._cache.get_or_set(
+            key, factory, label=f"package_registry.{method}({name})",
+        )
+
+
+def _extract_npm_repo_url(
+    payload: dict[str, Any], latest_version: str | None,
+) -> str | None:
+    """Pull ``repository.url`` from the top-level doc, else from the latest
+    version's manifest. Handles both the object form (``{"url": ...}``) and
+    the bare-string form npm allows."""
+    candidate = _repo_field_to_url(payload.get("repository"))
+    if candidate:
+        return candidate
+    versions_obj = payload.get("versions")
+    if isinstance(versions_obj, dict) and latest_version:
+        version_doc = versions_obj.get(latest_version)
+        if isinstance(version_doc, dict):
+            return _repo_field_to_url(version_doc.get("repository"))
+    return None
+
+
+def _repo_field_to_url(repository: Any) -> str | None:
+    if isinstance(repository, str) and repository.strip():
+        return repository.strip()
+    if isinstance(repository, dict):
+        url = repository.get("url")
+        if isinstance(url, str) and url.strip():
+            return url.strip()
+    return None
+
+
+# PyPI `project_urls` keys to consult for the source repo, in priority order.
+_PYPI_PROJECT_URL_KEYS = ("Source", "Repository", "Code", "Homepage")
+
+
+def _extract_pypi_repo_url(info: dict[str, Any]) -> str | None:
+    project_urls = info.get("project_urls")
+    if isinstance(project_urls, dict):
+        # Case-insensitive match on the priority keys (publishers vary the
+        # casing: "Source Code", "repository", etc.).
+        lowered = {
+            k.lower(): v
+            for k, v in project_urls.items()
+            if isinstance(k, str) and isinstance(v, str) and v.strip()
+        }
+        for key in _PYPI_PROJECT_URL_KEYS:
+            value = lowered.get(key.lower())
+            if value:
+                return value.strip()
+    home_page = info.get("home_page")
+    if isinstance(home_page, str) and home_page.strip():
+        return home_page.strip()
+    return None
+
+
+def _extract_pypi_latest_date(
+    payload: dict[str, Any],
+    releases_obj: Any,
+    latest_version: str | None,
+) -> str | None:
+    """Return the max ``upload_time_iso_8601`` for the latest release's files,
+    falling back to the top-level ``urls`` block."""
+
+    def _max_upload_time(files: Any) -> str | None:
+        if not isinstance(files, list):
+            return None
+        times = sorted(
+            f["upload_time_iso_8601"]
+            for f in files
+            if isinstance(f, dict)
+            and isinstance(f.get("upload_time_iso_8601"), str)
+            and f["upload_time_iso_8601"]
+        )
+        return times[-1] if times else None
+
+    if isinstance(releases_obj, dict) and latest_version:
+        date = _max_upload_time(releases_obj.get(latest_version))
+        if date:
+            return date
+    return _max_upload_time(payload.get("urls"))

--- a/src/v2/pipeline/stages/context_gather.py
+++ b/src/v2/pipeline/stages/context_gather.py
@@ -5,7 +5,12 @@ import os
 import re
 from typing import TYPE_CHECKING, Any
 
-from src.v2.agents.rule_based._repo_signals import detect_has_ci
+from src.v2.agents.rule_based._repo_signals import (
+    detect_has_ci,
+    parse_npm_name,
+    parse_pypi_name,
+    repo_url_matches,
+)
 from src.v2.pipeline.stages.models import ContextBundle
 
 
@@ -245,6 +250,64 @@ def _normalize_owned_repo_full_name(owner: str, repo: str) -> str:
     return f"{owner}/{repo}"
 
 
+def _enrich_repository_metadata_with_registry_packages(
+    *,
+    full_name: str,
+    aux_files: dict[str, Any] | None,
+    repository_metadata: dict[str, Any],
+    providers: ProviderSet,
+    warnings: list[str],
+) -> None:
+    """Discover the repo's published npm / PyPI packages and store them on
+    *repository_metadata* (``npm_package`` / ``pypi_package``) in place.
+
+    Gated on ``providers.package_registry`` being available; best-effort
+    (failures append a warning and never break the pipeline). Link policy
+    per package:
+
+    * registry's ``repository_url`` present AND back-references this repo →
+      store with ``link="verified"``.
+    * registry's ``repository_url`` present but points elsewhere → DROP
+      (almost certainly a name collision with a different project's package).
+    * registry's ``repository_url`` absent → store with ``link="name_only"``
+      (name match only; weaker but still useful signal).
+    """
+    registry = getattr(providers, "package_registry", None)
+    if registry is None:
+        return
+
+    def _link_and_store(pkg: dict[str, Any] | None, *, key: str) -> None:
+        if not isinstance(pkg, dict):
+            return
+        repository_url = pkg.get("repository_url")
+        if isinstance(repository_url, str) and repository_url.strip():
+            if repo_url_matches(repository_url, full_name):
+                pkg["link"] = "verified"
+            else:
+                # Back-reference points at a different repo — name collision.
+                return
+        else:
+            pkg["link"] = "name_only"
+        repository_metadata[key] = pkg
+
+    try:
+        npm_name = parse_npm_name(aux_files)
+        if npm_name:
+            _link_and_store(registry.get_npm_package(npm_name), key="npm_package")
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"npm package lookup failed for {full_name}: {exc}",
+        )
+    try:
+        pypi_name = parse_pypi_name(aux_files)
+        if pypi_name:
+            _link_and_store(registry.get_pypi_package(pypi_name), key="pypi_package")
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"PyPI package lookup failed for {full_name}: {exc}",
+        )
+
+
 def _optional_repository_context(
     *,
     full_name: str,
@@ -367,6 +430,17 @@ def _optional_repository_context(
         warnings.append(
             f"Repository root-listing (has_ci) failed for {full_name}: {exc}",
         )
+
+    # Published npm / PyPI packages — discovered from the manifest name +
+    # public-registry back-reference. Best-effort; gated on the
+    # package_registry provider being available.
+    _enrich_repository_metadata_with_registry_packages(
+        full_name=full_name,
+        aux_files=aux_files,
+        repository_metadata=repository_metadata,
+        providers=providers,
+        warnings=warnings,
+    )
 
     return {
         "full_name": full_name,
@@ -495,6 +569,16 @@ async def gather_context(  # noqa: C901, PLR0915
             warnings.append(
                 f"Repository root-listing (has_ci) failed for {full_name}: {exc}",
             )
+
+        # Published npm / PyPI packages (best-effort; same as
+        # _optional_repository_context above).
+        _enrich_repository_metadata_with_registry_packages(
+            full_name=full_name,
+            aux_files=aux_files,
+            repository_metadata=repository_metadata,
+            providers=providers,
+            warnings=warnings,
+        )
 
         context["repository"] = {
             "full_name": full_name,

--- a/tests/v2/test_npm_pypi_packages.py
+++ b/tests/v2/test_npm_pypi_packages.py
@@ -1,0 +1,605 @@
+"""Tests for npm + PyPI package discovery (manifest-linked).
+
+Covers (no real network — a fake session / fake provider is injected):
+  - parse_npm_name / parse_pypi_name: valid, scoped, poetry, setup.cfg
+    fallback, missing, malformed, private.
+  - repo_url_matches: git+https / ssh / scp / trailing slash / .git /
+    case-insensitive / non-github / mismatch.
+  - PackageRegistryProvider: canned npm + PyPI JSON → thin dict; 404 → None.
+  - summarize_registry_package: full dict + None input (all-None).
+  - context_gather link policy: verified vs name_only vs mismatch-dropped.
+  - repository_agent: emits flat `_npm_*` / `_pypi_*`; all-None when absent
+    or provider None.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from src.v2.agents import ProviderSet, RepositoryAgentV2
+from src.v2.agents.rule_based._repo_signals import (
+    parse_npm_name,
+    parse_pypi_name,
+    repo_url_matches,
+    summarize_registry_package,
+)
+from src.v2.ingest.providers.mock_github import MockGitHubProvider
+from src.v2.ingest.providers.package_registry_provider import (
+    PackageRegistryProvider,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes — no real network anywhere in this module.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        if isinstance(self._payload, ValueError):
+            raise self._payload
+        return self._payload
+
+
+class FakeSession:
+    """A `requests`-like session returning canned responses keyed by URL.
+
+    `routes` maps an exact URL → `_FakeResponse`. Any unmatched URL returns
+    a 404 so unexpected calls degrade to None rather than raising.
+    """
+
+    def __init__(self, routes: dict[str, _FakeResponse]) -> None:
+        self._routes = routes
+        self.requested: list[str] = []
+
+    def get(self, url: str, timeout: float | None = None) -> _FakeResponse:  # noqa: ARG002
+        self.requested.append(url)
+        return self._routes.get(url, _FakeResponse(404, None))
+
+
+class FakePackageRegistryProvider:
+    """A fake `package_registry` provider returning canned thin dicts."""
+
+    def __init__(
+        self,
+        *,
+        npm: dict[str, Any] | None = None,
+        pypi: dict[str, Any] | None = None,
+    ) -> None:
+        self._npm = npm
+        self._pypi = pypi
+        self.npm_calls: list[str] = []
+        self.pypi_calls: list[str] = []
+
+    def get_npm_package(self, name: str) -> dict[str, Any] | None:
+        self.npm_calls.append(name)
+        return dict(self._npm) if isinstance(self._npm, dict) else None
+
+    def get_pypi_package(self, name: str) -> dict[str, Any] | None:
+        self.pypi_calls.append(name)
+        return dict(self._pypi) if isinstance(self._pypi, dict) else None
+
+
+# Canned registry JSON --------------------------------------------------------
+
+_NPM_REGISTRY_JSON = {
+    "name": "@acme/tool",
+    "dist-tags": {"latest": "2.1.0"},
+    "versions": {
+        "2.1.0": {"repository": {"url": "git+https://github.com/acme/tool.git"}},
+        "2.0.0": {},
+        "1.0.0": {},
+    },
+    "time": {
+        "2.1.0": "2024-03-01T12:00:00.000Z",
+        "2.0.0": "2024-01-15T08:00:00.000Z",
+    },
+    "repository": {"type": "git", "url": "git+https://github.com/acme/tool.git"},
+}
+
+_PYPI_REGISTRY_JSON = {
+    "info": {
+        "name": "acme-tool",
+        "version": "3.4.0",
+        "project_urls": {
+            "Homepage": "https://acme.example",
+            "Source": "https://github.com/acme/acme-tool",
+        },
+        "home_page": "https://acme.example",
+    },
+    "releases": {
+        "3.4.0": [{"upload_time_iso_8601": "2024-05-01T10:00:00.000000Z"}],
+        "3.3.0": [{"upload_time_iso_8601": "2024-02-01T10:00:00.000000Z"}],
+    },
+    "urls": [{"upload_time_iso_8601": "2024-05-01T10:00:00.000000Z"}],
+}
+
+
+def _npm_session(payload: Any = _NPM_REGISTRY_JSON, status: int = 200) -> FakeSession:
+    return FakeSession({
+        "https://registry.npmjs.org/@acme%2Ftool": _FakeResponse(status, payload),
+        "https://registry.npmjs.org/lodash": _FakeResponse(status, payload),
+    })
+
+
+def _pypi_session(payload: Any = _PYPI_REGISTRY_JSON, status: int = 200) -> FakeSession:
+    return FakeSession({
+        "https://pypi.org/pypi/acme-tool/json": _FakeResponse(status, payload),
+    })
+
+
+# ---------------------------------------------------------------------------
+# parse_npm_name
+# ---------------------------------------------------------------------------
+
+
+def test_parse_npm_name_valid() -> None:
+    aux = {"package.json": json.dumps({"name": "lodash", "version": "1.0.0"})}
+    assert parse_npm_name(aux) == "lodash"
+
+
+def test_parse_npm_name_scoped_kept_intact() -> None:
+    aux = {"package.json": json.dumps({"name": "@acme/tool"})}
+    assert parse_npm_name(aux) == "@acme/tool"
+
+
+def test_parse_npm_name_missing_returns_none() -> None:
+    assert parse_npm_name({"pyproject.toml": "x"}) is None
+    assert parse_npm_name({}) is None
+    assert parse_npm_name(None) is None
+
+
+def test_parse_npm_name_malformed_returns_none() -> None:
+    aux = {"package.json": "{not valid json"}
+    assert parse_npm_name(aux) is None
+
+
+def test_parse_npm_name_no_name_field_returns_none() -> None:
+    aux = {"package.json": json.dumps({"version": "1.0.0"})}
+    assert parse_npm_name(aux) is None
+
+
+def test_parse_npm_name_private_returns_none() -> None:
+    aux = {"package.json": json.dumps({"name": "secret", "private": True})}
+    assert parse_npm_name(aux) is None
+
+
+# ---------------------------------------------------------------------------
+# parse_pypi_name
+# ---------------------------------------------------------------------------
+
+
+def test_parse_pypi_name_pep621_project_table() -> None:
+    aux = {"pyproject.toml": '[project]\nname = "acme-tool"\nversion = "1.0"\n'}
+    assert parse_pypi_name(aux) == "acme-tool"
+
+
+def test_parse_pypi_name_poetry_table() -> None:
+    aux = {"pyproject.toml": '[tool.poetry]\nname = "poetry-pkg"\nversion = "1.0"\n'}
+    assert parse_pypi_name(aux) == "poetry-pkg"
+
+
+def test_parse_pypi_name_project_table_wins_over_poetry() -> None:
+    aux = {
+        "pyproject.toml": (
+            '[project]\nname = "pep621-name"\n'
+            '[tool.poetry]\nname = "poetry-name"\n'
+        ),
+    }
+    assert parse_pypi_name(aux) == "pep621-name"
+
+
+def test_parse_pypi_name_setup_cfg_fallback() -> None:
+    aux = {"setup.cfg": "[metadata]\nname = cfg-pkg\nversion = 1.0\n"}
+    assert parse_pypi_name(aux) == "cfg-pkg"
+
+
+def test_parse_pypi_name_missing_returns_none() -> None:
+    assert parse_pypi_name({"package.json": "{}"}) is None
+    assert parse_pypi_name({}) is None
+    assert parse_pypi_name(None) is None
+
+
+def test_parse_pypi_name_malformed_toml_returns_none() -> None:
+    aux = {"pyproject.toml": "[project\nname = broken"}
+    assert parse_pypi_name(aux) is None
+
+
+def test_parse_pypi_name_no_name_returns_none() -> None:
+    aux = {"pyproject.toml": '[project]\nversion = "1.0"\n'}
+    assert parse_pypi_name(aux) is None
+
+
+# ---------------------------------------------------------------------------
+# repo_url_matches
+# ---------------------------------------------------------------------------
+
+
+def test_repo_url_matches_git_plus_https_dot_git() -> None:
+    assert repo_url_matches("git+https://github.com/o/r.git", "o/r") is True
+
+
+def test_repo_url_matches_ssh_scheme() -> None:
+    assert repo_url_matches("ssh://git@github.com/o/r", "o/r") is True
+
+
+def test_repo_url_matches_scp_like() -> None:
+    assert repo_url_matches("git@github.com:o/r.git", "o/r") is True
+
+
+def test_repo_url_matches_git_protocol() -> None:
+    assert repo_url_matches("git://github.com/o/r.git", "o/r") is True
+
+
+def test_repo_url_matches_trailing_slash() -> None:
+    assert repo_url_matches("https://github.com/o/r/", "o/r") is True
+
+
+def test_repo_url_matches_case_insensitive() -> None:
+    assert repo_url_matches("https://GitHub.com/O/R", "o/r") is True
+
+
+def test_repo_url_matches_www_alias() -> None:
+    assert repo_url_matches("https://www.github.com/o/r", "o/r") is True
+
+
+def test_repo_url_matches_non_github_false() -> None:
+    assert repo_url_matches("https://gitlab.com/o/r", "o/r") is False
+
+
+def test_repo_url_matches_lookalike_subdomain_false() -> None:
+    # A package whose repository.url points at a github.com *lookalike*
+    # subdomain must NOT be accepted as a verified back-reference, even when
+    # the owner/repo path matches exactly.
+    assert repo_url_matches("https://evil.github.com/o/r", "o/r") is False
+    assert repo_url_matches("https://github.com.evil.test/o/r", "o/r") is False
+
+
+def test_repo_url_matches_mismatch_false() -> None:
+    assert repo_url_matches("https://github.com/other/repo", "o/r") is False
+
+
+def test_repo_url_matches_none_and_empty_false() -> None:
+    assert repo_url_matches(None, "o/r") is False
+    assert repo_url_matches("", "o/r") is False
+    assert repo_url_matches("https://github.com/o/r", "noslash") is False
+
+
+# ---------------------------------------------------------------------------
+# PackageRegistryProvider — injected fake session (no real network)
+# ---------------------------------------------------------------------------
+
+
+def test_provider_get_npm_package_thin_dict() -> None:
+    provider = PackageRegistryProvider(session=_npm_session())
+    pkg = provider.get_npm_package("@acme/tool")
+    assert pkg is not None
+    assert pkg["name"] == "@acme/tool"
+    assert pkg["latest_version"] == "2.1.0"
+    assert pkg["versions"] == ["1.0.0", "2.0.0", "2.1.0"]
+    assert pkg["latest_release_date"] == "2024-03-01T12:00:00.000Z"
+    assert pkg["repository_url"] == "git+https://github.com/acme/tool.git"
+    assert pkg["registry_url"] == "https://www.npmjs.com/package/@acme/tool"
+
+
+def test_provider_get_npm_package_scoped_url_encoding() -> None:
+    session = _npm_session()
+    PackageRegistryProvider(session=session).get_npm_package("@acme/tool")
+    assert "https://registry.npmjs.org/@acme%2Ftool" in session.requested
+
+
+def test_provider_get_npm_package_repo_url_from_version_fallback() -> None:
+    payload = {
+        "name": "noroot",
+        "dist-tags": {"latest": "1.0.0"},
+        "versions": {
+            "1.0.0": {"repository": {"url": "https://github.com/acme/noroot"}},
+        },
+        "time": {"1.0.0": "2024-01-01T00:00:00Z"},
+    }
+    session = FakeSession({
+        "https://registry.npmjs.org/noroot": _FakeResponse(200, payload),
+    })
+    pkg = PackageRegistryProvider(session=session).get_npm_package("noroot")
+    assert pkg is not None
+    assert pkg["repository_url"] == "https://github.com/acme/noroot"
+
+
+def test_provider_get_npm_package_404_returns_none() -> None:
+    provider = PackageRegistryProvider(session=_npm_session(status=404))
+    assert provider.get_npm_package("@acme/tool") is None
+
+
+def test_provider_get_pypi_package_thin_dict() -> None:
+    provider = PackageRegistryProvider(session=_pypi_session())
+    pkg = provider.get_pypi_package("acme-tool")
+    assert pkg is not None
+    assert pkg["name"] == "acme-tool"
+    assert pkg["latest_version"] == "3.4.0"
+    assert pkg["versions"] == ["3.3.0", "3.4.0"]
+    assert pkg["latest_release_date"] == "2024-05-01T10:00:00.000000Z"
+    assert pkg["repository_url"] == "https://github.com/acme/acme-tool"
+    assert pkg["registry_url"] == "https://pypi.org/project/acme-tool/"
+
+
+def test_provider_get_pypi_package_404_returns_none() -> None:
+    provider = PackageRegistryProvider(session=_pypi_session(status=404))
+    assert provider.get_pypi_package("acme-tool") is None
+
+
+def test_provider_get_pypi_home_page_fallback() -> None:
+    payload = {
+        "info": {
+            "name": "homeonly",
+            "version": "1.0.0",
+            "project_urls": None,
+            "home_page": "https://github.com/acme/homeonly",
+        },
+        "releases": {"1.0.0": [{"upload_time_iso_8601": "2024-01-01T00:00:00Z"}]},
+    }
+    session = FakeSession({
+        "https://pypi.org/pypi/homeonly/json": _FakeResponse(200, payload),
+    })
+    pkg = PackageRegistryProvider(session=session).get_pypi_package("homeonly")
+    assert pkg is not None
+    assert pkg["repository_url"] == "https://github.com/acme/homeonly"
+
+
+def test_provider_transport_error_returns_none() -> None:
+    class _BoomSession:
+        def get(self, url: str, timeout: float | None = None) -> Any:  # noqa: ARG002
+            message = "boom"
+            raise ConnectionError(message)
+
+    provider = PackageRegistryProvider(session=_BoomSession())
+    assert provider.get_npm_package("x") is None
+    assert provider.get_pypi_package("y") is None
+
+
+# ---------------------------------------------------------------------------
+# summarize_registry_package
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_registry_package_full_dict() -> None:
+    pkg = {
+        "name": "@acme/tool",
+        "latest_version": "2.1.0",
+        "versions": ["1.0.0", "2.0.0", "2.1.0"],
+        "latest_release_date": "2024-03-01T12:00:00Z",
+        "repository_url": "git+https://github.com/acme/tool.git",
+        "registry_url": "https://www.npmjs.com/package/@acme/tool",
+        "link": "verified",
+    }
+    out = summarize_registry_package(pkg)
+    assert out == {
+        "package": "@acme/tool",
+        "latest_version": "2.1.0",
+        "versions": ["1.0.0", "2.0.0", "2.1.0"],
+        "latest_release_date": "2024-03-01T12:00:00Z",
+        "registry_url": "https://www.npmjs.com/package/@acme/tool",
+        "link": "verified",
+    }
+
+
+def test_summarize_registry_package_none_all_none() -> None:
+    out = summarize_registry_package(None)
+    assert out == {
+        "package": None,
+        "latest_version": None,
+        "versions": None,
+        "latest_release_date": None,
+        "registry_url": None,
+        "link": None,
+    }
+
+
+def test_summarize_registry_package_not_dict_all_none() -> None:
+    assert summarize_registry_package("nope")["package"] is None
+
+
+# ---------------------------------------------------------------------------
+# context_gather — link policy (verified / name_only / mismatch-dropped)
+# ---------------------------------------------------------------------------
+
+from src.v2.pipeline.stages.context_gather import (
+    _enrich_repository_metadata_with_registry_packages,
+)
+
+
+def _run_enrich(
+    *,
+    full_name: str,
+    aux_files: dict[str, str],
+    provider: Any,
+) -> tuple[dict[str, Any], list[str]]:
+    metadata: dict[str, Any] = {}
+    warnings: list[str] = []
+    providers = ProviderSet(github=MockGitHubProvider(), package_registry=provider)
+    _enrich_repository_metadata_with_registry_packages(
+        full_name=full_name,
+        aux_files=aux_files,
+        repository_metadata=metadata,
+        providers=providers,
+        warnings=warnings,
+    )
+    return metadata, warnings
+
+
+def test_context_gather_npm_verified() -> None:
+    provider = FakePackageRegistryProvider(
+        npm={
+            "name": "@acme/tool",
+            "repository_url": "git+https://github.com/acme/tool.git",
+        },
+    )
+    metadata, _ = _run_enrich(
+        full_name="acme/tool",
+        aux_files={"package.json": json.dumps({"name": "@acme/tool"})},
+        provider=provider,
+    )
+    assert metadata["npm_package"]["link"] == "verified"
+
+
+def test_context_gather_npm_name_only_when_repo_url_absent() -> None:
+    provider = FakePackageRegistryProvider(npm={"name": "lonely", "repository_url": None})
+    metadata, _ = _run_enrich(
+        full_name="acme/lonely",
+        aux_files={"package.json": json.dumps({"name": "lonely"})},
+        provider=provider,
+    )
+    assert metadata["npm_package"]["link"] == "name_only"
+
+
+def test_context_gather_npm_mismatch_dropped() -> None:
+    provider = FakePackageRegistryProvider(
+        npm={
+            "name": "collision",
+            "repository_url": "https://github.com/someone-else/other",
+        },
+    )
+    metadata, _ = _run_enrich(
+        full_name="acme/tool",
+        aux_files={"package.json": json.dumps({"name": "collision"})},
+        provider=provider,
+    )
+    assert "npm_package" not in metadata
+
+
+def test_context_gather_pypi_verified() -> None:
+    provider = FakePackageRegistryProvider(
+        pypi={
+            "name": "acme-tool",
+            "repository_url": "https://github.com/acme/acme-tool",
+        },
+    )
+    metadata, _ = _run_enrich(
+        full_name="acme/acme-tool",
+        aux_files={"pyproject.toml": '[project]\nname = "acme-tool"\n'},
+        provider=provider,
+    )
+    assert metadata["pypi_package"]["link"] == "verified"
+
+
+def test_context_gather_no_provider_noop() -> None:
+    metadata: dict[str, Any] = {}
+    warnings: list[str] = []
+    providers = ProviderSet(github=MockGitHubProvider())  # package_registry None
+    _enrich_repository_metadata_with_registry_packages(
+        full_name="acme/tool",
+        aux_files={"package.json": json.dumps({"name": "@acme/tool"})},
+        repository_metadata=metadata,
+        providers=providers,
+        warnings=warnings,
+    )
+    assert metadata == {}
+    assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# repository_agent — flat `_npm_*` / `_pypi_*` emission
+# ---------------------------------------------------------------------------
+
+
+def _make_repo_context(
+    *,
+    npm_package: dict[str, Any] | None = None,
+    pypi_package: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "name": "tool",
+        "full_name": "acme/tool",
+        "owner": {"login": "acme", "type": "Organization"},
+        "created_at": "2023-01-01T00:00:00Z",
+        "license": {"spdx_id": "MIT"},
+        "fork": False,
+        "source": {"full_name": None},
+    }
+    if npm_package is not None:
+        metadata["npm_package"] = npm_package
+    if pypi_package is not None:
+        metadata["pypi_package"] = pypi_package
+    return {
+        "full_name": "acme/tool",
+        "metadata": metadata,
+        "readme_content": "",
+        "contributors": [{"login": "alice"}],
+        "languages": {"Python": 1},
+        "aux_files": {},
+    }
+
+
+def test_repository_agent_emits_npm_and_pypi_flat_scalars() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+    npm = {
+        "name": "@acme/tool",
+        "latest_version": "2.1.0",
+        "versions": ["1.0.0", "2.1.0"],
+        "latest_release_date": "2024-03-01T12:00:00Z",
+        "registry_url": "https://www.npmjs.com/package/@acme/tool",
+        "link": "verified",
+    }
+    pypi = {
+        "name": "acme-tool",
+        "latest_version": "3.4.0",
+        "versions": ["3.3.0", "3.4.0"],
+        "latest_release_date": "2024-05-01T10:00:00Z",
+        "registry_url": "https://pypi.org/project/acme-tool/",
+        "link": "name_only",
+    }
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_repo_context(
+                    npm_package=npm, pypi_package=pypi,
+                ),
+            },
+            providers,
+        ),
+    )
+    raw = result.raw_output
+    assert raw["_npm_package"] == "@acme/tool"
+    assert raw["_npm_latest_version"] == "2.1.0"
+    assert raw["_npm_versions"] == ["1.0.0", "2.1.0"]
+    assert raw["_npm_latest_release_date"] == "2024-03-01T12:00:00Z"
+    assert raw["_npm_registry_url"] == "https://www.npmjs.com/package/@acme/tool"
+    assert raw["_npm_link"] == "verified"
+    assert raw["_pypi_package"] == "acme-tool"
+    assert raw["_pypi_latest_version"] == "3.4.0"
+    assert raw["_pypi_link"] == "name_only"
+
+
+def test_repository_agent_npm_pypi_all_none_when_absent() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_repo_context(),
+            },
+            providers,
+        ),
+    )
+    raw = result.raw_output
+    for key in (
+        "_npm_package",
+        "_npm_latest_version",
+        "_npm_versions",
+        "_npm_latest_release_date",
+        "_npm_registry_url",
+        "_npm_link",
+        "_pypi_package",
+        "_pypi_latest_version",
+        "_pypi_versions",
+        "_pypi_latest_release_date",
+        "_pypi_registry_url",
+        "_pypi_link",
+    ):
+        assert raw[key] is None, key


### PR DESCRIPTION
## Why
GitHub Packages doesn't cover **public npmjs.com** (only `npm.pkg.github.com`) and has **no PyPI support** at all — so a repo's published npm/PyPI packages are invisible to the GitHub API. This discovers them by reading the repo's manifest for the package name, querying the public registry, and verifying the registry's declared repo URL points back to this repo. Completes the package story alongside GHCR (#136).

## How it works
1. **Name** from the manifest already in `aux_files`: `package.json` (npm), `pyproject.toml` `[project]`/`[tool.poetry]` + `setup.cfg` fallback (PyPI).
2. **Query** the public registry: `registry.npmjs.org/<name>` (scoped names URL-encoded) / `pypi.org/pypi/<name>/json`.
3. **Verify the link**: the registry's `repository_url` must back-reference this repo.
   - matches → `link="verified"`
   - points elsewhere → **dropped** (name collision with a different project)
   - absent → `link="name_only"` (weaker but kept)

## Emitted triples (`?include_internal_fields=true`)
`gme-internal:npm_package / npm_latest_version / npm_versions / npm_latest_release_date / npm_registry_url / npm_link` — and the `pypi_*` mirror. Always present (None when no package / no manifest / provider off).

## Components
- **`PackageRegistryProvider`** (new) — injectable session + optional cache, best-effort (None on 404/non-200/parse/transport; never raises).
- **`_repo_signals.py`** — `parse_npm_name`, `parse_pypi_name`, `repo_url_matches`, `summarize_registry_package` (pure, no I/O).
- **`context_gather`** — the link policy, wired into both repository code paths, gated on `providers.package_registry`.
- **`repository_agent`** — splats the flat scalars beside releases/GHCR.
- **`ProviderSet.package_registry`** + `dependencies.py` wiring gated by `V2_PACKAGE_REGISTRY_ENABLED` (default `true`; mock path → None).

## Security note
`repo_url_matches` normalizes the many `repository.url` shapes (`git+https`, `ssh://`, scp-like `git@host:o/r`, `git://`, `.git`, trailing slash, case) and **rejects github.com lookalike subdomains** (e.g. `evil.github.com/o/r`) so a malicious package can't claim a "verified" link — covered by a regression test.

## Scope
npm + PyPI via their public registries. Other ecosystems (Maven/NuGet/RubyGems/Cargo) not included.

## Tests
42 tests in `tests/v2/test_npm_pypi_packages.py` (name parsing, link heuristics incl. lookalike rejection, provider with a fake session, context_gather link policy incl. mismatch-drop, agent scalars). No real network. Full `tests/v2/` green: **1527 passed, 1 skipped**. New files ruff-clean; zero new lint in modified files.