### PR TITLE
feat(v2): GitHub low-hanging fruit — funding, community health, git tags, code-of-conduct

### DIFF
--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -25,6 +25,7 @@ from typing import Any
 from urllib.parse import unquote
 
 import tomllib
+import yaml
 
 logger = logging.getLogger(__name__)
 
@@ -654,6 +655,68 @@ def parse_maven_coords(aux_files: Any) -> tuple[str, str] | None:
     if not group:
         return None
     return (group, artifact)
+
+
+# GitHub FUNDING.yml platform → URL template ({} = the declared handle). Each
+# value may be a scalar handle or a list of handles; `custom` carries raw URLs.
+_FUNDING_PLATFORMS: dict[str, str] = {
+    "github": "https://github.com/sponsors/{}",
+    "patreon": "https://www.patreon.com/{}",
+    "open_collective": "https://opencollective.com/{}",
+    "ko_fi": "https://ko-fi.com/{}",
+    "tidelift": "https://tidelift.com/funding/github/{}",
+    "community_bridge": "https://crowdfunding.lfx.linuxfoundation.org/projects/{}",
+    "liberapay": "https://liberapay.com/{}",
+    "issuehunt": "https://issuehunt.io/r/{}",
+    "lfx_crowdfunding": "https://crowdfunding.lfx.linuxfoundation.org/projects/{}",
+    "polar": "https://polar.sh/{}",
+    "buy_me_a_coffee": "https://www.buymeacoffee.com/{}",
+    "thanks_dev": "https://thanks.dev/{}",
+}
+
+
+def _funding_handles(value: Any) -> list[str]:
+    """Normalise a FUNDING.yml value (scalar or list) to a list of handles."""
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    if isinstance(value, list):
+        return [v.strip() for v in value if isinstance(v, str) and v.strip()]
+    return []
+
+
+def parse_funding_urls(aux_files: Any) -> list[str]:
+    """Resolve a repo's ``.github/FUNDING.yml`` to canonical funding URLs.
+
+    Maps each sponsorship platform (``github``, ``patreon``, ``open_collective``,
+    ``ko_fi``, ``liberapay``, ``tidelift``, ``buy_me_a_coffee``, …) to its URL,
+    and passes ``custom`` entries through as raw URLs. Values may be a single
+    handle or a list. Returns a de-duped, order-preserving list (empty when no
+    FUNDING file / unparseable / no recognised platform).
+    """
+    content = _aux_file_lookup(aux_files, "funding.yml", "funding.yaml")
+    if content is None:
+        return []
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return []
+    if not isinstance(data, dict):
+        return []
+
+    candidates: list[str] = []
+    for platform, template in _FUNDING_PLATFORMS.items():
+        candidates.extend(template.format(h) for h in _funding_handles(data.get(platform)))
+    candidates.extend(
+        u for u in _funding_handles(data.get("custom"))
+        if u.startswith(("http://", "https://"))
+    )
+    seen: set[str] = set()
+    out: list[str] = []
+    for url in candidates:
+        if url and url not in seen:
+            seen.add(url)
+            out.append(url)
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -14,6 +14,7 @@ from src.v2.agents.models import (
 )
 from src.v2.agents.rule_based._repo_signals import (
     parse_docker_hub_url,
+    parse_funding_urls,
     parse_test_coverage,
     summarize_packages,
     summarize_registry_package,
@@ -57,6 +58,9 @@ _REPO_AUX_FILE_LOOKUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     # reporting guidance separately from undocumented ones, and gives
     # LLM agents a place to read for embargo / disclosure timelines.
     ("_security_url",      ("security.md",)),
+    # CODE_OF_CONDUCT — already fetched into aux_files; surface its URL like
+    # the other governance files.
+    ("_code_of_conduct_url", ("code_of_conduct.md", "code_of_conduct")),
 )
 
 
@@ -647,6 +651,35 @@ class RepositoryAgentV2:
                     repository.get("nuget_package"),
                 ).items()
             },
