### PR TITLE
feat(v2): Maven Central artifact discovery (gme-internal:maven_*)

### DIFF
--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -20,6 +20,7 @@ import configparser
 import json
 import logging
 import re
+import xml.etree.ElementTree as ET
 from typing import Any
 from urllib.parse import unquote
 
@@ -483,6 +484,23 @@ def _match_rubygems(url: str) -> str | None:
     return _strip_badge_ext(m.group("name")) if m else None
 
 
+_MAVEN_SHIELDS_RE = re.compile(
+    r"img\.shields\.io/maven-central/v/(?P<group>[^/\s)?#]+)/(?P<artifact>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+_MAVEN_LINK_RE = re.compile(
+    r"central\.sonatype\.com/artifact/(?P<group>[^/\s)?#]+)/(?P<artifact>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+
+
+def _match_maven(url: str) -> tuple[str, str] | None:
+    m = _MAVEN_SHIELDS_RE.search(url) or _MAVEN_LINK_RE.search(url)
+    if m:
+        return (m.group("group"), _strip_badge_ext(m.group("artifact")))
+    return None
+
+
 # (ecosystem-key, matcher) pairs consulted for each badge URL.
 _COORD_MATCHERS: tuple[tuple[str, Any], ...] = (
     ("pypi", _match_pypi),
@@ -490,6 +508,7 @@ _COORD_MATCHERS: tuple[tuple[str, Any], ...] = (
     ("conda", _match_conda),
     ("crates", _match_crates),
     ("rubygems", _match_rubygems),
+    ("maven", _match_maven),
 )
 
 
@@ -571,6 +590,52 @@ def parse_go_module(aux_files: Any) -> str | None:
         return None
     path = m.group("path").strip().strip('"')
     return path or None
+
+
+def _pom_child_text(parent: ET.Element, local: str) -> str | None:
+    """Return the text of *parent*'s direct child with local name *local*
+    (namespace-agnostic — Maven POMs use a default namespace)."""
+    for el in parent:
+        if isinstance(el.tag, str) and el.tag.rsplit("}", maxsplit=1)[-1] == local:
+            text = (el.text or "").strip()
+            return text or None
+    return None
+
+
+def _pom_child(parent: ET.Element, local: str) -> ET.Element | None:
+    for el in parent:
+        if isinstance(el.tag, str) and el.tag.rsplit("}", maxsplit=1)[-1] == local:
+            return el
+    return None
+
+
+def parse_maven_coords(aux_files: Any) -> tuple[str, str] | None:
+    """Extract ``(groupId, artifactId)`` from a repo's ``pom.xml``.
+
+    ``artifactId`` is required; ``groupId`` falls back to the ``<parent>``
+    ``groupId`` when not declared on the project directly (Maven inheritance).
+    Returns None when ``pom.xml`` is missing, malformed, or lacks an
+    ``artifactId``. (Gradle projects rarely carry coordinates in-repo → use a
+    Maven-Central badge instead.)
+    """
+    content = _aux_file_lookup(aux_files, "pom.xml")
+    if content is None:
+        return None
+    try:
+        root = ET.fromstring(content)  # noqa: S314 — local manifest, not untrusted XML feed
+    except ET.ParseError:
+        return None
+    artifact = _pom_child_text(root, "artifactId")
+    if not artifact:
+        return None
+    group = _pom_child_text(root, "groupId")
+    if not group:
+        parent = _pom_child(root, "parent")
+        if parent is not None:
+            group = _pom_child_text(parent, "groupId")
+    if not group:
+        return None
+    return (group, artifact)
 
 
 # ---------------------------------------------------------------------------

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -624,6 +624,20 @@ class RepositoryAgentV2:
                     repository.get("go_module"),
                 ).items()
             },
+            # Maven Central artifact — discovered from `pom.xml`
+            # (`groupId:artifactId`) or a maven-central badge. `_maven_package`
+            # is the `group:artifact` coordinate; `_maven_group_id` /
+            # `_maven_artifact_id` carry the split coordinates.
+            **{
+                f"_maven_{k}": v
+                for k, v in summarize_registry_package(
+                    repository.get("maven_package"),
+                ).items()
+            },
+            "_maven_group_id": (repository.get("maven_package") or {}).get("group_id"),
+            "_maven_artifact_id": (
+                (repository.get("maven_package") or {}).get("artifact_id")
+            ),
             # CI presence — detected from the repo root listing by
             # context_gather and stored in repository_metadata["has_ci"].
             # None when the listing was unavailable.

