### PR TITLE
feat(v2): Go module discovery (gme-internal:go_*) + Maven/NuGet/Go plan

### DIFF
--- a/docs/superpowers/specs/2026-06-07-maven-nuget-go-plan.md
+++ b/docs/superpowers/specs/2026-06-07-maven-nuget-go-plan.md
@@ -1,0 +1,149 @@
+# Plan — Maven, NuGet, and Go module discovery
+
+**Date:** 2026-06-07
+**Status:** plan (not yet implemented)
+**Extends:** the package-discovery machinery shipped in #138 (npm/PyPI) and #139
+(conda/crates/RubyGems + badges).
+
+## Reuse, don't reinvent
+All three slot into the **existing pattern** with no new architecture:
+
+- **Provider** — add `get_maven_package` / `get_nuget_package` / `get_go_module`
+  to `PackageRegistryProvider` (injectable `session`, `ProviderCache`,
+  best-effort None, descriptive `User-Agent`). Same thin-dict shape as the others
+  (`name, latest_version, versions, latest_release_date, repository_url,
+  registry_url` — Maven adds `group_id`/`artifact_id`).
+- **Discovery helpers** — `parse_maven_coords(aux_files)`, `parse_go_module(aux_files)`,
+  and NuGet via badges/manifest, in `_repo_signals.py` (pure).
+- **Linking** — same `repo_url_matches` + the verified / mismatch-DROP / name_only
+  policy in `context_gather`.
+- **Emission** — splat `summarize_registry_package(...)` with `_maven_` / `_nuget_`
+  / `_go_` prefixes in `repository_agent.py` → `gme-internal:{maven,nuget,go}_*`.
+- **Tests** — `tests/v2/` with a fake session (no real network), mirroring
+  `test_badges_multi_registry.py`.
+
+The only genuinely new work per ecosystem is (a) the discovery source, (b) the
+registry's API + field mapping, and (c) the back-reference verification. Below,
+per ecosystem, ranked by effort (Go easiest → NuGet hardest).
+
+---
+
+## 1. Go modules — LOW effort, cleanest verification
+
+**Discovery.** `go.mod` is **already fetched** into `aux_files` (the github
+provider's curated manifest list includes `go.mod`). Its first line is
+`module <module-path>` — e.g. `module github.com/CSBDeep/CSBDeep` or
+`github.com/owner/repo/v2`. `parse_go_module(aux_files)` returns that path.
+
+**Registry — the Go module proxy** (`proxy.golang.org`, no auth):
+- versions: `GET https://proxy.golang.org/<esc-module>/@v/list` → newline-separated
+  version list.
+- latest: `GET https://proxy.golang.org/<esc-module>/@latest` → `{"Version","Time"}`.
+- registry_url (human): `https://pkg.go.dev/<module>`.
+- **Case escaping gotcha:** the proxy lowercases capitals via `!` escaping —
+  `github.com/BurntSushi/toml` → `github.com/!burnt!sushi/toml`. Implement
+  `_go_escape(path)` (each uppercase `X` → `!x`).
+
+**Verification — trivial and strong.** The module path *is* the repo for the
+GitHub case: verify `module_path == github.com/<full_name>` (optionally a
+trailing `/vN` major-version suffix). No second fetch needed → always `verified`
+for github-hosted modules; vanity-import domains (custom host that redirects to a
+repo via `go-import` meta tags) are out of scope for v1 → `name_only` or skip.
+
+**Emits:** `gme-internal:go_module`, `go_latest_version`, `go_versions`,
+`go_latest_release_date`, `go_registry_url`, `go_link`.
+
+**Effort:** ~half a day. No auth, manifest already available, self-verifying.
+
+---
+
+## 2. Maven (Java/Kotlin/Scala) — MEDIUM effort
+
+**Discovery.** `pom.xml` is **already fetched** into `aux_files`.
+`parse_maven_coords(aux_files)` parses it (stdlib `xml.etree.ElementTree`,
+namespace-aware) → `(groupId, artifactId)`. Notes: `groupId` may be inherited
+from `<parent>` (fall back to `<parent><groupId>`); Gradle projects
+(`build.gradle`) usually don't carry the coordinates in-repo (group in
+`build.gradle`, name in `settings.gradle`) → Gradle discovery is best-effort /
+badge-driven (`img.shields.io/maven-central/v/<group>/<artifact>`).
+
+**Registry — Maven Central search** (`search.maven.org`, no auth):
+- existence + latest: `GET https://search.maven.org/solrsearch/select?q=g:"<group>"+AND+a:"<artifact>"&rows=1&wt=json`
+  → `response.docs[0].latestVersion` + `timestamp` (ms epoch).
+- versions: same with `&core=gav&rows=200` → one doc per version (`v` field,
+  `timestamp` per version).
+- registry_url: `https://central.sonatype.com/artifact/<group>/<artifact>`.
+
+**Verification — weaker; two options:**
+- *(a, recommended v1)* The coordinates come from the **repo's own `pom.xml`**, so
+  existence-on-Central + coordinates-from-our-repo is already a reasonably strong
+  link → store `verified` when the repo pom yielded the coords, `name_only` when
+  coords came from a badge.
+- *(b, stronger, +1 fetch)* Fetch the released POM
+  `https://repo1.maven.org/maven2/<group/path>/<artifact>/<ver>/<artifact>-<ver>.pom`
+  and parse `<scm><url>` / `<url>`, then `repo_url_matches`. Adds latency; defer.
+
+**Emits:** `gme-internal:maven_package` (`group:artifact`), `maven_group_id`,
+`maven_artifact_id`, `maven_latest_version`, `maven_versions`,
+`maven_latest_release_date`, `maven_registry_url`, `maven_link`.
+
+**Effort:** ~1 day (XML parsing + parent-groupId fallback + Solr response shape).
+
+---
+
+## 3. NuGet (.NET) — MEDIUM/HIGH effort (discovery is the hard part)
+
+**Discovery.** NuGet package id lives in `*.csproj` `<PackageId>` (or defaults to
+the assembly name), `*.nuspec` `<id>`, or `Directory.Build.props` — **none are in
+the fetched `aux_files` curated list, and they're globs**. Options:
+- *(a, recommended v1)* **badge-driven** — `extract_registry_coords` already runs;
+  add NuGet patterns (link `nuget.org/packages/<id>`,
+  image `img.shields.io/nuget/v/<id>` | `img.shields.io/nuget/vpre/<id>`). Most
+  .NET READMEs carry a NuGet badge. Zero manifest-fetch changes.
+- *(b, later)* extend the github provider's aux-file fetch to grab the first
+  `*.csproj`/`*.nuspec` (needs a glob-list step, since the filename is unknown) and
+  parse `<PackageId>`/`<id>`. More plumbing; do only if badge coverage proves thin.
+
+**Registry — NuGet v3** (`api.nuget.org`, no auth):
+- versions: `GET https://api.nuget.org/v3-flatcontainer/<id-lower>/index.json`
+  → `{"versions":[...]}` (latest = last non-prerelease).
+- metadata + repo/project URL + dates:
+  `GET https://api.nuget.org/v3/registration5-gz-semver2/<id-lower>/index.json`
+  (gzip; `catalogEntry.projectUrl`, `.repository`, `.published`), or the search
+  endpoint `https://azuresearch-usnc.nuget.org/query?q=packageid:<id>` →
+  `projectUrl`.
+- registry_url: `https://www.nuget.org/packages/<id>`.
+
+**Verification.** `catalogEntry.repository.url` (when the package opted into
+Source Link / repository metadata) or `projectUrl` → `repo_url_matches`. Many
+packages omit repository metadata → `name_only` fallback common.
+
+**Emits:** `gme-internal:nuget_package`, `nuget_latest_version`,
+`nuget_versions`, `nuget_latest_release_date`, `nuget_registry_url`, `nuget_link`.
+
+**Effort:** ~1–1.5 days (gzip registration handling + the manifest-vs-badge
+discovery decision + verification gaps).
+
+---
+
+## Suggested phasing
+1. **Go** first (fast win, manifest present, self-verifying).
+2. **Maven** (manifest present; medium).
+3. **NuGet** (badge-driven v1; revisit manifest fetch if coverage is thin).
+
+Each is an independent PR following the #138/#139 shape: provider method + pure
+helper(s) + context_gather wiring + `repository_agent` splat + fake-session
+tests, gated through the full `tests/v2/` suite. No new dependencies (stdlib
+`xml.etree`, `gzip`, `json`).
+
+## Cross-cutting notes
+- **Badge coords already generalise.** `extract_registry_coords` is the natural
+  home for `maven-central`, `nuget`, and (rarely) Go badges — add the patterns
+  there so badge-only repos are covered uniformly.
+- **`repo_url_matches` is github-only today.** Go/Maven/NuGet back-refs are
+  github URLs in the common case, so it applies as-is; if we later want GitLab
+  back-refs, generalise the host check then.
+- **Rate/UA.** All three public APIs are unauthenticated; keep the descriptive
+  `User-Agent` and the best-effort None-on-failure contract. Maven Central Solr
+  and the NuGet search endpoint are the most rate-sensitive — the existing
+  `ProviderCache` covers re-extracts.