+            # Funding / sponsorship URLs parsed from .github/FUNDING.yml
+            # (GitHub Sponsors, Patreon, Open Collective, Ko-fi, …). List of
+            # canonical URLs, or None when no FUNDING file / no platforms.
+            "_funding_urls": (parse_funding_urls(compiled_context.get("aux_files")) or None),
+            # GitHub community health profile (GET /community/profile): overall
+            # health %, plus presence of code-of-conduct / issue / PR templates.
+            # None when the profile was unavailable.
+            "_community_health_percentage": (
+                (repository.get("community_profile") or {}).get("health_percentage")
+            ),
+            "_has_code_of_conduct": (
+                (repository.get("community_profile") or {}).get("has_code_of_conduct")
+            ),
+            "_has_issue_template": (
+                (repository.get("community_profile") or {}).get("has_issue_template")
+            ),
+            "_has_pull_request_template": (
+                (repository.get("community_profile") or {}).get(
+                    "has_pull_request_template",
+                )
+            ),
+            # Git tags (newest first) — versioning for repos that tag without
+            # cutting GitHub Releases. Raw list + count; None when no tags.
+            "_git_tags": (repository.get("git_tags") or None),
+            "_git_tag_count": (
+                len(repository["git_tags"])
+                if isinstance(repository.get("git_tags"), list)
+                else None
+            ),
             # CI presence — detected from the repo root listing by
             # context_gather and stored in repository_metadata["has_ci"].
             # None when the listing was unavailable.

--- a/src/v2/ingest/providers/base.py
+++ b/src/v2/ingest/providers/base.py
@@ -193,6 +193,28 @@ class GitHubProvider(BaseProvider, ABC):
         del full_name
         return []
 
+    def get_repository_community_profile(self, full_name: str) -> dict[str, Any] | None:
+        """Return GitHub's community health profile for ``owner/repo``.
+
+        From ``GET /repos/{owner}/{repo}/community/profile``:
+        ``health_percentage``, a ``documentation`` URL, and ``files`` presence
+        (code_of_conduct / contributing / issue_template / pull_request_template
+        / license / readme). Default returns None so partial mocks need not
+        stub it; implementations must not raise (None on failure).
+        """
+        del full_name
+        return None
+
+    def get_repository_tags(self, full_name: str) -> list[str]:
+        """Return the repository's git tag names (newest first), or ``[]``.
+
+        From ``GET /repos/{owner}/{repo}/tags`` — captures versioning for repos
+        that tag without cutting GitHub Releases. Default returns ``[]``;
+        implementations must not raise.
+        """
+        del full_name
+        return []
+
 
 class InfoscienceProvider(BaseProvider, ABC):
     """Adapter interface for Infoscience metadata retrieval."""

--- a/src/v2/ingest/providers/github_provider.py
+++ b/src/v2/ingest/providers/github_provider.py
@@ -917,6 +917,91 @@ class RealGitHubProvider(GitHubProvider):
             key, _fetch, label=f"github.get_releases({full_name})",
         )
 
