### PR TITLE
feat(v2): NuGet package discovery (gme-internal:nuget_*) — completes Maven/NuGet/Go

### DIFF
--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -444,8 +444,10 @@ _RUBYGEMS_IMAGE_RE = re.compile(
 
 
 # Badge image URLs (badge.fury.io, img.shields.io) often end in an image
-# extension (`csbdeep.svg`); no real package name does, so strip it.
-_BADGE_EXT_RE = re.compile(r"\.(?:svg|png|json|gif)$", re.IGNORECASE)
+# extension (`csbdeep.svg`); no real package name does, so strip it. NOTE:
+# only true image extensions — NOT `.json` (collides with legit package names
+# like `Newtonsoft.Json`; shields/fury badges are `.svg`/`.png`, never `.json`).
+_BADGE_EXT_RE = re.compile(r"\.(?:svg|png|gif)$", re.IGNORECASE)
 
 
 def _strip_badge_ext(name: str) -> str:
@@ -501,6 +503,21 @@ def _match_maven(url: str) -> tuple[str, str] | None:
     return None
 
 
+_NUGET_LINK_RE = re.compile(
+    r"nuget\.org/packages/(?P<name>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+_NUGET_IMAGE_RE = re.compile(
+    r"img\.shields\.io/nuget/(?:v|vpre)/(?P<name>[^/\s)?#]+)",
+    re.IGNORECASE,
+)
+
+
+def _match_nuget(url: str) -> str | None:
+    m = _NUGET_LINK_RE.search(url) or _NUGET_IMAGE_RE.search(url)
+    return _strip_badge_ext(m.group("name")) if m else None
+
+
 # (ecosystem-key, matcher) pairs consulted for each badge URL.
 _COORD_MATCHERS: tuple[tuple[str, Any], ...] = (
     ("pypi", _match_pypi),
@@ -509,6 +526,7 @@ _COORD_MATCHERS: tuple[tuple[str, Any], ...] = (
     ("crates", _match_crates),
     ("rubygems", _match_rubygems),
     ("maven", _match_maven),
+    ("nuget", _match_nuget),
 )
 
 

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -638,6 +638,15 @@ class RepositoryAgentV2:
             "_maven_artifact_id": (
                 (repository.get("maven_package") or {}).get("artifact_id")
             ),
+            # NuGet (.NET) package — discovered from a nuget.org / shields
+            # badge; back-reference verified via the package's Source-Link
+            # `repository` URL (homepage `projectUrl` is intentionally not used).
+            **{
+                f"_nuget_{k}": v
+                for k, v in summarize_registry_package(
+                    repository.get("nuget_package"),
+                ).items()
+            },
             # CI presence — detected from the repo root listing by
             # context_gather and stored in repository_metadata["has_ci"].
             # None when the listing was unavailable.

--- a/src/v2/ingest/providers/package_registry_provider.py
+++ b/src/v2/ingest/providers/package_registry_provider.py
@@ -522,6 +522,100 @@ class PackageRegistryProvider:
             ),
         }
 