--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -551,6 +551,28 @@ def parse_crates_name(aux_files: Any) -> str | None:
     return _name_from_table(data.get("package"))
 
 
+# The `module` directive in a go.mod: `module github.com/owner/repo` (an
+# inline `// comment` may follow). We take the first such directive.
+_GO_MODULE_RE = re.compile(r"^\s*module\s+(?P<path>\S+)", re.MULTILINE)
+
+
+def parse_go_module(aux_files: Any) -> str | None:
+    """Extract the module path from a repo's ``go.mod`` ``module`` directive.
+
+    Returns the module path (e.g. ``github.com/owner/repo`` or
+    ``github.com/owner/repo/v2``), or None when ``go.mod`` is missing or has
+    no ``module`` line. A trailing inline ``// comment`` is stripped.
+    """
+    content = _aux_file_lookup(aux_files, "go.mod")
+    if content is None:
+        return None
+    m = _GO_MODULE_RE.search(content)
+    if not m:
+        return None
+    path = m.group("path").strip().strip('"')
+    return path or None
+
+
 # ---------------------------------------------------------------------------
 # npm / PyPI registry package discovery — manifest name parsing + back-ref
 # ---------------------------------------------------------------------------

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -613,6 +613,17 @@ class RepositoryAgentV2:
                     repository.get("rubygems_package"),
                 ).items()
             },