+    def get_repository_community_profile(self, full_name: str) -> dict[str, Any] | None:
+        """Fetch GitHub's community health profile for ``owner/repo`` via
+        `/repos/{owner}/{repo}/community/profile` (public, cached). Returns a
+        thinned dict (health %, documentation URL, file-presence booleans), or
+        None on 404 / non-200 / transport error."""
+
+        def _fetch() -> dict[str, Any] | None:
+            url = f"https://api.github.com/repos/{full_name}/community/profile"
+            try:
+                response = self._run_with_rate_limit(
+                    lambda: requests.get(url, headers=_github_auth_headers(), timeout=15),
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("github community profile fetch failed: %s", full_name)
+                return None
+            if response.status_code == 404:
+                return None
+            if response.status_code != 200:
+                logger.info(
+                    "github community profile returned %d for %s",
+                    response.status_code, full_name,
+                )
+                return None
+            try:
+                payload = response.json()
+            except ValueError:
+                logger.exception("github community profile not JSON: %s", full_name)
+                return None
+            if not isinstance(payload, dict):
+                return None
+            files = payload.get("files") if isinstance(payload.get("files"), dict) else {}
+            return {
+                "health_percentage": payload.get("health_percentage"),
+                "documentation": payload.get("documentation"),
+                "has_code_of_conduct": files.get("code_of_conduct") is not None,
+                "has_contributing": files.get("contributing") is not None,
+                "has_issue_template": files.get("issue_template") is not None,
+                "has_pull_request_template": (
+                    files.get("pull_request_template") is not None
+                ),
+            }
+
+        if self._cache is None:
+            return _fetch()
+        key = ProviderCache.make_key(
+            "github", "get_community_profile_v1", full_name=full_name,
+        )
+        return self._cache.get_or_set(
+            key, _fetch, label=f"github.get_community_profile({full_name})",
+        )
+
+    def get_repository_tags(self, full_name: str) -> list[str]:
+        """Fetch git tag names for ``owner/repo`` via `/repos/.../tags`
+        (public, cached, first page of 100, newest first). Empty on
+        404 / non-200 / transport error."""
+
+        def _fetch() -> list[str]:
+            url = f"https://api.github.com/repos/{full_name}/tags?per_page=100"
+            try:
+                response = self._run_with_rate_limit(
+                    lambda: requests.get(url, headers=_github_auth_headers(), timeout=15),
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("github tags fetch failed: %s", full_name)
+                return []
+            if response.status_code != 200:
+                return []
+            try:
+                payload = response.json()
+            except ValueError:
+                return []
+            if not isinstance(payload, list):
+                return []
+            return [
+                t["name"] for t in payload
+                if isinstance(t, dict) and isinstance(t.get("name"), str) and t["name"]
+            ]
+
+        if self._cache is None:
+            return _fetch()
+        key = ProviderCache.make_key("github", "get_tags_v1", full_name=full_name)
+        return self._cache.get_or_set(
+            key, _fetch, label=f"github.get_tags({full_name})",
+        )
+
     def _list_owner_container_packages(self, owner: str) -> dict[str, Any]:
         """List an owner's GHCR container packages, cached by owner.
 

--- a/src/v2/pipeline/stages/context_gather.py
+++ b/src/v2/pipeline/stages/context_gather.py
@@ -513,6 +513,22 @@ def _optional_repository_context(
         warnings.append(
             f"Repository container-images lookup failed for {full_name}: {exc}",
         )
+    try:
+        profile = providers.github.get_repository_community_profile(full_name)
+        if isinstance(profile, dict):
+            repository_metadata["community_profile"] = profile
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"Repository community-profile lookup failed for {full_name}: {exc}",
+        )
+    try:
+        tags = providers.github.get_repository_tags(full_name)
+        if isinstance(tags, list) and tags:
+            repository_metadata["git_tags"] = tags
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"Repository tags lookup failed for {full_name}: {exc}",
+        )
 
     # CI detection — list the repo root once and check for known CI
     # indicator files / directories. Best-effort: None on failure so the
@@ -655,6 +671,22 @@ async def gather_context(  # noqa: C901, PLR0915
         except Exception as exc:  # noqa: BLE001
             warnings.append(
                 f"Repository container-images lookup failed for {full_name}: {exc}",
+            )
+        try:
+            profile = providers.github.get_repository_community_profile(full_name)
+            if isinstance(profile, dict):
+                repository_metadata["community_profile"] = profile
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(
+                f"Repository community-profile lookup failed for {full_name}: {exc}",
+            )
+        try:
+            tags = providers.github.get_repository_tags(full_name)
+            if isinstance(tags, list) and tags:
+                repository_metadata["git_tags"] = tags
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(
+                f"Repository tags lookup failed for {full_name}: {exc}",
             )
 
         # CI detection (best-effort; None on provider failure).

--- a/tests/v2/test_github_extras.py
+++ b/tests/v2/test_github_extras.py
@@ -1,0 +1,208 @@
+"""Tests for the GitHub "low-hanging fruit" enrichment:
+
+- FUNDING.yml → funding URLs (pure parser)
+- community health profile + git tags (provider methods, mocked requests)
+- repository agent stamping funding / community / tags / code-of-conduct fields.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import patch
+
+from src.v2.agents import ProviderSet, RepositoryAgentV2
+from src.v2.agents.rule_based._repo_signals import parse_funding_urls
+from src.v2.ingest.providers.github_provider import RealGitHubProvider
+from src.v2.ingest.providers.mock_github import MockGitHubProvider
+
+_EXPECTED_TAGS = 3
+_EXPECTED_HEALTH = 80
+
+
+class _FakeResponse:
+    def __init__(self, *, status_code: int, payload: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _provider() -> RealGitHubProvider:
+    return RealGitHubProvider(
+        gimie_extractor=lambda _url, _fmt: {},
+        user_lookup=lambda username: {"login": username},
+        organization_lookup=lambda org_name: {"login": org_name},
+    )
+
+
+def _patch_get(response: Any):
+    return patch(
+        "src.v2.ingest.providers.github_provider.requests.get",
+        return_value=response,
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_funding_urls
+# ---------------------------------------------------------------------------
+
+
+def test_parse_funding_urls_all_platforms() -> None:
+    funding = (
+        "github: [octocat, surftocat]\n"
+        "patreon: octo\n"
+        "open_collective: myproj\n"
+        "ko_fi: octo\n"
+        "liberapay: octo\n"
+        "buy_me_a_coffee: octo\n"
+        'custom: ["https://example.com/donate", "not-a-url"]\n'
+    )
+    urls = parse_funding_urls({".github/FUNDING.yml": funding})
+    assert "https://github.com/sponsors/octocat" in urls
+    assert "https://github.com/sponsors/surftocat" in urls
+    assert "https://www.patreon.com/octo" in urls
+    assert "https://opencollective.com/myproj" in urls
+    assert "https://ko-fi.com/octo" in urls
+    assert "https://liberapay.com/octo" in urls
+    assert "https://www.buymeacoffee.com/octo" in urls
+    assert "https://example.com/donate" in urls
+    assert "not-a-url" not in urls  # custom non-URL dropped
+
+
+def test_parse_funding_urls_scalar_github_handle() -> None:
+    assert parse_funding_urls({"funding.yml": "github: octocat\n"}) == [
+        "https://github.com/sponsors/octocat",
+    ]
+
+
+def test_parse_funding_urls_dedupes_preserving_order() -> None:
+    funding = "github: [a, a, b]\n"
+    assert parse_funding_urls({"funding.yml": funding}) == [
+        "https://github.com/sponsors/a",
+        "https://github.com/sponsors/b",
+    ]
+
+
+def test_parse_funding_urls_missing_or_malformed() -> None:
+    assert parse_funding_urls({"package.json": "{}"}) == []
+    assert parse_funding_urls(None) == []
+    assert parse_funding_urls({"funding.yml": "key: [unterminated\n"}) == []
+    assert parse_funding_urls({"funding.yml": "just a string"}) == []
+
+
+# ---------------------------------------------------------------------------
+# provider: community profile + tags
+# ---------------------------------------------------------------------------
+
+
+def test_get_repository_community_profile_thins() -> None:
+    payload = {
+        "health_percentage": 80,
+        "documentation": "https://example.com/docs",
+        "files": {
+            "code_of_conduct": {"name": "Contributor Covenant"},
+            "contributing": {"url": "..."},
+            "issue_template": None,
+            "pull_request_template": {"url": "..."},
+        },
+    }
+    with _patch_get(_FakeResponse(status_code=200, payload=payload)):
+        out = _provider().get_repository_community_profile("octocat/Hello-World")
+    assert out is not None
+    assert out["health_percentage"] == _EXPECTED_HEALTH
+    assert out["has_code_of_conduct"] is True
+    assert out["has_contributing"] is True
+    assert out["has_issue_template"] is False
+    assert out["has_pull_request_template"] is True
+
+
+def test_get_repository_community_profile_404_none() -> None:
+    with _patch_get(_FakeResponse(status_code=404)):
+        assert _provider().get_repository_community_profile("a/b") is None
+
+
+def test_get_repository_tags_names() -> None:
+    payload = [{"name": "v3.0.0"}, {"name": "v2.0.0"}, {"name": "v1.0.0"}, {"x": 1}]
+    with _patch_get(_FakeResponse(status_code=200, payload=payload)):
+        tags = _provider().get_repository_tags("octocat/Hello-World")
+    assert tags == ["v3.0.0", "v2.0.0", "v1.0.0"]
+    assert len(tags) == _EXPECTED_TAGS
+
+
+def test_get_repository_tags_non_200_empty() -> None:
+    with _patch_get(_FakeResponse(status_code=500)):
+        assert _provider().get_repository_tags("a/b") == []
+
+
+# ---------------------------------------------------------------------------
+# repository agent emission
+# ---------------------------------------------------------------------------
+
+
+def _stub_context(
+    *,
+    aux_files: dict[str, str] | None = None,
+    community_profile: dict[str, Any] | None = None,
+    git_tags: list[str] | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "name": "tool", "full_name": "acme/tool",
+        "owner": {"login": "acme", "type": "Organization"},
+        "created_at": "2023-01-01T00:00:00Z", "license": {"spdx_id": "MIT"},
+        "fork": False, "source": {"full_name": None},
+    }
+    if community_profile is not None:
+        metadata["community_profile"] = community_profile
+    if git_tags is not None:
+        metadata["git_tags"] = git_tags
+    return {
+        "full_name": "acme/tool", "metadata": metadata,
+        "readme_content": "", "contributors": [{"login": "alice"}],
+        "languages": {"Python": 1}, "aux_files": aux_files or {},
+    }
+
+
+def _run(context: dict[str, Any]) -> dict[str, Any]:
+    agent = RepositoryAgentV2()
+    providers = ProviderSet(github=MockGitHubProvider())
+    result = asyncio.run(agent.run(
+        {"full_name": "acme/tool", "repository_context": context}, providers,
+    ))
+    return result.raw_output
+
+
+def test_agent_emits_funding_community_tags_coc() -> None:
+    raw = _run(_stub_context(
+        aux_files={
+            ".github/FUNDING.yml": "github: acme\n",
+            "CODE_OF_CONDUCT.md": "# Code of Conduct",
+        },
+        community_profile={
+            "health_percentage": 80,
+            "has_code_of_conduct": True,
+            "has_issue_template": False,
+            "has_pull_request_template": True,
+        },
+        git_tags=["v2.0.0", "v1.0.0"],
+    ))
+    assert raw["_funding_urls"] == ["https://github.com/sponsors/acme"]
+    assert raw["_code_of_conduct_url"] == (
+        "https://github.com/acme/tool/blob/HEAD/CODE_OF_CONDUCT.md"
+    )
+    assert raw["_community_health_percentage"] == _EXPECTED_HEALTH
+    assert raw["_has_code_of_conduct"] is True
+    assert raw["_has_issue_template"] is False
+    assert raw["_has_pull_request_template"] is True
+    assert raw["_git_tags"] == ["v2.0.0", "v1.0.0"]
+    assert raw["_git_tag_count"] == len(["v2.0.0", "v1.0.0"])
+
+
+def test_agent_extras_none_when_absent() -> None:
+    raw = _run(_stub_context())
+    assert raw["_funding_urls"] is None
+    assert raw["_code_of_conduct_url"] is None
+    assert raw["_community_health_percentage"] is None
+    assert raw["_has_code_of_conduct"] is None
+    assert raw["_git_tags"] is None
+    assert raw["_git_tag_count"] is None


### PR DESCRIPTION
Four cheap GitHub signals we weren't surfacing yet (all best-effort, `gme-internal:`, read "no data" until re-extract).

| Field(s) | Source | Cost |
|---|---|---|
| `gme-internal:funding_urls` | `.github/FUNDING.yml` (**already fetched**) | parse only |
| `gme-internal:community_health_percentage` + `_has_code_of_conduct` / `_has_issue_template` / `_has_pull_request_template` | `GET /community/profile` | 1 call |
| `gme-internal:git_tags` (+ `_git_tag_count`) | `GET /tags` | 1 call |
| `_code_of_conduct_url` | `code_of_conduct.md` (**already fetched**) | one-line |

## Details
- **`parse_funding_urls`** maps every FUNDING platform (GitHub Sponsors, Patreon, Open Collective, Ko-fi, Liberapay, Tidelift, Buy Me a Coffee, …) to its canonical URL; `custom:` entries pass through as raw URLs; scalar or list; de-duped, order-preserving.
- **`get_repository_community_profile`** / **`get_repository_tags`** — new provider methods (with base-class `None`/`[]` defaults so mocks/partial providers need no stub; never raise). `context_gather` stores them in both repository code paths.
- **Code-of-conduct URL** — `code_of_conduct.md` was already fetched; just added to the aux-file URL lookups alongside CONTRIBUTING/SECURITY/CITATION/AUTHORS/publiccode.

## Verified live
CSBDeep community health 37% + docs URL; ripgrep 100 tags; FUNDING parsing across all platforms.

## Tests
`tests/v2/test_github_extras.py` (10): funding parser (all platforms, scalar, dedupe, missing/malformed), provider methods via mocked `requests` (thin dict, 404→None, non-200→[]), agent emission + all-None when absent. Full `tests/v2/` green: **1617 passed, 1 skipped**. New files ruff-clean; the only delta in `github_provider.py` is 3 literal-`200`/`404` PLR2004 matching that file's pervasive existing idiom (ruff isn't a CI gate).

## Deliberately skipped
`is_template`/`allow_forking` (trivial bools), `security_and_analysis` (needs admin scope — not low-hanging), `_contributor_count` (derivable).