+    def get_nuget_package(self, package_id: str) -> dict[str, Any] | None:
+        """Fetch thin metadata for a NuGet package *package_id*.
+
+        Search endpoint → canonical id + latest stable version; flat-container
+        → the full version list; registration → ``repository`` URL + latest
+        ``published`` date. ``repository_url`` is taken ONLY from the package's
+        Source-Link ``repository`` (NOT ``projectUrl``, which is usually a
+        homepage) so the back-reference check never false-drops on a homepage.
+        """
+        if not (isinstance(package_id, str) and package_id.strip()):
+            return None
+        package_id = package_id.strip()
+
+        def _fetch() -> dict[str, Any] | None:
+            subject = f"nuget:{package_id}"
+            search = self._get_json(
+                "https://azuresearch-usnc.nuget.org/query"
+                f"?q=packageid:{quote(package_id, safe='')}&take=1",
+                subject=subject,
+            )
+            data = search.get("data") if isinstance(search, dict) else None
+            if not (isinstance(data, list) and data and isinstance(data[0], dict)):
+                return None
+            head = data[0]
+            name = _first_str(head.get("id")) or package_id
+            latest_version = _first_str(head.get("version"))
+
+            id_lower = name.lower()
+            flat = self._get_json(
+                f"https://api.nuget.org/v3-flatcontainer/{quote(id_lower, safe='')}"
+                "/index.json",
+                subject=f"{subject}:versions",
+            )
+            versions: list[str] = []
+            if isinstance(flat, dict) and isinstance(flat.get("versions"), list):
+                versions = [v for v in flat["versions"] if isinstance(v, str) and v]
+                if len(versions) > _MAX_VERSIONS:
+                    logger.info(
+                        "nuget package %s has %d versions; truncating to %d",
+                        name, len(versions), _MAX_VERSIONS,
+                    )
+                    versions = versions[:_MAX_VERSIONS]
+
+            repository_url, published = self._nuget_repo_and_date(
+                id_lower, latest_version, subject=subject,
+            )
+
+            return {
+                "name": name,
+                "latest_version": latest_version,
+                "versions": versions or None,
+                "latest_release_date": published,
+                "repository_url": repository_url,
+                "registry_url": f"https://www.nuget.org/packages/{name}",
+            }
+
+        return self._cached(_fetch, method="get_nuget_package", name=package_id)
+
+    def _nuget_repo_and_date(
+        self, id_lower: str, target_version: str | None, *, subject: str,
+    ) -> tuple[str | None, str | None]:
+        """Best-effort (repository_url, published) for *target_version* from the
+        NuGet registration index. Handles inline leaves and one paged sub-page;
+        returns (None, None) when neither is available."""
+        idx = self._get_json(
+            "https://api.nuget.org/v3/registration5-gz-semver2/"
+            f"{quote(id_lower, safe='')}/index.json",
+            subject=f"{subject}:registration",
+        )
+        pages = idx.get("items") if isinstance(idx, dict) else None
+        if not (isinstance(pages, list) and pages):
+            return (None, None)
+        last = pages[-1]
+        leaves = last.get("items") if isinstance(last, dict) else None
+        if not isinstance(leaves, list):
+            page_url = last.get("@id") if isinstance(last, dict) else None
+            if isinstance(page_url, str):
+                sub = self._get_json(page_url, subject=f"{subject}:registration-page")
+                leaves = sub.get("items") if isinstance(sub, dict) else None
+        if not isinstance(leaves, list):
+            return (None, None)
+
+        entry = _nuget_catalog_entry(leaves, target_version)
+        if entry is None:
+            return (None, None)
+        repo = entry.get("repository")
+        repo_url = None
+        if isinstance(repo, dict):
+            repo_url = _first_str(repo.get("url"))
+        elif isinstance(repo, str):
+            repo_url = _first_str(repo)
+        published = _first_str(entry.get("published"))
+        return (repo_url, published)
+
     # ------------------------------------------------------------------
     # shared helpers
     # ------------------------------------------------------------------
@@ -607,6 +701,22 @@ def _solr_docs(payload: Any) -> list[dict[str, Any]]:
         return []
     docs = response.get("docs")
     return [d for d in docs if isinstance(d, dict)] if isinstance(docs, list) else []
+
+
+def _nuget_catalog_entry(
+    leaves: list[Any], target_version: str | None,
+) -> dict[str, Any] | None:
+    """Return the ``catalogEntry`` for *target_version* among registration
+    *leaves* (else the last leaf's entry)."""
+    last_entry: dict[str, Any] | None = None
+    for leaf in leaves:
+        entry = leaf.get("catalogEntry") if isinstance(leaf, dict) else None
+        if not isinstance(entry, dict):
+            continue
+        last_entry = entry
+        if target_version and entry.get("version") == target_version:
+            return entry
+    return last_entry
 
 
 def _ms_to_iso(value: Any) -> str | None:

--- a/src/v2/pipeline/stages/context_gather.py
+++ b/src/v2/pipeline/stages/context_gather.py
@@ -390,6 +390,16 @@ def _enrich_repository_metadata_with_registry_packages(  # noqa: C901, PLR0912, 
         warnings.append(
             f"Maven package lookup failed for {full_name}: {exc}",
         )
+    try:
+        nuget_name = coords.get("nuget")
+        if nuget_name and hasattr(registry, "get_nuget_package"):
+            _link_and_store(
+                registry.get_nuget_package(nuget_name), key="nuget_package",
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"NuGet package lookup failed for {full_name}: {exc}",
+        )
 
 
 def _optional_repository_context(

--- a/tests/v2/test_nuget_discovery.py
+++ b/tests/v2/test_nuget_discovery.py
@@ -1,0 +1,232 @@
+"""Tests for NuGet package discovery (badge-driven, Source-Link verified).
+
+No real network — a fake session / fake provider is injected.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from src.v2.agents import ProviderSet, RepositoryAgentV2
+from src.v2.agents.rule_based._repo_signals import (
+    extract_registry_coords,
+    parse_badges,
+)
+from src.v2.ingest.providers.mock_github import MockGitHubProvider
+from src.v2.ingest.providers.package_registry_provider import PackageRegistryProvider
+from src.v2.pipeline.stages.context_gather import (
+    _enrich_repository_metadata_with_registry_packages,
+)
+
+_EXPECTED_NUGET_VERSIONS = 3
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class _NuGetSession:
+    """Routes by URL substring: search / flat-container / registration."""
+
+    def __init__(self, *, search: Any, versions: Any, registration: Any) -> None:
+        self._search = search
+        self._versions = versions
+        self._registration = registration
+        self.requested: list[str] = []
+
+    def get(self, url: str, timeout: float | None = None, headers: Any = None) -> _FakeResp:  # noqa: ARG002
+        self.requested.append(url)
+        if "azuresearch" in url:
+            return _FakeResp(200, self._search)
+        if "v3-flatcontainer" in url:
+            return _FakeResp(200, self._versions)
+        if "registration" in url:
+            return _FakeResp(200, self._registration)
+        return _FakeResp(404, None)
+
+
+def _nuget_session(*, repository: Any = None) -> _NuGetSession:
+    catalog = {
+        "version": "13.0.4",
+        "published": "2025-09-16T08:13:09.313+00:00",
+        "projectUrl": "https://www.newtonsoft.com/json",
+    }
+    if repository is not None:
+        catalog["repository"] = repository
+    return _NuGetSession(
+        search={"data": [{"id": "Newtonsoft.Json", "version": "13.0.4",
+                          "projectUrl": "https://www.newtonsoft.com/json"}]},
+        versions={"versions": ["11.0.1", "12.0.3", "13.0.4"]},
+        registration={"items": [{"items": [{"catalogEntry": catalog}]}]},
+    )
+
+
+class _FakeNuGetProvider:
+    def __init__(self, result: dict[str, Any] | None) -> None:
+        self._result = result
+        self.calls: list[str] = []
+
+    def get_nuget_package(self, package_id: str) -> dict[str, Any] | None:
+        self.calls.append(package_id)
+        return dict(self._result) if isinstance(self._result, dict) else None
+
+
+# ---------------------------------------------------------------------------
+# badge coordinate extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_coords_nuget_link_and_image() -> None:
+    badges = parse_badges("[![n](img)](https://www.nuget.org/packages/Polly)")
+    assert extract_registry_coords(badges)["nuget"] == "Polly"
+    badges2 = parse_badges("[![n](https://img.shields.io/nuget/v/Serilog.svg)](x)")
+    assert extract_registry_coords(badges2)["nuget"] == "Serilog"
+
+
+def test_extract_coords_nuget_dotted_name_not_truncated() -> None:
+    # A `.svg` is stripped but a legit `.Json` suffix must be kept.
+    badges = parse_badges(
+        "[![n](https://img.shields.io/nuget/v/Newtonsoft.Json.svg)]"
+        "(https://www.nuget.org/packages/Newtonsoft.Json)",
+    )
+    assert extract_registry_coords(badges)["nuget"] == "Newtonsoft.Json"
+
+
+# ---------------------------------------------------------------------------
+# PackageRegistryProvider.get_nuget_package
+# ---------------------------------------------------------------------------
+
+
+def test_get_nuget_package_thin_dict_no_repository() -> None:
+    pkg = PackageRegistryProvider(session=_nuget_session()).get_nuget_package(
+        "Newtonsoft.Json",
+    )
+    assert pkg is not None
+    assert pkg["name"] == "Newtonsoft.Json"
+    assert pkg["latest_version"] == "13.0.4"
+    assert pkg["versions"] == ["11.0.1", "12.0.3", "13.0.4"]
+    assert len(pkg["versions"]) == _EXPECTED_NUGET_VERSIONS
+    assert pkg["latest_release_date"] == "2025-09-16T08:13:09.313+00:00"
+    assert pkg["repository_url"] is None  # no Source-Link repository → name_only
+    assert pkg["registry_url"] == "https://www.nuget.org/packages/Newtonsoft.Json"
+
+
+def test_get_nuget_package_repository_from_source_link() -> None:
+    session = _nuget_session(repository={"type": "git", "url": "https://github.com/acme/tool"})
+    pkg = PackageRegistryProvider(session=session).get_nuget_package("Newtonsoft.Json")
+    assert pkg is not None
+    assert pkg["repository_url"] == "https://github.com/acme/tool"
+
+
+def test_get_nuget_package_not_found_returns_none() -> None:
+    session = _NuGetSession(search={"data": []}, versions={}, registration={})
+    assert PackageRegistryProvider(session=session).get_nuget_package("Nope") is None
+
+
+# ---------------------------------------------------------------------------
+# context_gather link policy
+# ---------------------------------------------------------------------------
+
+
+def _enrich(full_name: str, provider: Any, readme: str) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    providers = ProviderSet(github=MockGitHubProvider(), package_registry=provider)
+    _enrich_repository_metadata_with_registry_packages(
+        full_name=full_name,
+        aux_files={},
+        repository_metadata=metadata,
+        providers=providers,
+        warnings=[],
+        readme=readme,
+    )
+    return metadata
+
+
+_README = "[![n](img)](https://www.nuget.org/packages/Acme.Tool)"
+
+
+def test_context_gather_nuget_verified() -> None:
+    provider = _FakeNuGetProvider({
+        "name": "Acme.Tool", "repository_url": "https://github.com/acme/tool",
+    })
+    meta = _enrich("acme/tool", provider, _README)
+    assert provider.calls == ["Acme.Tool"]
+    assert meta["nuget_package"]["link"] == "verified"
+
+
+def test_context_gather_nuget_name_only_when_no_repo() -> None:
+    provider = _FakeNuGetProvider({"name": "Acme.Tool", "repository_url": None})
+    meta = _enrich("acme/tool", provider, _README)
+    assert meta["nuget_package"]["link"] == "name_only"
+
+
+def test_context_gather_nuget_mismatch_dropped() -> None:
+    provider = _FakeNuGetProvider({
+        "name": "Acme.Tool", "repository_url": "https://github.com/other/repo",
+    })
+    meta = _enrich("acme/tool", provider, _README)
+    assert "nuget_package" not in meta
+
+
+def test_context_gather_nuget_absent_without_badge() -> None:
+    provider = _FakeNuGetProvider({"name": "x"})
+    meta = _enrich("acme/tool", provider, "# no badges here")
+    assert provider.calls == []
+    assert "nuget_package" not in meta
+
+
+# ---------------------------------------------------------------------------
+# repository_agent emission
+# ---------------------------------------------------------------------------
+
+
+def _stub_context(*, nuget_package: dict[str, Any] | None) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "name": "tool", "full_name": "acme/tool",
+        "owner": {"login": "acme", "type": "Organization"},
+        "created_at": "2023-01-01T00:00:00Z", "license": {"spdx_id": "MIT"},
+        "fork": False, "source": {"full_name": None},
+    }
+    if nuget_package is not None:
+        metadata["nuget_package"] = nuget_package
+    return {
+        "full_name": "acme/tool", "metadata": metadata,
+        "readme_content": "", "contributors": [{"login": "alice"}],
+        "languages": {"C#": 1}, "aux_files": {},
+    }
+
+
+def test_repository_agent_emits_nuget_scalars() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+    result = asyncio.run(agent.run(
+        {"full_name": "acme/tool", "repository_context": _stub_context(nuget_package={
+            "name": "Acme.Tool", "latest_version": "13.0.4",
+            "versions": ["12.0.3", "13.0.4"],
+            "latest_release_date": "2025-09-16T08:13:09.313+00:00",
+            "registry_url": "https://www.nuget.org/packages/Acme.Tool",
+            "link": "name_only",
+        })}, providers))
+    raw = result.raw_output
+    assert raw["_nuget_package"] == "Acme.Tool"
+    assert raw["_nuget_latest_version"] == "13.0.4"
+    assert raw["_nuget_versions"] == ["12.0.3", "13.0.4"]
+    assert raw["_nuget_link"] == "name_only"
+
+
+def test_repository_agent_nuget_scalars_none_when_absent() -> None:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+    result = asyncio.run(agent.run(
+        {"full_name": "acme/tool", "repository_context": _stub_context(nuget_package=None)},
+        providers,
+    ))
+    raw = result.raw_output
+    assert raw["_nuget_package"] is None
+    assert raw["_nuget_latest_version"] is None
+    assert raw["_nuget_link"] is None


### PR DESCRIPTION
Third and last of the planned ecosystems — closes out the Maven/NuGet/Go plan.

## How it works
- **Discovery** — badge-driven (NuGet manifests are unknown-name globs not in `aux_files`): `extract_registry_coords` gains NuGet patterns (`nuget.org/packages/<id>`, shields `nuget/v|vpre`).
- **Registry** — `get_nuget_package(id)`: search endpoint → canonical id + latest stable version; `v3-flatcontainer` → version list; registration (handles inline leaves **and** one paged sub-page) → latest `published` date + Source-Link `repository` URL.
- **Linking** — `repository_url` comes **only** from the package's `repository` (Source Link), **not** the `projectUrl` homepage, so a homepage never triggers a false mismatch-drop. Absent repository → `name_only` (common — many packages don't publish repository metadata, exactly as the plan anticipated).

## Emitted triples (`?include_internal_fields=true`)
`gme-internal:nuget_package`, `nuget_latest_version`, `nuget_versions`, `nuget_latest_release_date`, `nuget_registry_url`, `nuget_link`.

## Review fix
`_strip_badge_ext` was stripping a trailing `.json`, which collided with legit names ending in `.Json` — `Newtonsoft.Json` got truncated to `Newtonsoft`. shields/fury badges are `.svg`/`.png`, never `.json`, so `.json` is removed from the strip set (regression-tested).

## Verified live
Against `api.nuget.org` (no real network in tests): Newtonsoft.Json (84 versions), Serilog (200), Polly (89) — versions + dates correct; repository correctly None for packages without Source-Link metadata (→ name_only).

## Tests
`tests/v2/test_nuget_discovery.py` (11): badge coords incl. dotted-name guard, provider via fake session (with/without Source-Link repository, not-found→None), context_gather verified/name_only/mismatch-drop/absent, agent scalars + all-None. Full `tests/v2/` green: **1607 passed, 1 skipped**. New files ruff-clean.

## Status
With this, the full distribution set is covered: **releases, GHCR, npm, PyPI, conda, crates, RubyGems, Maven, Go, NuGet** + parsed badges.