+            # Go module — discovered by context_gather from `go.mod`'s
+            # `module` directive, queried against the Go module proxy, and
+            # verified by the module path back-referencing this repo. Same
+            # flat scalars as the others; `_go_package` carries the module
+            # path (e.g. github.com/owner/repo[/v2]).
+            **{
+                f"_go_{k}": v
+                for k, v in summarize_registry_package(
+                    repository.get("go_module"),
+                ).items()
+            },
             # CI presence — detected from the repo root listing by
             # context_gather and stored in repository_metadata["has_ci"].
             # None when the listing was unavailable.

--- a/src/v2/ingest/providers/package_registry_provider.py
+++ b/src/v2/ingest/providers/package_registry_provider.py
@@ -397,6 +397,64 @@ class PackageRegistryProvider:
             "registry_url": f"https://rubygems.org/gems/{pkg_name}",
         }
 
+    def get_go_module(self, module: str) -> dict[str, Any] | None:
+        """Fetch thin metadata for Go *module* from the module proxy.
+
+        GETs ``https://proxy.golang.org/<esc>/@latest`` (JSON ``{Version,Time}``)
+        and ``/@v/list`` (newline-separated versions). ``<esc>`` lowercases
+        capitals via ``!`` escaping (proxy requirement). ``repository_url`` is
+        derived from the module path for github-hosted modules so the
+        back-reference check works; non-github (vanity) paths yield None →
+        ``name_only``. Returns None when the proxy knows nothing about it.
+        """
+        if not isinstance(module, str) or not module.strip():
+            return None
+        module = module.strip()
+
+        def _fetch() -> dict[str, Any] | None:
+            return self._thin_go(module)
+
+        return self._cached(_fetch, method="get_go_module", name=module)
+
+    def _thin_go(self, module: str) -> dict[str, Any] | None:
+        escaped = _go_escape(module)
+        latest = self._get_json(
+            f"https://proxy.golang.org/{escaped}/@latest", subject=f"go:{module}",
+        )
+        latest_version = None
+        latest_release_date = None
+        if isinstance(latest, dict):
+            latest_version = _first_str(latest.get("Version"))
+            latest_release_date = _first_str(latest.get("Time"))
+
+        list_text = self._get_text(
+            f"https://proxy.golang.org/{escaped}/@v/list", subject=f"go-list:{module}",
+        )
+        versions: list[str] = []
+        if isinstance(list_text, str):
+            versions = sorted(
+                line.strip() for line in list_text.splitlines() if line.strip()
+            )
+            if len(versions) > _MAX_VERSIONS:
+                logger.info(
+                    "go module %s has %d versions; truncating to %d",
+                    module, len(versions), _MAX_VERSIONS,
+                )
+                versions = versions[:_MAX_VERSIONS]
+
+        if latest_version is None and not versions:
+            # Proxy has no record of this module.
+            return None
+
+        return {
+            "name": module,
+            "latest_version": latest_version,
+            "versions": versions or None,
+            "latest_release_date": latest_release_date,
+            "repository_url": _go_repository_url(module),
+            "registry_url": f"https://pkg.go.dev/{module}",
+        }
+
     # ------------------------------------------------------------------
     # shared helpers
     # ------------------------------------------------------------------
