### PR TITLE
feat(v2): README badges + conda/crates.io/RubyGems package discovery

### DIFF
--- a/docs/superpowers/specs/2026-06-07-badges-conda-crates-rubygems.md
+++ b/docs/superpowers/specs/2026-06-07-badges-conda-crates-rubygems.md
@@ -1,0 +1,129 @@
+# README badges + conda / crates.io / RubyGems discovery
+
+**Date:** 2026-06-07
+**Branch:** `feat/badges-multi-registry`
+**Goal:** (1) Parse README badges into a `gme-internal:badges` field, and (2) use
+badges (and manifests) to discover packages on **conda/Anaconda**, **crates.io**,
+and **RubyGems**, emitted as flat `gme-internal:*` scalars — extending the
+manifest-linked npm/PyPI discovery already shipped (#138).
+
+## Build on existing pattern
+- `PackageRegistryProvider` (`src/v2/ingest/providers/package_registry_provider.py`)
+  already has `get_npm_package` / `get_pypi_package` (injectable `session`,
+  optional `ProviderCache`, best-effort None-on-failure). Add the three new
+  registries here, same shape.
+- `_repo_signals.py`: `repo_url_matches`, `summarize_registry_package`
+  (always-present keys: package, latest_version, versions, latest_release_date,
+  registry_url, link). Reuse both. Add badge + coord helpers here (pure, no I/O).
+- `context_gather.py`: `_enrich_repository_metadata_with_registry_packages`
+  already does parse-name → query → link-policy (verified / mismatch-drop /
+  name_only) → store on `repository_metadata`. Extend it.
+- `repository_agent.py`: splats `summarize_registry_package(...)` with `_<eco>_`
+  prefixes into the entity dict; `jsonld_build` emits `gme-internal:*`.
+- `aux_files` already includes `cargo.toml` (crates name source). No gemspec is
+  fetched → RubyGems is badge-driven. conda has no repo manifest → badge-driven.
+- `repo_url_matches` currently only validates **github.com** URLs; conda/crates/
+  RubyGems back-refs are github URLs in the common case, so it applies directly.
+
+## Part 1 — Badge parsing (pure, `_repo_signals.py`)
+- `parse_badges(readme) -> list[dict]`: match Markdown linked badges
+  `[![alt](image_url)](link_url)` AND plain image badges `![alt](image_url)`
+  (link_url None). Return de-duped, order-preserving list of
+  `{"label": alt, "image_url": img, "link_url": link_or_None}`. Empty on
+  None/empty. Cap ~100, log if truncated.
+- `extract_registry_coords(badges) -> dict`: from the badge list, recognise
+  registry coordinates (prefer `link_url`, fall back to `image_url`). Return the
+  FIRST match per ecosystem:
+  - `pypi`: link `pypi.org/project/<name>` | `pypi.python.org/pypi/<name>`;
+    image `badge.fury.io/py/<name>` | `img.shields.io/pypi/v/<name>` →
+    `{"pypi": "<name>"}`
+  - `npm`: link `npmjs.com/package/<name>` (keep scoped `@scope/pkg`);
+    image `badge.fury.io/js/<name>` | `img.shields.io/npm/v/<name>`
+  - `conda`: link `anaconda.org/<channel>/<name>`; image
+    `anaconda.org/<channel>/<name>/badges/...` | `img.shields.io/conda/v/<channel>/<name>`
+    → `{"conda": ("<channel>", "<name>")}`
+  - `crates`: link `crates.io/crates/<name>`; image `img.shields.io/crates/v/<name>`
+  - `rubygems`: link `rubygems.org/gems/<name>`; image
+    `img.shields.io/gem/v/<name>` | `badge.fury.io/rb/<name>`
+  Return `{}` for nothing recognised. (URL-decode `%2F` etc. as needed; ignore CI
+  badges like `github.com/.../workflows/...`.)
+- `parse_crates_name(aux_files) -> str | None`: `cargo.toml` via `tomllib` →
+  `[package].name`. None on missing/malformed.
+
+## Part 2 — Registry providers (`package_registry_provider.py`)
+All best-effort (None on 404 / non-200 / parse / transport; never raise),
+cached, and send a descriptive `User-Agent` header (crates.io **requires** one;
+set it for all). Each returns the same thin-dict shape as npm/PyPI
+(`name, latest_version, versions, latest_release_date, repository_url,
+registry_url`) plus conda adds `channel`.
+
+- `get_conda_package(channel, name)` — GET `https://api.anaconda.org/package/<channel>/<name>`.
+  Map: `latest_version` ← `latest_version`; `versions` ← `versions` (list, cap ~200);
+  `repository_url` ← `dev_url` else `source_git_url` else `html_url`;
+  `latest_release_date` ← best-effort from `files`/`ndownloads` if present, else None
+  (Anaconda's per-version timestamps are under `files[].upload_time`; take the max,
+  else None); `registry_url` ← `https://anaconda.org/<channel>/<name>`;
+  add `channel`.
+- `get_crates_package(name)` — GET `https://crates.io/api/v1/crates/<name>`.
+  Map: `latest_version` ← `crate.max_stable_version` else `crate.newest_version`;
+  `versions` ← `[v["num"] for v in versions]` (cap ~200);
+  `repository_url` ← `crate.repository`;
+  `latest_release_date` ← `crate.updated_at`;
+  `registry_url` ← `https://crates.io/crates/<name>`.
+- `get_rubygems_package(name)` — GET `https://rubygems.org/api/v1/gems/<name>.json`.
+  Map: `latest_version` ← `version`; `repository_url` ← `source_code_uri` else
+  `homepage_uri`; `registry_url` ← `https://rubygems.org/gems/<name>`;
+  `versions` ← best-effort from a second GET
+  `https://rubygems.org/api/v1/versions/<name>.json` → `[v["number"]]` (cap ~200;
+  tolerate failure → None); `latest_release_date` ← from that versions payload
+  (max `created_at`) else None.
+
+## Part 3 — `context_gather` wiring
+In `_enrich_repository_metadata_with_registry_packages`:
+- Parse badges from the README (the stage already has README content — thread it
+  in if not already a param) → store `repository_metadata["badges"]` when non-empty.
+- `coords = extract_registry_coords(badges)`.
+- **Strengthen npm/PyPI**: when `parse_npm_name`/`parse_pypi_name` returns None,
+  fall back to `coords.get("npm")` / `coords.get("pypi")`.
+- **conda**: if `coords.get("conda")` → `(channel, name)` → `get_conda_package`
+  → link policy (verified / mismatch-drop / name_only) → store `conda_package`.
+- **crates**: name from `parse_crates_name(aux_files)` else `coords.get("crates")`
+  → `get_crates_package` → link policy → store `crates_package`.
+- **rubygems**: name from `coords.get("rubygems")` → `get_rubygems_package` →
+  link policy → store `rubygems_package`.
+Same best-effort try/except → `warnings`. Keep the link policy identical to
+npm/PyPI (`repo_url_matches` present+match → verified; present+mismatch → DROP;
+absent → name_only).
+
+## Part 4 — `repository_agent.py` flat scalars
+- Emit raw badges + count:
+  `"_badges": (repository.get("badges") or None)`,
+  `"_badge_count": (len(repository["badges"]) if isinstance(repository.get("badges"), list) else None)`.
+- Splat `summarize_registry_package(repository.get("<eco>_package"))` with
+  prefixes `_conda_`, `_crates_`, `_rubygems_` (beside the existing
+  `_npm_`/`_pypi_` splats). For conda, ALSO emit
+  `"_conda_channel": (repository.get("conda_package") or {}).get("channel")`.
+
+Resulting terms (under `?include_internal_fields=true`):
+`gme-internal:badges` (raw list), `gme-internal:badge_count`,
+`gme-internal:{conda,crates,rubygems}_{package,latest_version,versions,latest_release_date,registry_url,link}`,
+`gme-internal:conda_channel`.
+
+## Tests (`tests/v2/`, NO real network)
+- `parse_badges`: linked + plain-image badges, dedupe, empty.
+- `extract_registry_coords`: pypi/npm/conda/crates/rubygems via link AND via
+  shields/fury image; CI badge ignored; conda channel+name tuple.
+- `parse_crates_name`: cargo.toml `[package].name`, missing/malformed.
+- Each provider with an injected fake session → thin dict (incl. versions,
+  repository_url, conda channel, crates max_stable_version); 404 → None;
+  crates User-Agent header asserted present.
+- `context_gather`: fake provider + a README with the spec's CSBDeep badges →
+  `badges` populated, `conda_package` discovered + verified (dev_url back-ref),
+  mismatch dropped; crates from cargo.toml.
+- `repository_agent`: emits `_badges`/`_badge_count` + `_conda_*`/`_crates_*`/
+  `_rubygems_*` (+ `_conda_channel`); all-None when absent.
+
+## Gate
+Full `tests/v2/` green. No real network/LLM. New files ruff-clean; no new lint
+in modified files. `repo_url_matches` github-only host check stays strict
+(rejects lookalike subdomains).

--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -18,10 +18,14 @@ from __future__ import annotations
 
 import configparser
 import json
+import logging
 import re
 from typing import Any
+from urllib.parse import unquote
 
 import tomllib
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # _has_ci detection
@@ -327,6 +331,224 @@ def summarize_packages(container_images: Any) -> dict[str, Any]:
     if updated:
         out["latest_package_updated_at"] = updated[-1]
     return out
+
+
+# ---------------------------------------------------------------------------
+# Badge parsing + registry coordinate extraction (pure, no I/O)
+# ---------------------------------------------------------------------------
+
+# Maximum number of badges carried in `gme-internal:badges`. A handful of
+# READMEs embed dozens of status badges; the cap keeps the list bounded.
+_MAX_BADGES = 100
+
+# Linked badge: `[![alt](image_url)](link_url)`
+_BADGE_LINKED_RE = re.compile(
+    r"\[!\[(?P<alt>[^\]]*)\]\((?P<img>[^)\s]+)(?:\s+[^)]*)?\)\]"
+    r"\((?P<link>[^)\s]+)(?:\s+[^)]*)?\)",
+)
+# Plain image badge: `![alt](image_url)`
+_BADGE_IMAGE_RE = re.compile(
+    r"!\[(?P<alt>[^\]]*)\]\((?P<img>[^)\s]+)(?:\s+[^)]*)?\)",
+)
+
+
+def parse_badges(readme: str | None) -> list[dict[str, Any]]:
+    """Extract Markdown badges from *readme* as structured records.
+
+    Recognises linked badges ``[![alt](image_url)](link_url)`` and plain
+    image badges ``![alt](image_url)`` (``link_url`` None). Returns a
+    de-duped, order-preserving list of
+    ``{"label": alt, "image_url": img, "link_url": link_or_None}``.
+
+    Empty list on None/empty input. Capped at ~100 entries (a warning is
+    logged when truncated). Linked badges take precedence over the plain
+    image inside them: the linked form is matched first and its span is
+    masked so the inner ``![alt](img)`` is not double-counted.
+    """
+    if not isinstance(readme, str) or not readme:
+        return []
+
+    seen: set[tuple[str, str, str | None]] = set()
+    result: list[dict[str, Any]] = []
+
+    def _add(alt: str, img: str, link: str | None) -> None:
+        key = (alt, img, link)
+        if key in seen:
+            return
+        seen.add(key)
+        result.append({"label": alt, "image_url": img, "link_url": link})
+
+    # Match linked badges first, masking their spans so the inner plain
+    # image isn't matched again by the plain-image pass below.
+    masked = list(readme)
+    for m in _BADGE_LINKED_RE.finditer(readme):
+        _add(m.group("alt"), m.group("img"), m.group("link"))
+        for i in range(m.start(), m.end()):
+            masked[i] = "\0"
+    masked_text = "".join(masked)
+    for m in _BADGE_IMAGE_RE.finditer(masked_text):
+        _add(m.group("alt"), m.group("img"), None)
+
+    if len(result) > _MAX_BADGES:
+        logger.info(
+            "README has %d badges; truncating to %d", len(result), _MAX_BADGES,
+        )
+        result = result[:_MAX_BADGES]
+    return result
+
+
+# Registry-coordinate matchers. Each returns a value for the ecosystem when
+# the URL matches, else None. URLs are URL-decoded first so `%2F` etc. work.
+_PYPI_LINK_RE = re.compile(
+    r"(?:pypi\.org/project|pypi\.python\.org/pypi)/(?P<name>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+_PYPI_IMAGE_RE = re.compile(
+    r"(?:badge\.fury\.io/py|img\.shields\.io/pypi/v)/(?P<name>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+_NPM_LINK_RE = re.compile(
+    r"npmjs\.com/package/(?P<name>(?:@[^/\s)?#]+/)?[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+_NPM_IMAGE_RE = re.compile(
+    r"(?:badge\.fury\.io/js|img\.shields\.io/npm/v)/"
+    r"(?P<name>(?:@[^/\s)?#]+/)?[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+_CONDA_LINK_RE = re.compile(
+    r"anaconda\.org/(?P<channel>[^/\s)?#]+)/(?P<name>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+_CONDA_SHIELDS_RE = re.compile(
+    r"img\.shields\.io/conda/v/(?P<channel>[^/\s)?#]+)/(?P<name>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+_CRATES_LINK_RE = re.compile(
+    r"crates\.io/crates/(?P<name>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+_CRATES_IMAGE_RE = re.compile(
+    r"img\.shields\.io/crates/v/(?P<name>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+_RUBYGEMS_LINK_RE = re.compile(
+    r"rubygems\.org/gems/(?P<name>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+_RUBYGEMS_IMAGE_RE = re.compile(
+    r"(?:img\.shields\.io/gem/v|badge\.fury\.io/rb)/(?P<name>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+
+
+# Badge image URLs (badge.fury.io, img.shields.io) often end in an image
+# extension (`csbdeep.svg`); no real package name does, so strip it.
+_BADGE_EXT_RE = re.compile(r"\.(?:svg|png|json|gif)$", re.IGNORECASE)
+
+
+def _strip_badge_ext(name: str) -> str:
+    return _BADGE_EXT_RE.sub("", name)
+
+
+def _match_pypi(url: str) -> str | None:
+    m = _PYPI_LINK_RE.search(url) or _PYPI_IMAGE_RE.search(url)
+    return _strip_badge_ext(m.group("name")) if m else None
+
+
+def _match_npm(url: str) -> str | None:
+    m = _NPM_LINK_RE.search(url) or _NPM_IMAGE_RE.search(url)
+    return _strip_badge_ext(m.group("name")) if m else None
+
+
+def _match_conda(url: str) -> tuple[str, str] | None:
+    m = _CONDA_SHIELDS_RE.search(url)
+    if m:
+        return (m.group("channel"), _strip_badge_ext(m.group("name")))
+    m = _CONDA_LINK_RE.search(url)
+    if m:
+        # `anaconda.org/<channel>/<name>` — the `/badges/...` suffix on
+        # image badges is ignored because the regex stops at `<name>`.
+        return (m.group("channel"), _strip_badge_ext(m.group("name")))
+    return None
+
+
+def _match_crates(url: str) -> str | None:
+    m = _CRATES_LINK_RE.search(url) or _CRATES_IMAGE_RE.search(url)
+    return _strip_badge_ext(m.group("name")) if m else None
+
+
+def _match_rubygems(url: str) -> str | None:
+    m = _RUBYGEMS_LINK_RE.search(url) or _RUBYGEMS_IMAGE_RE.search(url)
+    return _strip_badge_ext(m.group("name")) if m else None
+
+
+# (ecosystem-key, matcher) pairs consulted for each badge URL.
+_COORD_MATCHERS: tuple[tuple[str, Any], ...] = (
+    ("pypi", _match_pypi),
+    ("npm", _match_npm),
+    ("conda", _match_conda),
+    ("crates", _match_crates),
+    ("rubygems", _match_rubygems),
+)
+
+
+def _coords_from_url(url: str, out: dict[str, Any]) -> None:
+    """Fill the first match per ecosystem into *out* from a single URL."""
+    for key, matcher in _COORD_MATCHERS:
+        if key in out:
+            continue
+        value = matcher(url)
+        if value:
+            out[key] = value
+
+
+def extract_registry_coords(badges: Any) -> dict[str, Any]:
+    """Recognise package-registry coordinates in a parsed *badges* list.
+
+    For each badge, prefer the ``link_url`` (a click-through to the actual
+    registry page) and fall back to the ``image_url`` (a shields.io /
+    badge.fury.io status image). Returns the FIRST match per ecosystem:
+
+    * ``pypi``     → ``"<name>"``
+    * ``npm``      → ``"<name>"`` (scoped ``@scope/pkg`` kept intact)
+    * ``conda``    → ``("<channel>", "<name>")``
+    * ``crates``   → ``"<name>"``
+    * ``rubygems`` → ``"<name>"``
+
+    CI / workflow badges (github.com/.../workflows/...) are ignored since
+    they match none of the registry patterns. Returns ``{}`` when nothing
+    is recognised.
+    """
+    out: dict[str, Any] = {}
+    if not isinstance(badges, list):
+        return out
+    for badge in badges:
+        if not isinstance(badge, dict):
+            continue
+        for raw in (badge.get("link_url"), badge.get("image_url")):
+            if not isinstance(raw, str) or not raw:
+                continue
+            _coords_from_url(unquote(raw), out)
+    return out
+
+
+def parse_crates_name(aux_files: Any) -> str | None:
+    """Extract the crate name from a repo's ``cargo.toml`` ``[package].name``.
+
+    Returns the name as-declared, or None when ``cargo.toml`` is missing,
+    malformed, or has no ``[package].name``.
+    """
+    content = _aux_file_lookup(aux_files, "cargo.toml")
+    if content is None:
+        return None
+    try:
+        data = tomllib.loads(content)
+    except (tomllib.TOMLDecodeError, ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return _name_from_table(data.get("package"))
 
 
 # ---------------------------------------------------------------------------

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -577,6 +577,42 @@ class RepositoryAgentV2:
                     repository.get("pypi_package"),
                 ).items()
             },
+            # README badges — parsed from the raw README by context_gather
+            # into a list of {label, image_url, link_url} records, stored as
+            # repository_metadata["badges"]. `_badges` is the raw list (or
+            # None); `_badge_count` is the count (or None when no badges).
+            "_badges": (repository.get("badges") or None),
+            "_badge_count": (
+                len(repository["badges"])
+                if isinstance(repository.get("badges"), list)
+                else None
+            ),
+            # Published conda / crates.io / RubyGems packages — discovered by
+            # context_gather from README badge coordinates (+ cargo.toml for
+            # crates) and the public-registry back-reference, stored as
+            # `conda_package` / `crates_package` / `rubygems_package`. Same
+            # flat `gme-internal:*` scalars as `_npm_*` / `_pypi_*`. conda
+            # also emits `_conda_channel` (the Anaconda channel). Always
+            # present (all None when no badge / provider disabled / drop).
+            **{
+                f"_conda_{k}": v
+                for k, v in summarize_registry_package(
+                    repository.get("conda_package"),
+                ).items()
+            },
+            "_conda_channel": (repository.get("conda_package") or {}).get("channel"),
+            **{
+                f"_crates_{k}": v
+                for k, v in summarize_registry_package(
+                    repository.get("crates_package"),
+                ).items()
+            },
+            **{
+                f"_rubygems_{k}": v
+                for k, v in summarize_registry_package(
+                    repository.get("rubygems_package"),
+                ).items()
+            },
             # CI presence — detected from the repo root listing by
             # context_gather and stored in repository_metadata["has_ci"].
             # None when the listing was unavailable.

--- a/src/v2/ingest/providers/package_registry_provider.py
+++ b/src/v2/ingest/providers/package_registry_provider.py
@@ -33,6 +33,13 @@ _REQUEST_TIMEOUT_SECONDS = 15
 _HTTP_OK = 200
 _HTTP_NOT_FOUND = 404
 
+# Descriptive User-Agent — crates.io REQUIRES one (rejects requests without
+# it) and it is polite for every registry. Sent on all outbound requests.
+_USER_AGENT = (
+    "open-pulse-metadata-enricher "
+    "(+https://github.com/Imaging-Plaza; package discovery)"
+)
+
 
 class PackageRegistryProvider:
     """Fetch thin published-package metadata from npmjs.com / PyPI.
@@ -178,13 +185,234 @@ class PackageRegistryProvider:
         }
 
     # ------------------------------------------------------------------
+    # conda / Anaconda
+    # ------------------------------------------------------------------
+
+    def get_conda_package(
+        self, channel: str, name: str,
+    ) -> dict[str, Any] | None:
+        """Fetch thin metadata for conda package *channel*/*name*.
+
+        GETs ``https://api.anaconda.org/package/<channel>/<name>``. Returns
+        None on any failure. Adds a ``channel`` key to the thin dict.
+        """
+        if not isinstance(channel, str) or not channel.strip():
+            return None
+        if not isinstance(name, str) or not name.strip():
+            return None
+        channel = channel.strip()
+        name = name.strip()
+
+        def _fetch() -> dict[str, Any] | None:
+            ch = quote(channel, safe="")
+            pkg = quote(name, safe="")
+            url = f"https://api.anaconda.org/package/{ch}/{pkg}"
+            payload = self._get_json(url, subject=f"conda:{channel}/{name}")
+            if not isinstance(payload, dict):
+                return None
+            return self._thin_conda(payload, channel, name)
+
+        return self._cached(
+            _fetch, method="get_conda_package", name=f"{channel}/{name}",
+        )
+
+    @staticmethod
+    def _thin_conda(
+        payload: dict[str, Any], channel: str, name: str,
+    ) -> dict[str, Any] | None:
+        pkg_name = payload.get("name")
+        pkg_name = pkg_name if isinstance(pkg_name, str) and pkg_name else name
+
+        latest_version = payload.get("latest_version")
+        latest_version = latest_version if isinstance(latest_version, str) else None
+
+        versions_obj = payload.get("versions")
+        versions: list[str] = []
+        if isinstance(versions_obj, list):
+            versions = [v for v in versions_obj if isinstance(v, str) and v]
+        if len(versions) > _MAX_VERSIONS:
+            logger.info(
+                "conda package %s/%s has %d versions; truncating to %d",
+                channel, name, len(versions), _MAX_VERSIONS,
+            )
+            versions = versions[:_MAX_VERSIONS]
+
+        repository_url = _first_str(
+            payload.get("dev_url"),
+            payload.get("source_git_url"),
+            payload.get("html_url"),
+        )
+
+        latest_release_date = _max_str(
+            f.get("upload_time")
+            for f in payload.get("files", [])
+            if isinstance(f, dict)
+        )
+
+        return {
+            "name": pkg_name,
+            "latest_version": latest_version,
+            "versions": versions or None,
+            "latest_release_date": latest_release_date,
+            "repository_url": repository_url,
+            "registry_url": f"https://anaconda.org/{channel}/{pkg_name}",
+            "channel": channel,
+        }
+
+    # ------------------------------------------------------------------
+    # crates.io
+    # ------------------------------------------------------------------
+
+    def get_crates_package(self, name: str) -> dict[str, Any] | None:
+        """Fetch thin metadata for crates.io crate *name*.
+
+        GETs ``https://crates.io/api/v1/crates/<name>``. Returns None on
+        failure. crates.io REQUIRES a User-Agent header (sent by _get_json).
+        """
+        if not isinstance(name, str) or not name.strip():
+            return None
+        name = name.strip()
+
+        def _fetch() -> dict[str, Any] | None:
+            encoded = quote(name, safe="")
+            url = f"https://crates.io/api/v1/crates/{encoded}"
+            payload = self._get_json(url, subject=f"crates:{name}")
+            if not isinstance(payload, dict):
+                return None
+            return self._thin_crates(payload, name)
+
+        return self._cached(_fetch, method="get_crates_package", name=name)
+
+    @staticmethod
+    def _thin_crates(payload: dict[str, Any], name: str) -> dict[str, Any] | None:
+        crate = payload.get("crate") if isinstance(payload.get("crate"), dict) else {}
+
+        pkg_name = crate.get("name")
+        pkg_name = pkg_name if isinstance(pkg_name, str) and pkg_name else name
+
+        latest_version = _first_str(
+            crate.get("max_stable_version"), crate.get("newest_version"),
+        )
+
+        versions_obj = payload.get("versions")
+        versions: list[str] = []
+        if isinstance(versions_obj, list):
+            versions = [
+                v["num"]
+                for v in versions_obj
+                if isinstance(v, dict) and isinstance(v.get("num"), str) and v["num"]
+            ]
+        if len(versions) > _MAX_VERSIONS:
+            logger.info(
+                "crate %s has %d versions; truncating to %d",
+                name, len(versions), _MAX_VERSIONS,
+            )
+            versions = versions[:_MAX_VERSIONS]
+
+        repository_url = _first_str(crate.get("repository"))
+        latest_release_date = _first_str(crate.get("updated_at"))
+
+        return {
+            "name": pkg_name,
+            "latest_version": latest_version,
+            "versions": versions or None,
+            "latest_release_date": latest_release_date,
+            "repository_url": repository_url,
+            "registry_url": f"https://crates.io/crates/{pkg_name}",
+        }
+
+    # ------------------------------------------------------------------
+    # RubyGems
+    # ------------------------------------------------------------------
+
+    def get_rubygems_package(self, name: str) -> dict[str, Any] | None:
+        """Fetch thin metadata for RubyGems gem *name*.
+
+        GETs ``https://rubygems.org/api/v1/gems/<name>.json`` and, best-effort,
+        ``https://rubygems.org/api/v1/versions/<name>.json`` for the version
+        list. Returns None on failure of the primary request.
+        """
+        if not isinstance(name, str) or not name.strip():
+            return None
+        name = name.strip()
+
+        def _fetch() -> dict[str, Any] | None:
+            encoded = quote(name, safe="")
+            url = f"https://rubygems.org/api/v1/gems/{encoded}.json"
+            payload = self._get_json(url, subject=f"rubygems:{name}")
+            if not isinstance(payload, dict):
+                return None
+            versions_url = (
+                f"https://rubygems.org/api/v1/versions/{encoded}.json"
+            )
+            versions_payload = self._get_json(
+                versions_url, subject=f"rubygems-versions:{name}",
+            )
+            return self._thin_rubygems(payload, versions_payload, name)
+
+        return self._cached(_fetch, method="get_rubygems_package", name=name)
+
+    @staticmethod
+    def _thin_rubygems(
+        payload: dict[str, Any], versions_payload: Any, name: str,
+    ) -> dict[str, Any] | None:
+        pkg_name = payload.get("name")
+        pkg_name = pkg_name if isinstance(pkg_name, str) and pkg_name else name
+
+        latest_version = payload.get("version")
+        latest_version = latest_version if isinstance(latest_version, str) else None
+
+        repository_url = _first_str(
+            payload.get("source_code_uri"), payload.get("homepage_uri"),
+        )
+
+        versions: list[str] = []
+        latest_release_date: str | None = None
+        if isinstance(versions_payload, list):
+            versions = [
+                v["number"]
+                for v in versions_payload
+                if isinstance(v, dict)
+                and isinstance(v.get("number"), str)
+                and v["number"]
+            ]
+            if len(versions) > _MAX_VERSIONS:
+                logger.info(
+                    "gem %s has %d versions; truncating to %d",
+                    name, len(versions), _MAX_VERSIONS,
+                )
+                versions = versions[:_MAX_VERSIONS]
+            latest_release_date = _max_str(
+                v.get("created_at")
+                for v in versions_payload
+                if isinstance(v, dict)
+            )
+
+        return {
+            "name": pkg_name,
+            "latest_version": latest_version,
+            "versions": versions or None,
+            "latest_release_date": latest_release_date,
+            "repository_url": repository_url,
+            "registry_url": f"https://rubygems.org/gems/{pkg_name}",
+        }
+
+    # ------------------------------------------------------------------
     # shared helpers
     # ------------------------------------------------------------------
 
     def _get_json(self, url: str, *, subject: str) -> Any:
-        """GET *url* and return parsed JSON, or None on any failure."""
+        """GET *url* and return parsed JSON, or None on any failure.
+
+        Sends a descriptive ``User-Agent`` header on every request (crates.io
+        rejects requests without one).
+        """
         try:
-            response = self._session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+            response = self._session.get(
+                url,
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+                headers={"User-Agent": _USER_AGENT},
+            )
         except Exception:  # noqa: BLE001 — best-effort; never raise on transport error.
             logger.info("package registry fetch failed: %s", subject)
             return None
@@ -215,6 +443,23 @@ class PackageRegistryProvider:
         return self._cache.get_or_set(
             key, factory, label=f"package_registry.{method}({name})",
         )
+
+
+def _first_str(*candidates: Any) -> str | None:
+    """Return the first non-empty stripped string in *candidates*, else None."""
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return None
+
+
+def _max_str(values: Any) -> str | None:
+    """Return the lexically-max non-empty string in *values*, else None.
+
+    Used for ISO 8601 timestamps where lexical order == chronological order.
+    """
+    strings = sorted(v for v in values if isinstance(v, str) and v)
+    return strings[-1] if strings else None
 
 
 def _extract_npm_repo_url(

--- a/src/v2/pipeline/stages/context_gather.py
+++ b/src/v2/pipeline/stages/context_gather.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING, Any
 
 from src.v2.agents.rule_based._repo_signals import (
     detect_has_ci,
+    extract_registry_coords,
+    parse_badges,
+    parse_crates_name,
     parse_npm_name,
     parse_pypi_name,
     repo_url_matches,
@@ -250,16 +253,28 @@ def _normalize_owned_repo_full_name(owner: str, repo: str) -> str:
     return f"{owner}/{repo}"
 
 
-def _enrich_repository_metadata_with_registry_packages(
+def _enrich_repository_metadata_with_registry_packages(  # noqa: C901, PLR0913
     *,
     full_name: str,
     aux_files: dict[str, Any] | None,
     repository_metadata: dict[str, Any],
     providers: ProviderSet,
     warnings: list[str],
+    readme: str | None = None,
 ) -> None:
-    """Discover the repo's published npm / PyPI packages and store them on
-    *repository_metadata* (``npm_package`` / ``pypi_package``) in place.
+    """Discover the repo's published packages and store them on
+    *repository_metadata* in place.
+
+    Parses README badges into ``repository_metadata["badges"]`` (when any),
+    then discovers packages across npm / PyPI / conda / crates.io / RubyGems:
+
+    * npm / PyPI: manifest name (``package.json`` / ``pyproject.toml`` /
+      ``setup.cfg``), falling back to badge coordinates when no manifest name.
+    * conda: badge coordinates only (no repo manifest).
+    * crates.io: ``cargo.toml`` ``[package].name``, else badge coordinates.
+    * RubyGems: badge coordinates only (no gemspec is fetched).
+
+    Stored as ``{npm,pypi,conda,crates,rubygems}_package``.
 
     Gated on ``providers.package_registry`` being available; best-effort
     (failures append a warning and never break the pipeline). Link policy
@@ -271,7 +286,15 @@ def _enrich_repository_metadata_with_registry_packages(
       (almost certainly a name collision with a different project's package).
     * registry's ``repository_url`` absent → store with ``link="name_only"``
       (name match only; weaker but still useful signal).
+
+    Badge parsing runs even when ``package_registry`` is None (badges are a
+    README-derived signal, not a registry call).
     """
+    badges = parse_badges(readme)
+    if badges:
+        repository_metadata["badges"] = badges
+    coords = extract_registry_coords(badges)
+
     registry = getattr(providers, "package_registry", None)
     if registry is None:
         return
@@ -291,7 +314,7 @@ def _enrich_repository_metadata_with_registry_packages(
         repository_metadata[key] = pkg
 
     try:
-        npm_name = parse_npm_name(aux_files)
+        npm_name = parse_npm_name(aux_files) or coords.get("npm")
         if npm_name:
             _link_and_store(registry.get_npm_package(npm_name), key="npm_package")
     except Exception as exc:  # noqa: BLE001
@@ -299,12 +322,45 @@ def _enrich_repository_metadata_with_registry_packages(
             f"npm package lookup failed for {full_name}: {exc}",
         )
     try:
-        pypi_name = parse_pypi_name(aux_files)
+        pypi_name = parse_pypi_name(aux_files) or coords.get("pypi")
         if pypi_name:
             _link_and_store(registry.get_pypi_package(pypi_name), key="pypi_package")
     except Exception as exc:  # noqa: BLE001
         warnings.append(
             f"PyPI package lookup failed for {full_name}: {exc}",
+        )
+    try:
+        conda_coord = coords.get("conda")
+        if conda_coord:
+            channel, conda_name = conda_coord
+            _link_and_store(
+                registry.get_conda_package(channel, conda_name),
+                key="conda_package",
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"conda package lookup failed for {full_name}: {exc}",
+        )
+    try:
+        crates_name = parse_crates_name(aux_files) or coords.get("crates")
+        if crates_name:
+            _link_and_store(
+                registry.get_crates_package(crates_name), key="crates_package",
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"crates package lookup failed for {full_name}: {exc}",
+        )
+    try:
+        rubygems_name = coords.get("rubygems")
+        if rubygems_name:
+            _link_and_store(
+                registry.get_rubygems_package(rubygems_name),
+                key="rubygems_package",
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"RubyGems package lookup failed for {full_name}: {exc}",
         )
 
 
@@ -431,15 +487,17 @@ def _optional_repository_context(
             f"Repository root-listing (has_ci) failed for {full_name}: {exc}",
         )
 
-    # Published npm / PyPI packages — discovered from the manifest name +
-    # public-registry back-reference. Best-effort; gated on the
-    # package_registry provider being available.
+    # Published packages (npm / PyPI / conda / crates / RubyGems) + README
+    # badges — discovered from the manifest name / badge coordinates +
+    # public-registry back-reference. Best-effort. Badge parsing needs the
+    # RAW README (the cleaned `readme_content` has had badges stripped).
     _enrich_repository_metadata_with_registry_packages(
         full_name=full_name,
         aux_files=aux_files,
         repository_metadata=repository_metadata,
         providers=providers,
         warnings=warnings,
+        readme=readme_from_provider,
     )
 
     return {
@@ -570,14 +628,16 @@ async def gather_context(  # noqa: C901, PLR0915
                 f"Repository root-listing (has_ci) failed for {full_name}: {exc}",
             )
 
-        # Published npm / PyPI packages (best-effort; same as
-        # _optional_repository_context above).
+        # Published packages + README badges (best-effort; same as
+        # _optional_repository_context above). Pass the RAW README so badge
+        # parsing sees the un-stripped `![..](..)` constructs.
         _enrich_repository_metadata_with_registry_packages(
             full_name=full_name,
             aux_files=aux_files,
             repository_metadata=repository_metadata,
             providers=providers,
             warnings=warnings,
+            readme=readme_from_provider,
         )
 
         context["repository"] = {

--- a/tests/v2/test_badges_multi_registry.py
+++ b/tests/v2/test_badges_multi_registry.py
@@ -1,0 +1,783 @@
+"""Tests for README badge parsing + conda / crates.io / RubyGems discovery.
+
+Extends the npm/PyPI machinery (see ``test_npm_pypi_packages.py``). No real
+network anywhere — a fake session / fake provider is injected.
+
+Covers:
+  - parse_badges: linked + plain-image badges, dedupe, empty.
+  - extract_registry_coords: pypi/npm/conda/crates/rubygems via link AND
+    via shields/fury image; CI badge ignored; conda channel+name tuple.
+  - parse_crates_name: cargo.toml [package].name, missing/malformed.
+  - PackageRegistryProvider.get_{conda,crates,rubygems}_package: canned JSON
+    → thin dict (versions, repository_url, conda channel, crates
+    max_stable_version); 404 → None; crates User-Agent header asserted.
+  - context_gather: README with CSBDeep-style badges → badges populated,
+    conda discovered + verified (dev_url back-ref), mismatch dropped, crates
+    from cargo.toml.
+  - repository_agent: emits `_badges`/`_badge_count` + `_conda_*`/`_crates_*`/
+    `_rubygems_*` (+ `_conda_channel`); all-None when absent.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from src.v2.agents import ProviderSet, RepositoryAgentV2
+from src.v2.agents.rule_based._repo_signals import (
+    extract_registry_coords,
+    parse_badges,
+    parse_crates_name,
+)
+from src.v2.ingest.providers.mock_github import MockGitHubProvider
+from src.v2.ingest.providers.package_registry_provider import (
+    PackageRegistryProvider,
+)
+from src.v2.pipeline.stages.context_gather import (
+    _enrich_repository_metadata_with_registry_packages,
+)
+
+# Expected counts (named to satisfy the magic-value lint).
+_CSBDEEP_BADGE_COUNT = 3
+_BADGE_CAP = 100
+_AGENT_BADGE_COUNT = 2
+
+# ---------------------------------------------------------------------------
+# Fakes — no real network anywhere in this module.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        if isinstance(self._payload, ValueError):
+            raise self._payload
+        return self._payload
+
+
+class FakeSession:
+    """A `requests`-like session returning canned responses keyed by URL."""
+
+    def __init__(self, routes: dict[str, _FakeResponse]) -> None:
+        self._routes = routes
+        self.requested: list[str] = []
+        self.headers_seen: list[dict[str, str] | None] = []
+
+    def get(
+        self,
+        url: str,
+        timeout: float | None = None,  # noqa: ARG002
+        headers: dict[str, str] | None = None,
+    ) -> _FakeResponse:
+        self.requested.append(url)
+        self.headers_seen.append(headers)
+        return self._routes.get(url, _FakeResponse(404, None))
+
+
+class FakeMultiRegistryProvider:
+    """A fake `package_registry` provider returning canned thin dicts."""
+
+    def __init__(
+        self,
+        *,
+        npm: dict[str, Any] | None = None,
+        pypi: dict[str, Any] | None = None,
+        conda: dict[str, Any] | None = None,
+        crates: dict[str, Any] | None = None,
+        rubygems: dict[str, Any] | None = None,
+    ) -> None:
+        self._npm = npm
+        self._pypi = pypi
+        self._conda = conda
+        self._crates = crates
+        self._rubygems = rubygems
+        self.npm_calls: list[str] = []
+        self.pypi_calls: list[str] = []
+        self.conda_calls: list[tuple[str, str]] = []
+        self.crates_calls: list[str] = []
+        self.rubygems_calls: list[str] = []
+
+    def get_npm_package(self, name: str) -> dict[str, Any] | None:
+        self.npm_calls.append(name)
+        return dict(self._npm) if isinstance(self._npm, dict) else None
+
+    def get_pypi_package(self, name: str) -> dict[str, Any] | None:
+        self.pypi_calls.append(name)
+        return dict(self._pypi) if isinstance(self._pypi, dict) else None
+
+    def get_conda_package(self, channel: str, name: str) -> dict[str, Any] | None:
+        self.conda_calls.append((channel, name))
+        return dict(self._conda) if isinstance(self._conda, dict) else None
+
+    def get_crates_package(self, name: str) -> dict[str, Any] | None:
+        self.crates_calls.append(name)
+        return dict(self._crates) if isinstance(self._crates, dict) else None
+
+    def get_rubygems_package(self, name: str) -> dict[str, Any] | None:
+        self.rubygems_calls.append(name)
+        return dict(self._rubygems) if isinstance(self._rubygems, dict) else None
+
+
+# ---------------------------------------------------------------------------
+# parse_badges
+# ---------------------------------------------------------------------------
+
+
+def test_parse_badges_linked_and_plain() -> None:
+    readme = (
+        "# Project\n"
+        "[![PyPI](https://img.shields.io/pypi/v/foo)](https://pypi.org/project/foo)\n"
+        "![Build](https://img.shields.io/badge/build-passing-green)\n"
+    )
+    badges = parse_badges(readme)
+    assert badges == [
+        {
+            "label": "PyPI",
+            "image_url": "https://img.shields.io/pypi/v/foo",
+            "link_url": "https://pypi.org/project/foo",
+        },
+        {
+            "label": "Build",
+            "image_url": "https://img.shields.io/badge/build-passing-green",
+            "link_url": None,
+        },
+    ]
+
+
+def test_parse_badges_dedupe() -> None:
+    readme = (
+        "![A](https://img.shields.io/x)\n"
+        "![A](https://img.shields.io/x)\n"
+    )
+    badges = parse_badges(readme)
+    assert len(badges) == 1
+
+
+def test_parse_badges_linked_not_double_counted() -> None:
+    # The inner ![alt](img) of a linked badge must not produce a second
+    # plain-image record.
+    readme = "[![A](https://img.shields.io/x)](https://example.com)"
+    badges = parse_badges(readme)
+    assert len(badges) == 1
+    assert badges[0]["link_url"] == "https://example.com"
+
+
+def test_parse_badges_empty_and_none() -> None:
+    assert parse_badges(None) == []
+    assert parse_badges("") == []
+    assert parse_badges("no badges here") == []
+
+
+def test_parse_badges_cap() -> None:
+    readme = "\n".join(
+        f"![b{i}](https://img.shields.io/{i})" for i in range(150)
+    )
+    badges = parse_badges(readme)
+    assert len(badges) == _BADGE_CAP
+
+
+# ---------------------------------------------------------------------------
+# extract_registry_coords
+# ---------------------------------------------------------------------------
+
+
+def _coord(image: str, link: str | None = None) -> list[dict[str, Any]]:
+    return [{"label": "x", "image_url": image, "link_url": link}]
+
+
+def test_extract_coords_pypi_link_and_image() -> None:
+    assert extract_registry_coords(
+        _coord("img", "https://pypi.org/project/mypkg"),
+    ) == {"pypi": "mypkg"}
+    assert extract_registry_coords(
+        _coord("https://badge.fury.io/py/mypkg"),
+    ) == {"pypi": "mypkg"}
+    assert extract_registry_coords(
+        _coord("https://img.shields.io/pypi/v/mypkg"),
+    ) == {"pypi": "mypkg"}
+
+
+def test_extract_coords_strips_badge_image_extension() -> None:
+    # Image-only badges (badge.fury.io / shields with an explicit .svg) must
+    # NOT leak the extension into the package name.
+    assert extract_registry_coords(
+        _coord("https://badge.fury.io/py/csbdeep.svg"),
+    ) == {"pypi": "csbdeep"}
+    assert extract_registry_coords(
+        _coord("https://img.shields.io/crates/v/serde.svg"),
+    ) == {"crates": "serde"}
+    assert extract_registry_coords(
+        _coord("https://badge.fury.io/rb/rails.svg"),
+    ) == {"rubygems": "rails"}
+    assert extract_registry_coords(
+        _coord("https://img.shields.io/conda/v/conda-forge/csbdeep.svg"),
+    ) == {"conda": ("conda-forge", "csbdeep")}
+
+
+def test_extract_coords_npm_link_and_image_scoped() -> None:
+    assert extract_registry_coords(
+        _coord("img", "https://www.npmjs.com/package/@scope/pkg"),
+    ) == {"npm": "@scope/pkg"}
+    assert extract_registry_coords(
+        _coord("https://img.shields.io/npm/v/lodash"),
+    ) == {"npm": "lodash"}
+    assert extract_registry_coords(
+        _coord("https://badge.fury.io/js/lodash"),
+    ) == {"npm": "lodash"}
+
+
+def test_extract_coords_conda_tuple_link_and_image() -> None:
+    assert extract_registry_coords(
+        _coord("img", "https://anaconda.org/conda-forge/csbdeep"),
+    ) == {"conda": ("conda-forge", "csbdeep")}
+    assert extract_registry_coords(
+        _coord("https://img.shields.io/conda/v/bioconda/mypkg"),
+    ) == {"conda": ("bioconda", "mypkg")}
+    # Anaconda badge image with /badges/ suffix — channel+name only.
+    assert extract_registry_coords(
+        _coord("https://anaconda.org/conda-forge/csbdeep/badges/version.svg"),
+    ) == {"conda": ("conda-forge", "csbdeep")}
+
+
+def test_extract_coords_crates_link_and_image() -> None:
+    assert extract_registry_coords(
+        _coord("img", "https://crates.io/crates/serde"),
+    ) == {"crates": "serde"}
+    assert extract_registry_coords(
+        _coord("https://img.shields.io/crates/v/serde"),
+    ) == {"crates": "serde"}
+
+
+def test_extract_coords_rubygems_link_and_image() -> None:
+    assert extract_registry_coords(
+        _coord("img", "https://rubygems.org/gems/rails"),
+    ) == {"rubygems": "rails"}
+    assert extract_registry_coords(
+        _coord("https://img.shields.io/gem/v/rails"),
+    ) == {"rubygems": "rails"}
+    assert extract_registry_coords(
+        _coord("https://badge.fury.io/rb/rails"),
+    ) == {"rubygems": "rails"}
+
+
+def test_extract_coords_ci_badge_ignored() -> None:
+    badges = _coord(
+        "https://github.com/o/r/workflows/CI/badge.svg",
+        "https://github.com/o/r/actions",
+    )
+    assert extract_registry_coords(badges) == {}
+
+
+def test_extract_coords_first_match_per_ecosystem() -> None:
+    badges = [
+        {"label": "a", "image_url": "https://img.shields.io/pypi/v/first", "link_url": None},
+        {"label": "b", "image_url": "https://img.shields.io/pypi/v/second", "link_url": None},
+    ]
+    assert extract_registry_coords(badges)["pypi"] == "first"
+
+
+def test_extract_coords_url_decode() -> None:
+    assert extract_registry_coords(
+        _coord("img", "https://www.npmjs.com/package/%40scope%2Fpkg"),
+    ) == {"npm": "@scope/pkg"}
+
+
+def test_extract_coords_empty() -> None:
+    assert extract_registry_coords([]) == {}
+    assert extract_registry_coords(None) == {}
+
+
+# ---------------------------------------------------------------------------
+# parse_crates_name
+# ---------------------------------------------------------------------------
+
+
+def test_parse_crates_name_valid() -> None:
+    aux = {"cargo.toml": '[package]\nname = "my-crate"\nversion = "0.1.0"\n'}
+    assert parse_crates_name(aux) == "my-crate"
+
+
+def test_parse_crates_name_case_insensitive_filename() -> None:
+    aux = {"Cargo.toml": '[package]\nname = "my-crate"\n'}
+    assert parse_crates_name(aux) == "my-crate"
+
+
+def test_parse_crates_name_missing() -> None:
+    assert parse_crates_name({"package.json": "{}"}) is None
+    assert parse_crates_name({}) is None
+    assert parse_crates_name(None) is None
+
+
+def test_parse_crates_name_malformed() -> None:
+    assert parse_crates_name({"cargo.toml": "[package\nname = broken"}) is None
+
+
+def test_parse_crates_name_no_name() -> None:
+    assert parse_crates_name({"cargo.toml": '[package]\nversion = "0.1.0"\n'}) is None
+
+
+# ---------------------------------------------------------------------------
+# PackageRegistryProvider — conda / crates / rubygems via fake session
+# ---------------------------------------------------------------------------
+
+_CONDA_JSON = {
+    "name": "csbdeep",
+    "latest_version": "0.7.4",
+    "versions": ["0.6.0", "0.7.0", "0.7.4"],
+    "dev_url": "https://github.com/CSBDeep/CSBDeep",
+    "source_git_url": "https://github.com/other/mirror",
+    "html_url": "https://anaconda.org/conda-forge/csbdeep",
+    "files": [
+        {"upload_time": "2023-01-01T00:00:00"},
+        {"upload_time": "2023-06-01T00:00:00"},
+    ],
+}
+
+_CRATES_JSON = {
+    "crate": {
+        "name": "serde",
+        "max_stable_version": "1.0.197",
+        "newest_version": "1.0.198-beta",
+        "repository": "https://github.com/serde-rs/serde",
+        "updated_at": "2024-03-01T10:00:00Z",
+    },
+    "versions": [
+        {"num": "1.0.197"},
+        {"num": "1.0.196"},
+    ],
+}
+
+_RUBYGEMS_JSON = {
+    "name": "rails",
+    "version": "7.1.0",
+    "source_code_uri": "https://github.com/rails/rails",
+    "homepage_uri": "https://rubyonrails.org",
+}
+
+_RUBYGEMS_VERSIONS_JSON = [
+    {"number": "7.1.0", "created_at": "2024-01-01T00:00:00.000Z"},
+    {"number": "7.0.0", "created_at": "2023-01-01T00:00:00.000Z"},
+]
+
+
+def test_provider_get_conda_package_thin_dict() -> None:
+    session = FakeSession({
+        "https://api.anaconda.org/package/conda-forge/csbdeep": _FakeResponse(
+            200, _CONDA_JSON,
+        ),
+    })
+    pkg = PackageRegistryProvider(session=session).get_conda_package(
+        "conda-forge", "csbdeep",
+    )
+    assert pkg is not None
+    assert pkg["name"] == "csbdeep"
+    assert pkg["latest_version"] == "0.7.4"
+    assert pkg["versions"] == ["0.6.0", "0.7.0", "0.7.4"]
+    assert pkg["repository_url"] == "https://github.com/CSBDeep/CSBDeep"
+    assert pkg["registry_url"] == "https://anaconda.org/conda-forge/csbdeep"
+    assert pkg["channel"] == "conda-forge"
+    assert pkg["latest_release_date"] == "2023-06-01T00:00:00"
+
+
+def test_provider_get_conda_package_404_returns_none() -> None:
+    session = FakeSession({})  # everything 404s
+    assert PackageRegistryProvider(session=session).get_conda_package(
+        "conda-forge", "missing",
+    ) is None
+
+
+def test_provider_get_crates_package_thin_dict() -> None:
+    session = FakeSession({
+        "https://crates.io/api/v1/crates/serde": _FakeResponse(200, _CRATES_JSON),
+    })
+    pkg = PackageRegistryProvider(session=session).get_crates_package("serde")
+    assert pkg is not None
+    assert pkg["name"] == "serde"
+    # max_stable_version wins over newest_version (which is a beta).
+    assert pkg["latest_version"] == "1.0.197"
+    assert pkg["versions"] == ["1.0.197", "1.0.196"]
+    assert pkg["repository_url"] == "https://github.com/serde-rs/serde"
+    assert pkg["latest_release_date"] == "2024-03-01T10:00:00Z"
+    assert pkg["registry_url"] == "https://crates.io/crates/serde"
+
+
+def test_provider_get_crates_user_agent_header_present() -> None:
+    session = FakeSession({
+        "https://crates.io/api/v1/crates/serde": _FakeResponse(200, _CRATES_JSON),
+    })
+    PackageRegistryProvider(session=session).get_crates_package("serde")
+    assert session.headers_seen
+    for headers in session.headers_seen:
+        assert headers is not None
+        assert "User-Agent" in headers
+        assert headers["User-Agent"].strip()
+
+
+def test_provider_get_crates_package_404_returns_none() -> None:
+    session = FakeSession({})
+    assert PackageRegistryProvider(session=session).get_crates_package(
+        "nope",
+    ) is None
+
+
+def test_provider_get_rubygems_package_thin_dict() -> None:
+    session = FakeSession({
+        "https://rubygems.org/api/v1/gems/rails.json": _FakeResponse(
+            200, _RUBYGEMS_JSON,
+        ),
+        "https://rubygems.org/api/v1/versions/rails.json": _FakeResponse(
+            200, _RUBYGEMS_VERSIONS_JSON,
+        ),
+    })
+    pkg = PackageRegistryProvider(session=session).get_rubygems_package("rails")
+    assert pkg is not None
+    assert pkg["name"] == "rails"
+    assert pkg["latest_version"] == "7.1.0"
+    assert pkg["versions"] == ["7.1.0", "7.0.0"]
+    assert pkg["repository_url"] == "https://github.com/rails/rails"
+    assert pkg["registry_url"] == "https://rubygems.org/gems/rails"
+    assert pkg["latest_release_date"] == "2024-01-01T00:00:00.000Z"
+
+
+def test_provider_get_rubygems_versions_failure_tolerated() -> None:
+    # Primary gem JSON succeeds, versions endpoint 404s → versions None,
+    # but the package is still returned.
+    session = FakeSession({
+        "https://rubygems.org/api/v1/gems/rails.json": _FakeResponse(
+            200, _RUBYGEMS_JSON,
+        ),
+    })
+    pkg = PackageRegistryProvider(session=session).get_rubygems_package("rails")
+    assert pkg is not None
+    assert pkg["versions"] is None
+    assert pkg["latest_release_date"] is None
+    assert pkg["latest_version"] == "7.1.0"
+
+
+def test_provider_get_rubygems_homepage_fallback() -> None:
+    payload = {
+        "name": "homeonly",
+        "version": "1.0.0",
+        "homepage_uri": "https://github.com/acme/homeonly",
+    }
+    session = FakeSession({
+        "https://rubygems.org/api/v1/gems/homeonly.json": _FakeResponse(
+            200, payload,
+        ),
+    })
+    pkg = PackageRegistryProvider(session=session).get_rubygems_package(
+        "homeonly",
+    )
+    assert pkg is not None
+    assert pkg["repository_url"] == "https://github.com/acme/homeonly"
+
+
+def test_provider_get_rubygems_404_returns_none() -> None:
+    session = FakeSession({})
+    assert PackageRegistryProvider(session=session).get_rubygems_package(
+        "nope",
+    ) is None
+
+
+# ---------------------------------------------------------------------------
+# context_gather — badges + multi-registry discovery + link policy
+# ---------------------------------------------------------------------------
+
+# CSBDeep-style README: PyPI + conda badges + a CI badge.
+_CSBDEEP_README = (
+    "# CSBDeep\n"
+    "[![PyPI version]"
+    "(https://img.shields.io/pypi/v/csbdeep)]"
+    "(https://pypi.org/project/csbdeep)\n"
+    "[![Anaconda-Server Badge]"
+    "(https://anaconda.org/conda-forge/csbdeep/badges/version.svg)]"
+    "(https://anaconda.org/conda-forge/csbdeep)\n"
+    "[![CI]"
+    "(https://github.com/CSBDeep/CSBDeep/workflows/CI/badge.svg)]"
+    "(https://github.com/CSBDeep/CSBDeep/actions)\n"
+)
+
+
+def _run_enrich(
+    *,
+    full_name: str,
+    aux_files: dict[str, str],
+    provider: Any,
+    readme: str | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    metadata: dict[str, Any] = {}
+    warnings: list[str] = []
+    providers = ProviderSet(github=MockGitHubProvider(), package_registry=provider)
+    _enrich_repository_metadata_with_registry_packages(
+        full_name=full_name,
+        aux_files=aux_files,
+        repository_metadata=metadata,
+        providers=providers,
+        warnings=warnings,
+        readme=readme,
+    )
+    return metadata, warnings
+
+
+def test_context_gather_badges_populated() -> None:
+    provider = FakeMultiRegistryProvider()
+    metadata, _ = _run_enrich(
+        full_name="CSBDeep/CSBDeep",
+        aux_files={},
+        provider=provider,
+        readme=_CSBDEEP_README,
+    )
+    assert isinstance(metadata["badges"], list)
+    assert len(metadata["badges"]) == _CSBDEEP_BADGE_COUNT
+    labels = [b["label"] for b in metadata["badges"]]
+    assert "PyPI version" in labels
+
+
+def test_context_gather_conda_verified_via_dev_url() -> None:
+    provider = FakeMultiRegistryProvider(
+        conda={
+            "name": "csbdeep",
+            "channel": "conda-forge",
+            "repository_url": "https://github.com/CSBDeep/CSBDeep",
+        },
+    )
+    metadata, _ = _run_enrich(
+        full_name="CSBDeep/CSBDeep",
+        aux_files={},
+        provider=provider,
+        readme=_CSBDEEP_README,
+    )
+    assert provider.conda_calls == [("conda-forge", "csbdeep")]
+    assert metadata["conda_package"]["link"] == "verified"
+    assert metadata["conda_package"]["channel"] == "conda-forge"
+
+
+def test_context_gather_conda_mismatch_dropped() -> None:
+    provider = FakeMultiRegistryProvider(
+        conda={
+            "name": "csbdeep",
+            "channel": "conda-forge",
+            "repository_url": "https://github.com/someone-else/other",
+        },
+    )
+    metadata, _ = _run_enrich(
+        full_name="CSBDeep/CSBDeep",
+        aux_files={},
+        provider=provider,
+        readme=_CSBDEEP_README,
+    )
+    assert "conda_package" not in metadata
+
+
+def test_context_gather_crates_from_cargo_toml() -> None:
+    provider = FakeMultiRegistryProvider(
+        crates={
+            "name": "my-crate",
+            "repository_url": "https://github.com/acme/my-crate",
+        },
+    )
+    metadata, _ = _run_enrich(
+        full_name="acme/my-crate",
+        aux_files={"cargo.toml": '[package]\nname = "my-crate"\n'},
+        provider=provider,
+        readme=None,
+    )
+    assert provider.crates_calls == ["my-crate"]
+    assert metadata["crates_package"]["link"] == "verified"
+
+
+def test_context_gather_crates_from_badge_when_no_manifest() -> None:
+    provider = FakeMultiRegistryProvider(
+        crates={"name": "serde", "repository_url": None},
+    )
+    readme = "[![crate](https://img.shields.io/crates/v/serde)](https://crates.io/crates/serde)"
+    metadata, _ = _run_enrich(
+        full_name="serde-rs/serde",
+        aux_files={},
+        provider=provider,
+        readme=readme,
+    )
+    assert provider.crates_calls == ["serde"]
+    assert metadata["crates_package"]["link"] == "name_only"
+
+
+def test_context_gather_rubygems_from_badge() -> None:
+    provider = FakeMultiRegistryProvider(
+        rubygems={
+            "name": "rails",
+            "repository_url": "https://github.com/rails/rails",
+        },
+    )
+    readme = "[![gem](https://img.shields.io/gem/v/rails)](https://rubygems.org/gems/rails)"
+    metadata, _ = _run_enrich(
+        full_name="rails/rails",
+        aux_files={},
+        provider=provider,
+        readme=readme,
+    )
+    assert provider.rubygems_calls == ["rails"]
+    assert metadata["rubygems_package"]["link"] == "verified"
+
+
+def test_context_gather_npm_falls_back_to_badge_coords() -> None:
+    # No package.json manifest → npm name comes from the badge.
+    provider = FakeMultiRegistryProvider(
+        npm={"name": "lodash", "repository_url": None},
+    )
+    readme = "[![npm](https://img.shields.io/npm/v/lodash)](https://www.npmjs.com/package/lodash)"
+    metadata, _ = _run_enrich(
+        full_name="lodash/lodash",
+        aux_files={},
+        provider=provider,
+        readme=readme,
+    )
+    assert provider.npm_calls == ["lodash"]
+    assert metadata["npm_package"]["link"] == "name_only"
+
+
+def test_context_gather_badges_parsed_without_provider() -> None:
+    metadata: dict[str, Any] = {}
+    warnings: list[str] = []
+    providers = ProviderSet(github=MockGitHubProvider())  # no package_registry
+    _enrich_repository_metadata_with_registry_packages(
+        full_name="CSBDeep/CSBDeep",
+        aux_files={},
+        repository_metadata=metadata,
+        providers=providers,
+        warnings=warnings,
+        readme=_CSBDEEP_README,
+    )
+    # Badges still parsed even though registry lookups are skipped.
+    assert len(metadata["badges"]) == _CSBDEEP_BADGE_COUNT
+    assert "conda_package" not in metadata
+    assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# repository_agent — flat scalar emission
+# ---------------------------------------------------------------------------
+
+
+def _make_repo_context(
+    *,
+    badges: list[dict[str, Any]] | None = None,
+    conda_package: dict[str, Any] | None = None,
+    crates_package: dict[str, Any] | None = None,
+    rubygems_package: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "name": "tool",
+        "full_name": "acme/tool",
+        "owner": {"login": "acme", "type": "Organization"},
+        "created_at": "2023-01-01T00:00:00Z",
+        "license": {"spdx_id": "MIT"},
+        "fork": False,
+        "source": {"full_name": None},
+    }
+    if badges is not None:
+        metadata["badges"] = badges
+    if conda_package is not None:
+        metadata["conda_package"] = conda_package
+    if crates_package is not None:
+        metadata["crates_package"] = crates_package
+    if rubygems_package is not None:
+        metadata["rubygems_package"] = rubygems_package
+    return {
+        "full_name": "acme/tool",
+        "metadata": metadata,
+        "readme_content": "",
+        "contributors": [{"login": "alice"}],
+        "languages": {"Python": 1},
+        "aux_files": {},
+    }
+
+
+def test_repository_agent_emits_badges_and_multi_registry() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+    badges = [
+        {"label": "PyPI", "image_url": "https://img.shields.io/pypi/v/x", "link_url": None},
+        {"label": "conda", "image_url": "https://anaconda.org/conda-forge/x/badges/v.svg", "link_url": None},
+    ]
+    conda = {
+        "name": "csbdeep",
+        "channel": "conda-forge",
+        "latest_version": "0.7.4",
+        "versions": ["0.7.0", "0.7.4"],
+        "latest_release_date": "2023-06-01T00:00:00",
+        "registry_url": "https://anaconda.org/conda-forge/csbdeep",
+        "link": "verified",
+    }
+    crates = {
+        "name": "serde",
+        "latest_version": "1.0.197",
+        "versions": ["1.0.196", "1.0.197"],
+        "latest_release_date": "2024-03-01T10:00:00Z",
+        "registry_url": "https://crates.io/crates/serde",
+        "link": "verified",
+    }
+    rubygems = {
+        "name": "rails",
+        "latest_version": "7.1.0",
+        "versions": ["7.0.0", "7.1.0"],
+        "latest_release_date": "2024-01-01T00:00:00Z",
+        "registry_url": "https://rubygems.org/gems/rails",
+        "link": "name_only",
+    }
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_repo_context(
+                    badges=badges,
+                    conda_package=conda,
+                    crates_package=crates,
+                    rubygems_package=rubygems,
+                ),
+            },
+            providers,
+        ),
+    )
+    raw = result.raw_output
+    assert raw["_badges"] == badges
+    assert raw["_badge_count"] == _AGENT_BADGE_COUNT
+    assert raw["_conda_package"] == "csbdeep"
+    assert raw["_conda_latest_version"] == "0.7.4"
+    assert raw["_conda_channel"] == "conda-forge"
+    assert raw["_conda_link"] == "verified"
+    assert raw["_crates_package"] == "serde"
+    assert raw["_crates_latest_version"] == "1.0.197"
+    assert raw["_crates_link"] == "verified"
+    assert raw["_rubygems_package"] == "rails"
+    assert raw["_rubygems_latest_version"] == "7.1.0"
+    assert raw["_rubygems_link"] == "name_only"
+
+
+def test_repository_agent_multi_registry_all_none_when_absent() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_repo_context(),
+            },
+            providers,
+        ),
+    )
+    raw = result.raw_output
+    assert raw["_badges"] is None
+    assert raw["_badge_count"] is None
+    assert raw["_conda_channel"] is None
+    for prefix in ("_conda_", "_crates_", "_rubygems_"):
+        for suffix in (
+            "package",
+            "latest_version",
+            "versions",
+            "latest_release_date",
+            "registry_url",
+            "link",
+        ):
+            assert raw[prefix + suffix] is None, prefix + suffix

--- a/tests/v2/test_npm_pypi_packages.py
+++ b/tests/v2/test_npm_pypi_packages.py
@@ -56,7 +56,12 @@ class FakeSession:
         self._routes = routes
         self.requested: list[str] = []
 
-    def get(self, url: str, timeout: float | None = None) -> _FakeResponse:  # noqa: ARG002
+    def get(  # noqa: ARG002
+        self,
+        url: str,
+        timeout: float | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> _FakeResponse:
         self.requested.append(url)
         return self._routes.get(url, _FakeResponse(404, None))
 
@@ -351,7 +356,12 @@ def test_provider_get_pypi_home_page_fallback() -> None:
 
 def test_provider_transport_error_returns_none() -> None:
     class _BoomSession:
-        def get(self, url: str, timeout: float | None = None) -> Any:  # noqa: ARG002
+        def get(  # noqa: ARG002
+            self,
+            url: str,
+            timeout: float | None = None,
+            headers: dict[str, str] | None = None,
+        ) -> Any:
             message = "boom"
             raise ConnectionError(message)
 


### PR DESCRIPTION
## Summary
Two things, driven by the observation that badges are often the only in-repo signal for some registries (conda recipes live in a separate feedstock, not the repo):

1. **Parse README badges** → `gme-internal:badges` (raw list of `{label, image_url, link_url}`) + `gme-internal:badge_count`.
2. **Discover packages on conda/Anaconda, crates.io, and RubyGems** from those badges (and the `cargo.toml` manifest), emitted as flat `gme-internal:*` scalars — extending the manifest-linked npm/PyPI discovery (#138).

## How
- `parse_badges` handles `[![alt](img)](link)` and plain `![alt](img)` (dedup, cap 100).
- `extract_registry_coords` recognises registry coordinates from the badge link (preferred) or image (`badge.fury.io`, `img.shields.io`, `anaconda.org`, `crates.io`, `rubygems.org`, `pypi.org`, `npmjs.com`); conda yields `(channel, name)`; CI/workflow badges ignored.
- New provider methods `get_conda_package` (`api.anaconda.org`), `get_crates_package` (`crates.io/api/v1`), `get_rubygems_package` (`rubygems.org/api/v1` + versions endpoint). All best-effort, cached, with a descriptive **User-Agent** (crates.io requires one).
- `context_gather` discovers conda (badge), crates (`cargo.toml` else badge), rubygems (badge), and uses badge links to **strengthen npm/PyPI** when the manifest name is missing.
- Same **link policy** as npm/PyPI: registry's `repository_url` back-references the repo → `verified`; mismatch → **dropped**; absent → `name_only` (`repo_url_matches`, which still rejects github.com lookalike subdomains).

## Emitted triples (`?include_internal_fields=true`)
`gme-internal:badges`, `gme-internal:badge_count`, and `gme-internal:{conda,crates,rubygems}_{package,latest_version,versions,latest_release_date,registry_url,link}` + `gme-internal:conda_channel`.

## Review fix
Image-only badges like `badge.fury.io/py/csbdeep.svg` were leaking the `.svg` into the package name (your CSBDeep example dodged it because its PyPI/conda badges have clean `link_url`s, but image-only badges are common). Now stripped, with a regression test.

## Tests
`tests/v2/test_badges_multi_registry.py` — badge parsing, coord extraction (link + image, ext-strip, CI-ignore, conda tuple), `parse_crates_name`, each provider via a fake session (incl. crates User-Agent assertion, 404→None), `context_gather` with your exact CSBDeep badge block (badges populated, conda verified via `dev_url`, mismatch dropped, crates from `cargo.toml`), agent scalars + all-None when absent. No real network. Full `tests/v2/` green: **1566 passed, 1 skipped**. New files ruff-clean.

## Scope
Adds conda + crates + RubyGems (your pick). Maven/NuGet/Go not included.