--- a/src/v2/ingest/providers/package_registry_provider.py
+++ b/src/v2/ingest/providers/package_registry_provider.py
@@ -14,6 +14,7 @@ mirroring the github provider's release / container-image fetchers.
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import quote
 
@@ -455,6 +456,72 @@ class PackageRegistryProvider:
             "registry_url": f"https://pkg.go.dev/{module}",
         }
 
+    def get_maven_package(
+        self, group_id: str, artifact_id: str,
+    ) -> dict[str, Any] | None:
+        """Fetch thin metadata for a Maven Central artifact ``group:artifact``.
+
+        Uses the Maven Central Solr API: one query for ``latestVersion`` +
+        latest ``timestamp``, one ``core=gav`` query for the version list.
+        ``repository_url`` is left None — the Solr index does not expose the
+        POM ``<scm>``; the back-reference is established by ``context_gather``
+        from the repo's own ``pom.xml`` (see the link policy there).
+        """
+        if not (isinstance(group_id, str) and group_id.strip()):
+            return None
+        if not (isinstance(artifact_id, str) and artifact_id.strip()):
+            return None
+        group_id, artifact_id = group_id.strip(), artifact_id.strip()
+
+        def _fetch() -> dict[str, Any] | None:
+            base = "https://search.maven.org/solrsearch/select"
+            q = quote(f'g:"{group_id}" AND a:"{artifact_id}"', safe="")
+            subject = f"maven:{group_id}:{artifact_id}"
+            latest = self._get_json(
+                f"{base}?q={q}&rows=1&wt=json", subject=subject,
+            )
+            docs = _solr_docs(latest)
+            if not docs:
+                return None
+            head = docs[0]
+            versions_payload = self._get_json(
+                f"{base}?q={q}&core=gav&rows={_MAX_VERSIONS}&wt=json",
+                subject=f"{subject}:gav",
+            )
+            return self._thin_maven(
+                group_id, artifact_id, head, _solr_docs(versions_payload),
+            )
+
+        return self._cached(
+            _fetch, method="get_maven_package", name=f"{group_id}:{artifact_id}",
+        )
+
+    @staticmethod
+    def _thin_maven(
+        group_id: str,
+        artifact_id: str,
+        head: dict[str, Any],
+        version_docs: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        latest_version = _first_str(head.get("latestVersion"))
+        latest_release_date = _ms_to_iso(head.get("timestamp"))
+        versions = [
+            d["v"] for d in version_docs
+            if isinstance(d, dict) and isinstance(d.get("v"), str) and d["v"]
+        ]
+        return {
+            "name": f"{group_id}:{artifact_id}",
+            "group_id": group_id,
+            "artifact_id": artifact_id,
+            "latest_version": latest_version,
+            "versions": versions or None,
+            "latest_release_date": latest_release_date,
+            "repository_url": None,
+            "registry_url": (
+                f"https://central.sonatype.com/artifact/{group_id}/{artifact_id}"
+            ),
+        }
+
     # ------------------------------------------------------------------
     # shared helpers
     # ------------------------------------------------------------------
@@ -529,6 +596,28 @@ def _first_str(*candidates: Any) -> str | None:
         if isinstance(candidate, str) and candidate.strip():
             return candidate.strip()
     return None
+
+
+def _solr_docs(payload: Any) -> list[dict[str, Any]]:
+    """Return the ``response.docs`` list from a Maven Central Solr payload."""
+    if not isinstance(payload, dict):
+        return []
+    response = payload.get("response")
+    if not isinstance(response, dict):
+        return []
+    docs = response.get("docs")
+    return [d for d in docs if isinstance(d, dict)] if isinstance(docs, list) else []
+
+
+def _ms_to_iso(value: Any) -> str | None:
+    """Convert a millisecond epoch (Maven ``timestamp``) to an ISO 8601 UTC
+    string, or None when the value isn't a usable number."""
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    try:
+        return datetime.fromtimestamp(value / 1000, tz=timezone.utc).isoformat()
+    except (ValueError, OverflowError, OSError):
+        return None
 
 
 def _go_escape(module: str) -> str:

--- a/src/v2/pipeline/stages/context_gather.py
+++ b/src/v2/pipeline/stages/context_gather.py
@@ -11,6 +11,7 @@ from src.v2.agents.rule_based._repo_signals import (
     parse_badges,
     parse_crates_name,
     parse_go_module,
+    parse_maven_coords,
     parse_npm_name,
     parse_pypi_name,
     repo_url_matches,
@@ -372,6 +373,22 @@ def _enrich_repository_metadata_with_registry_packages(  # noqa: C901, PLR0912, 
     except Exception as exc:  # noqa: BLE001
         warnings.append(
             f"Go module lookup failed for {full_name}: {exc}",
+        )
+    try:
+        # Maven Central exposes no repo URL via Solr, so the link is decided by
+        # the discovery source: coords from the repo's own pom.xml are a strong
+        # self-reference (verified); coords from a badge are name_only.
+        from_manifest = parse_maven_coords(aux_files)
+        maven_coord = from_manifest or coords.get("maven")
+        if maven_coord and hasattr(registry, "get_maven_package"):
+            group_id, artifact_id = maven_coord
+            maven_pkg = registry.get_maven_package(group_id, artifact_id)
+            if isinstance(maven_pkg, dict):
+                maven_pkg["link"] = "verified" if from_manifest else "name_only"
+                repository_metadata["maven_package"] = maven_pkg
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"Maven package lookup failed for {full_name}: {exc}",
         )
 
 

--- a/tests/v2/test_maven_discovery.py
+++ b/tests/v2/test_maven_discovery.py
@@ -1,0 +1,266 @@
+"""Tests for Maven Central artifact discovery (pom.xml / badge linked).
+
+No real network — a fake session / fake provider is injected.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from src.v2.agents import ProviderSet, RepositoryAgentV2
+from src.v2.agents.rule_based._repo_signals import (
+    extract_registry_coords,
+    parse_badges,
+    parse_maven_coords,
+)
+from src.v2.ingest.providers.mock_github import MockGitHubProvider
+from src.v2.ingest.providers.package_registry_provider import (
+    PackageRegistryProvider,
+    _ms_to_iso,
+)
+from src.v2.pipeline.stages.context_gather import (
+    _enrich_repository_metadata_with_registry_packages,
+)
+
+_EXPECTED_MAVEN_VERSIONS = 3
+
+_POM = (
+    '<project xmlns="http://maven.apache.org/POM/4.0.0">'
+    "<modelVersion>4.0.0</modelVersion>"
+    "<groupId>com.acme</groupId><artifactId>widget</artifactId>"
+    "</project>"
+)
+_POM_PARENT_GROUP = (
+    '<project xmlns="http://maven.apache.org/POM/4.0.0">'
+    "<parent><groupId>com.acme</groupId><artifactId>parent</artifactId></parent>"
+    "<artifactId>widget</artifactId></project>"
+)
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        if isinstance(self._payload, ValueError):
+            raise self._payload
+        return self._payload
+
+
+class _MavenSession:
+    """Returns the `latest` payload for the rows=1 query and the `gav`
+    payload for the core=gav query, keyed on the `core=gav` substring."""
+
+    def __init__(self, *, latest: Any, gav: Any) -> None:
+        self._latest = latest
+        self._gav = gav
+        self.requested: list[str] = []
+
+    def get(self, url: str, timeout: float | None = None, headers: Any = None) -> _FakeResp:  # noqa: ARG002
+        self.requested.append(url)
+        payload = self._gav if "core=gav" in url else self._latest
+        return _FakeResp(200, payload)
+
+
+def _solr(docs: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"response": {"numFound": len(docs), "docs": docs}}
+
+
+def _maven_session() -> _MavenSession:
+    return _MavenSession(
+        latest=_solr([{
+            "g": "com.acme", "a": "widget",
+            "latestVersion": "2.1.0", "timestamp": 1744651522422, "versionCount": 3,
+        }]),
+        gav=_solr([
+            {"v": "2.1.0", "timestamp": 1744651522422},
+            {"v": "2.0.0", "timestamp": 1742918069784},
+            {"v": "1.0.0", "timestamp": 1700000000000},
+        ]),
+    )
+
+
+class _FakeMavenProvider:
+    def __init__(self, result: dict[str, Any] | None) -> None:
+        self._result = result
+        self.calls: list[tuple[str, str]] = []
+
+    def get_maven_package(self, group_id: str, artifact_id: str) -> dict[str, Any] | None:
+        self.calls.append((group_id, artifact_id))
+        return dict(self._result) if isinstance(self._result, dict) else None
+
+
+# ---------------------------------------------------------------------------
+# parse_maven_coords
+# ---------------------------------------------------------------------------
+
+
+def test_parse_maven_coords_basic() -> None:
+    assert parse_maven_coords({"pom.xml": _POM}) == ("com.acme", "widget")
+
+
+def test_parse_maven_coords_parent_group_fallback() -> None:
+    assert parse_maven_coords({"pom.xml": _POM_PARENT_GROUP}) == ("com.acme", "widget")
+
+
+def test_parse_maven_coords_no_artifact_returns_none() -> None:
+    pom = '<project xmlns="http://maven.apache.org/POM/4.0.0"><groupId>g</groupId></project>'
+    assert parse_maven_coords({"pom.xml": pom}) is None
+
+
+def test_parse_maven_coords_malformed_returns_none() -> None:
+    assert parse_maven_coords({"pom.xml": "<project><artifactId>x"}) is None
+
+
+def test_parse_maven_coords_missing_returns_none() -> None:
+    assert parse_maven_coords({"package.json": "{}"}) is None
+    assert parse_maven_coords(None) is None
+
+
+# ---------------------------------------------------------------------------
+# badge coordinate extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_coords_maven_shields_and_link() -> None:
+    badges = parse_badges(
+        "[![mvn](https://img.shields.io/maven-central/v/org.foo/bar.svg)](x)",
+    )
+    assert extract_registry_coords(badges)["maven"] == ("org.foo", "bar")
+    badges2 = parse_badges(
+        "[![mvn](img)](https://central.sonatype.com/artifact/org.baz/qux)",
+    )
+    assert extract_registry_coords(badges2)["maven"] == ("org.baz", "qux")
+
+
+# ---------------------------------------------------------------------------
+# _ms_to_iso
+# ---------------------------------------------------------------------------
+
+
+def test_ms_to_iso() -> None:
+    assert _ms_to_iso(1744651522422).startswith("2025-04-14T")
+    assert _ms_to_iso(None) is None
+    assert _ms_to_iso("nope") is None
+    assert _ms_to_iso(True) is None  # noqa: FBT003 — bool must be rejected, not treated as epoch
+
+
+# ---------------------------------------------------------------------------
+# PackageRegistryProvider.get_maven_package
+# ---------------------------------------------------------------------------
+
+
+def test_get_maven_package_thin_dict() -> None:
+    pkg = PackageRegistryProvider(session=_maven_session()).get_maven_package(
+        "com.acme", "widget",
+    )
+    assert pkg is not None
+    assert pkg["name"] == "com.acme:widget"
+    assert pkg["group_id"] == "com.acme"
+    assert pkg["artifact_id"] == "widget"
+    assert pkg["latest_version"] == "2.1.0"
+    assert pkg["versions"] == ["2.1.0", "2.0.0", "1.0.0"]
+    assert len(pkg["versions"]) == _EXPECTED_MAVEN_VERSIONS
+    assert pkg["latest_release_date"].startswith("2025-04-14T")
+    assert pkg["repository_url"] is None
+    assert pkg["registry_url"] == "https://central.sonatype.com/artifact/com.acme/widget"
+
+
+def test_get_maven_package_not_found_returns_none() -> None:
+    session = _MavenSession(latest=_solr([]), gav=_solr([]))
+    assert PackageRegistryProvider(session=session).get_maven_package("x", "y") is None
+
+
+# ---------------------------------------------------------------------------
+# context_gather link policy (manifest → verified, badge → name_only)
+# ---------------------------------------------------------------------------
+
+
+def _enrich(full_name: str, aux_files: dict[str, str], provider: Any, readme: str | None) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    providers = ProviderSet(github=MockGitHubProvider(), package_registry=provider)
+    _enrich_repository_metadata_with_registry_packages(
+        full_name=full_name,
+        aux_files=aux_files,
+        repository_metadata=metadata,
+        providers=providers,
+        warnings=[],
+        readme=readme,
+    )
+    return metadata
+
+
+def test_context_gather_maven_from_pom_verified() -> None:
+    provider = _FakeMavenProvider({"name": "com.acme:widget", "group_id": "com.acme"})
+    meta = _enrich("acme/widget", {"pom.xml": _POM}, provider, None)
+    assert provider.calls == [("com.acme", "widget")]
+    assert meta["maven_package"]["link"] == "verified"
+
+
+def test_context_gather_maven_from_badge_name_only() -> None:
+    provider = _FakeMavenProvider({"name": "org.foo:bar"})
+    readme = "[![mvn](https://img.shields.io/maven-central/v/org.foo/bar.svg)](x)"
+    meta = _enrich("acme/widget", {}, provider, readme)
+    assert provider.calls == [("org.foo", "bar")]
+    assert meta["maven_package"]["link"] == "name_only"
+
+
+def test_context_gather_maven_absent() -> None:
+    provider = _FakeMavenProvider({"name": "x"})
+    meta = _enrich("acme/widget", {"package.json": "{}"}, provider, None)
+    assert provider.calls == []
+    assert "maven_package" not in meta
+
+
+# ---------------------------------------------------------------------------
+# repository_agent emission
+# ---------------------------------------------------------------------------
+
+
+def _stub_context(*, maven_package: dict[str, Any] | None) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "name": "widget", "full_name": "acme/widget",
+        "owner": {"login": "acme", "type": "Organization"},
+        "created_at": "2023-01-01T00:00:00Z", "license": {"spdx_id": "MIT"},
+        "fork": False, "source": {"full_name": None},
+    }
+    if maven_package is not None:
+        metadata["maven_package"] = maven_package
+    return {
+        "full_name": "acme/widget", "metadata": metadata,
+        "readme_content": "", "contributors": [{"login": "alice"}],
+        "languages": {"Java": 1}, "aux_files": {},
+    }
+
+
+def test_repository_agent_emits_maven_scalars() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+    result = asyncio.run(agent.run(
+        {"full_name": "acme/widget", "repository_context": _stub_context(maven_package={
+            "name": "com.acme:widget", "group_id": "com.acme", "artifact_id": "widget",
+            "latest_version": "2.1.0", "versions": ["2.1.0", "2.0.0"],
+            "latest_release_date": "2025-04-14T17:25:22Z",
+            "registry_url": "https://central.sonatype.com/artifact/com.acme/widget",
+            "link": "verified",
+        })}, providers))
+    raw = result.raw_output
+    assert raw["_maven_package"] == "com.acme:widget"
+    assert raw["_maven_group_id"] == "com.acme"
+    assert raw["_maven_artifact_id"] == "widget"
+    assert raw["_maven_latest_version"] == "2.1.0"
+    assert raw["_maven_link"] == "verified"
+
+
+def test_repository_agent_maven_scalars_none_when_absent() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+    result = asyncio.run(agent.run(
+        {"full_name": "acme/widget", "repository_context": _stub_context(maven_package=None)},
+        providers,
+    ))
+    raw = result.raw_output
+    assert raw["_maven_package"] is None
+    assert raw["_maven_group_id"] is None
+    assert raw["_maven_link"] is None


### PR DESCRIPTION
Second of the three remaining ecosystems from the plan. **`pom.xml` is already fetched** into `aux_files`, so coordinates come for free.

## How it works
- **Discovery** — `parse_maven_coords(aux_files)` → `(groupId, artifactId)` from `pom.xml` (namespace-agnostic; `groupId` falls back to `<parent>` per Maven inheritance). Gradle/badge fallback via a `maven-central` shields / `central.sonatype.com/artifact` badge matcher.
- **Registry** — `get_maven_package(group, artifact)` queries the Maven Central Solr API: `rows=1` for `latestVersion` + latest `timestamp`, `core=gav` for the version list. New `_solr_docs` + `_ms_to_iso` (ms-epoch → ISO) helpers.
- **Linking** — Solr exposes no POM `<scm>`, so the link is decided by **discovery source**: coords from the repo's own `pom.xml` → `verified` (strong self-reference); coords from a badge → `name_only`. (Optional stronger check — fetching the released POM's `<scm>` — is deferred per the plan.)

## Emitted triples (`?include_internal_fields=true`)
`gme-internal:maven_package` (`group:artifact`), `maven_group_id`, `maven_artifact_id`, `maven_latest_version`, `maven_versions`, `maven_latest_release_date`, `maven_registry_url` (`central.sonatype.com/artifact/…`), `maven_link`.

## Verified live
Against `search.maven.org` (no real network in tests): `com.google.guava:guava` → 33.4.8-jre, 150 versions, correct latest date + registry URL; pom parse incl. parent-group fallback; badge coords.

## Tests
`tests/v2/test_maven_discovery.py` (14): pom parse (basic, parent-group, no-artifact, malformed, missing), badge coord extraction, `_ms_to_iso`, provider via fake session (thin dict + not-found→None), context_gather manifest-verified vs badge-name_only vs absent, agent scalars + all-None. Full `tests/v2/` green: **1596 passed, 1 skipped**. New files ruff-clean; no new lint in modified files.

## Next
NuGet (badge-driven v1) closes out the plan.