@@ -430,6 +488,26 @@ class PackageRegistryProvider:
             logger.info("package registry response not JSON: %s", subject)
             return None
 
+    def _get_text(self, url: str, *, subject: str) -> str | None:
+        """GET *url* and return the body as text, or None on failure.
+
+        For endpoints that return plain text rather than JSON (the Go module
+        proxy's ``@v/list``). Same best-effort contract as ``_get_json``.
+        """
+        try:
+            response = self._session.get(
+                url,
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+                headers={"User-Agent": _USER_AGENT},
+            )
+        except Exception:  # noqa: BLE001 — best-effort; never raise on transport error.
+            logger.info("package registry fetch failed: %s", subject)
+            return None
+        if getattr(response, "status_code", None) != _HTTP_OK:
+            return None
+        text = getattr(response, "text", None)
+        return text if isinstance(text, str) else None
+
     def _cached(
         self,
         factory: Any,
@@ -451,6 +529,36 @@ def _first_str(*candidates: Any) -> str | None:
         if isinstance(candidate, str) and candidate.strip():
             return candidate.strip()
     return None
+
+
+def _go_escape(module: str) -> str:
+    """Escape a Go module path for the proxy: each uppercase letter X → !x.
+
+    The Go module proxy lowercases capitals via ``!`` escaping to keep paths
+    case-insensitive on case-insensitive filesystems
+    (``github.com/BurntSushi/toml`` → ``github.com/!burnt!sushi/toml``).
+    """
+    return "".join(f"!{c.lower()}" if c.isupper() else c for c in module)
+
+
+def _go_repository_url(module: str) -> str | None:
+    """Derive the source repo URL from a github-hosted module path.
+
+    ``github.com/owner/repo[/v2][/sub]`` → ``https://github.com/owner/repo``.
+    Non-github (vanity-import) paths return None (no reliable repo mapping
+    without resolving go-import meta tags), so they fall back to ``name_only``.
+    """
+    lower = module.lower()
+    if not (lower == "github.com" or lower.startswith("github.com/")):
+        return None
+    segments = [s for s in module.split("/") if s]
+    if len(segments) < _GO_GITHUB_MIN_SEGMENTS:
+        return None
+    return f"https://{segments[0]}/{segments[1]}/{segments[2]}"
+
+
+# github.com + owner + repo
+_GO_GITHUB_MIN_SEGMENTS = 3
 
 
 def _max_str(values: Any) -> str | None:

--- a/src/v2/pipeline/stages/context_gather.py
+++ b/src/v2/pipeline/stages/context_gather.py
@@ -10,6 +10,7 @@ from src.v2.agents.rule_based._repo_signals import (
     extract_registry_coords,
     parse_badges,
     parse_crates_name,
+    parse_go_module,
     parse_npm_name,
     parse_pypi_name,
     repo_url_matches,
@@ -253,7 +254,7 @@ def _normalize_owned_repo_full_name(owner: str, repo: str) -> str:
     return f"{owner}/{repo}"
 
 
-def _enrich_repository_metadata_with_registry_packages(  # noqa: C901, PLR0913
+def _enrich_repository_metadata_with_registry_packages(  # noqa: C901, PLR0912, PLR0913, PLR0915
     *,
     full_name: str,
     aux_files: dict[str, Any] | None,
@@ -361,6 +362,16 @@ def _enrich_repository_metadata_with_registry_packages(  # noqa: C901, PLR0913
     except Exception as exc:  # noqa: BLE001
         warnings.append(
             f"RubyGems package lookup failed for {full_name}: {exc}",
+        )
+    try:
+        go_module = parse_go_module(aux_files)
+        if go_module and hasattr(registry, "get_go_module"):
+            _link_and_store(
+                registry.get_go_module(go_module), key="go_module",
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"Go module lookup failed for {full_name}: {exc}",
         )
 
 

--- a/tests/v2/test_go_module.py
+++ b/tests/v2/test_go_module.py
@@ -1,0 +1,283 @@
+"""Tests for Go module discovery (manifest-linked, via the module proxy).
+
+No real network — a fake session / fake provider is injected.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from src.v2.agents import ProviderSet, RepositoryAgentV2
+from src.v2.agents.rule_based._repo_signals import parse_go_module
+from src.v2.ingest.providers.mock_github import MockGitHubProvider
+from src.v2.ingest.providers.package_registry_provider import (
+    PackageRegistryProvider,
+    _go_escape,
+    _go_repository_url,
+)
+from src.v2.pipeline.stages.context_gather import (
+    _enrich_repository_metadata_with_registry_packages,
+)
+
+_EXPECTED_GO_VERSIONS = 3
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, *, json_payload: Any = None, text: str | None = None) -> None:
+        self.status_code = status_code
+        self._json = json_payload
+        self.text = text if text is not None else ""
+
+    def json(self) -> Any:
+        if isinstance(self._json, ValueError):
+            raise self._json
+        return self._json
+
+
+class _FakeSession:
+    def __init__(self, routes: dict[str, _FakeResp]) -> None:
+        self._routes = routes
+        self.requested: list[str] = []
+
+    def get(
+        self,
+        url: str,
+        timeout: float | None = None,  # noqa: ARG002
+        headers: dict[str, str] | None = None,  # noqa: ARG002
+    ) -> _FakeResp:
+        self.requested.append(url)
+        return self._routes.get(url, _FakeResp(404))
+
+
+def _go_session(module: str = "github.com/acme/tool") -> _FakeSession:
+    esc = _go_escape(module)
+    return _FakeSession({
+        f"https://proxy.golang.org/{esc}/@latest": _FakeResp(
+            200, json_payload={"Version": "v1.4.0", "Time": "2024-05-01T10:00:00Z"},
+        ),
+        f"https://proxy.golang.org/{esc}/@v/list": _FakeResp(
+            200, text="v1.2.0\nv1.3.0\nv1.4.0\n",
+        ),
+    })
+
+
+class _FakeGoProvider:
+    def __init__(self, result: dict[str, Any] | None) -> None:
+        self._result = result
+        self.calls: list[str] = []
+
+    def get_go_module(self, module: str) -> dict[str, Any] | None:
+        self.calls.append(module)
+        return dict(self._result) if isinstance(self._result, dict) else None
+
+
+# ---------------------------------------------------------------------------
+# parse_go_module
+# ---------------------------------------------------------------------------
+
+
+def test_parse_go_module_basic() -> None:
+    assert parse_go_module({"go.mod": "module github.com/acme/tool\n\ngo 1.22\n"}) == "github.com/acme/tool"
+
+
+def test_parse_go_module_with_inline_comment_and_major_version() -> None:
+    aux = {"go.mod": "module github.com/acme/tool/v2 // root module\n\ngo 1.22\n"}
+    assert parse_go_module(aux) == "github.com/acme/tool/v2"
+
+
+def test_parse_go_module_missing_returns_none() -> None:
+    assert parse_go_module({"package.json": "{}"}) is None
+    assert parse_go_module({}) is None
+    assert parse_go_module(None) is None
+
+
+def test_parse_go_module_no_module_directive_returns_none() -> None:
+    assert parse_go_module({"go.mod": "go 1.22\nrequire ()\n"}) is None
+
+
+# ---------------------------------------------------------------------------
+# _go_escape / _go_repository_url
+# ---------------------------------------------------------------------------
+
+
+def test_go_escape_lowercases_capitals() -> None:
+    assert _go_escape("github.com/BurntSushi/toml") == "github.com/!burnt!sushi/toml"
+    assert _go_escape("github.com/acme/tool") == "github.com/acme/tool"
+
+
+def test_go_repository_url_github_with_major_suffix() -> None:
+    assert _go_repository_url("github.com/acme/tool/v2") == "https://github.com/acme/tool"
+    assert _go_repository_url("github.com/acme/tool") == "https://github.com/acme/tool"
+
+
+def test_go_repository_url_vanity_returns_none() -> None:
+    assert _go_repository_url("gopkg.in/yaml.v3") is None
+    assert _go_repository_url("example.com/x/y") is None
+    assert _go_repository_url("github.com/acme") is None  # too few segments
+
+
+# ---------------------------------------------------------------------------
+# PackageRegistryProvider.get_go_module
+# ---------------------------------------------------------------------------
+
+
+def test_get_go_module_thin_dict() -> None:
+    provider = PackageRegistryProvider(session=_go_session())
+    pkg = provider.get_go_module("github.com/acme/tool")
+    assert pkg is not None
+    assert pkg["name"] == "github.com/acme/tool"
+    assert pkg["latest_version"] == "v1.4.0"
+    assert pkg["versions"] == ["v1.2.0", "v1.3.0", "v1.4.0"]
+    assert len(pkg["versions"]) == _EXPECTED_GO_VERSIONS
+    assert pkg["latest_release_date"] == "2024-05-01T10:00:00Z"
+    assert pkg["repository_url"] == "https://github.com/acme/tool"
+    assert pkg["registry_url"] == "https://pkg.go.dev/github.com/acme/tool"
+
+
+def test_get_go_module_unknown_returns_none() -> None:
+    # Empty session → both @latest and @v/list 404 → None.
+    provider = PackageRegistryProvider(session=_FakeSession({}))
+    assert provider.get_go_module("github.com/acme/tool") is None
+
+
+def test_get_go_module_vanity_repository_url_none() -> None:
+    module = "gopkg.in/yaml.v3"
+    esc = _go_escape(module)
+    session = _FakeSession({
+        f"https://proxy.golang.org/{esc}/@latest": _FakeResp(
+            200, json_payload={"Version": "v3.0.1", "Time": "2022-05-27T00:00:00Z"},
+        ),
+        f"https://proxy.golang.org/{esc}/@v/list": _FakeResp(200, text="v3.0.0\nv3.0.1\n"),
+    })
+    pkg = PackageRegistryProvider(session=session).get_go_module(module)
+    assert pkg is not None
+    assert pkg["repository_url"] is None  # vanity → name_only downstream
+
+
+# ---------------------------------------------------------------------------
+# context_gather link policy
+# ---------------------------------------------------------------------------
+
+
+def _enrich(full_name: str, aux_files: dict[str, str], provider: Any) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    providers = ProviderSet(github=MockGitHubProvider(), package_registry=provider)
+    _enrich_repository_metadata_with_registry_packages(
+        full_name=full_name,
+        aux_files=aux_files,
+        repository_metadata=metadata,
+        providers=providers,
+        warnings=[],
+        readme=None,
+    )
+    return metadata
+
+
+def test_context_gather_go_module_verified() -> None:
+    provider = _FakeGoProvider({
+        "name": "github.com/acme/tool",
+        "latest_version": "v1.4.0",
+        "repository_url": "https://github.com/acme/tool",
+    })
+    meta = _enrich("acme/tool", {"go.mod": "module github.com/acme/tool\n"}, provider)
+    assert provider.calls == ["github.com/acme/tool"]
+    assert meta["go_module"]["link"] == "verified"
+
+
+def test_context_gather_go_module_name_only_when_no_repo_url() -> None:
+    provider = _FakeGoProvider({"name": "example.com/acme/tool", "repository_url": None})
+    meta = _enrich("acme/tool", {"go.mod": "module example.com/acme/tool\n"}, provider)
+    assert meta["go_module"]["link"] == "name_only"
+
+
+def test_context_gather_go_module_mismatch_dropped() -> None:
+    provider = _FakeGoProvider({
+        "name": "github.com/other/repo",
+        "repository_url": "https://github.com/other/repo",
+    })
+    meta = _enrich("acme/tool", {"go.mod": "module github.com/other/repo\n"}, provider)
+    assert "go_module" not in meta  # back-ref points elsewhere → dropped
+
+
+def test_context_gather_no_gomod_no_lookup() -> None:
+    provider = _FakeGoProvider({"name": "x"})
+    meta = _enrich("acme/tool", {"package.json": "{}"}, provider)
+    assert provider.calls == []
+    assert "go_module" not in meta
+
+
+# ---------------------------------------------------------------------------
+# repository_agent emission
+# ---------------------------------------------------------------------------
+
+
+def _make_stub_context(*, go_module: dict[str, Any] | None) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "name": "tool",
+        "full_name": "acme/tool",
+        "owner": {"login": "acme", "type": "Organization"},
+        "created_at": "2023-01-01T00:00:00Z",
+        "license": {"spdx_id": "MIT"},
+        "fork": False,
+        "source": {"full_name": None},
+    }
+    if go_module is not None:
+        metadata["go_module"] = go_module
+    return {
+        "full_name": "acme/tool",
+        "metadata": metadata,
+        "readme_content": "",
+        "contributors": [{"login": "alice"}],
+        "languages": {"Go": 1},
+        "aux_files": {},
+    }
+
+
+def test_repository_agent_emits_go_scalars() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(go_module={
+                    "name": "github.com/acme/tool",
+                    "latest_version": "v1.4.0",
+                    "versions": ["v1.2.0", "v1.3.0", "v1.4.0"],
+                    "latest_release_date": "2024-05-01T10:00:00Z",
+                    "registry_url": "https://pkg.go.dev/github.com/acme/tool",
+                    "link": "verified",
+                }),
+            },
+            providers,
+        ),
+    )
+    raw = result.raw_output
+    assert raw["_go_package"] == "github.com/acme/tool"
+    assert raw["_go_latest_version"] == "v1.4.0"
+    assert raw["_go_versions"] == ["v1.2.0", "v1.3.0", "v1.4.0"]
+    assert raw["_go_registry_url"] == "https://pkg.go.dev/github.com/acme/tool"
+    assert raw["_go_link"] == "verified"
+
+
+def test_repository_agent_go_scalars_none_when_absent() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+    result = asyncio.run(
+        agent.run(
+            {
+                "full_name": "acme/tool",
+                "repository_context": _make_stub_context(go_module=None),
+            },
+            providers,
+        ),
+    )
+    raw = result.raw_output
+    assert raw["_go_package"] is None
+    assert raw["_go_latest_version"] is None
+    assert raw["_go_link"] is None


### PR DESCRIPTION
First of the three remaining ecosystems from the plan (`docs/superpowers/specs/2026-06-07-maven-nuget-go-plan.md`, added here). **Go is the cleanest**: `go.mod` is already fetched into `aux_files`, and the module path self-verifies against the repo.

## How it works
- **Discovery** — `parse_go_module(aux_files)` reads the `module` directive from `go.mod` (e.g. `github.com/owner/repo` / `…/v2`).
- **Registry** — `get_go_module(module)` queries the Go module proxy: `/@latest` (JSON `{Version, Time}`) + `/@v/list` (newline text — new `_get_text` helper). `_go_escape` lowercases capitals via `!`-escaping (proxy requirement: `BurntSushi` → `!burnt!sushi`).
- **Linking** — `_go_repository_url` derives the github source URL from the module path; the same verified / mismatch-DROP / name_only policy applies (module path back-references the repo). Vanity-import domains → `name_only`.

## Emitted triples (`?include_internal_fields=true`)
`gme-internal:go_package` (= the module path), `go_latest_version`, `go_versions`, `go_latest_release_date`, `go_registry_url` (`pkg.go.dev/<module>`), `go_link`.

## Verified live
Against `proxy.golang.org` (no real network in tests): `client_golang` v1.23.2 (54 versions), `spf13/cobra` v1.10.2, `BurntSushi/toml` v1.6.0 — all with correct repo-URL derivation + `!`-escaping.

## Tests
`tests/v2/test_go_module.py` (16): parse_go_module, `_go_escape`, repo-URL derivation incl. vanity→None, provider via fake session (text + JSON, unknown→None), context_gather link policy incl. mismatch-drop and no-go.mod, agent scalars + all-None. Full `tests/v2/` green: **1582 passed, 1 skipped**. Zero new ruff in modified files; new files clean.

## Next
Maven and NuGet as separate PRs per the plan (Maven: `pom.xml` already fetched; NuGet: badge-driven v1).