### PR TITLE
docs: reference for gme-internal:* repository enrichment fields + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,29 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
   populate `gme-internal:hasDocumentation` (documentation URLs) and fill the
   test-coverage signal when the deterministic badge parse found none. Gated by
   `V2_REPO_SIGNALS_AGENT_MODE` (`apply`/`shadow`/`off`).
+- **Repository enrichment fields (`gme-internal:*`)** — a broad deterministic
+  layer surfaced under `?include_internal_fields=true`. See
+  [`docs/repository-enrichment-fields.md`](docs/repository-enrichment-fields.md):
+    - **Releases** — `release_count`, `first_release_date`, `latest_release_date`
+      (+ raw `releases`, `latest_version`); **git tags** (`git_tags`,
+      `git_tag_count`).
+    - **Container distribution** — `docker_hub_url`; GHCR `package_count`,
+      `package_names`, `package_image_refs`, `package_tags`,
+      `latest_package_updated_at` (+ raw `container_images`).
+    - **Published packages** for **npm, PyPI, conda, crates.io, RubyGems, Maven,
+      Go, NuGet** — each with `_package`, `_latest_version`, `_versions`,
+      `_latest_release_date`, `_registry_url`, and a `_link`
+      (`verified`/`name_only`) back-reference (+ `conda_channel`,
+      `maven_group_id`/`maven_artifact_id`). Discovered from manifests
+      (`package.json`, `pyproject.toml`, `cargo.toml`, `pom.xml`, `go.mod`) and
+      README badges; name-collision results are dropped.
+    - **README badges** — `badges` (label/image/link) + `badge_count`.
+    - **Funding** — `funding_urls` from `.github/FUNDING.yml`.
+    - **Community health** — `community_health_percentage`,
+      `has_code_of_conduct`, `has_issue_template`, `has_pull_request_template`.
+    - **CI / coverage** — `has_ci`, `test_coverage`; governance-file URL
+      pointers (`code_of_conduct_url`, `security_url`, …).
+  - Public-registry queries gated by `V2_PACKAGE_REGISTRY_ENABLED` (default on).
 
 ### Fixed
 

--- a/docs/repository-enrichment-fields.md
+++ b/docs/repository-enrichment-fields.md
@@ -1,0 +1,106 @@
+# Repository enrichment fields (`gme-internal:*`)
+
+The v2 repository pipeline collects a broad layer of provider metadata that the
+Open Pulse ontology does not (yet) model. These surface under the auxiliary
+`gme-internal:` JSON-LD vocabulary
+(`https://openpulse.science/git-metadata-extractor#`).
+
+!!! note "How to see them"
+    They are **stripped by default** (ontology-compliant output). Add
+    **`?include_internal_fields=true`** to `GET /v2/extract/{path}` to keep them.
+    Each `_`-prefixed entity field becomes a `gme-internal:<field>` term that
+    expands to a real IRI, so the payload still loads into an RDF store. Strict
+    SHACL validation runs identically either way — the flag only changes what the
+    consumer sees. Fields read "no data" (absent / `null`) until a repository is
+    (re-)extracted.
+
+All fields below are **deterministic** (rule-based, computed in `context_gather`
++ the repository agent) unless noted, so they are independent of the
+`agent_runtime` (`rule_based` / `llm` / `hybrid`).
+
+## Repository metadata
+
+From the GitHub repository object.
+
+| Field | Meaning |
+|---|---|
+| `description` | Repo tagline |
+| `homepage` | Project website set on the repo |
+| `primary_language` | GitHub's primary language |
+| `keywords` | Repository topics |
+| `default_branch`, `visibility`, `archived`, `disabled`, `size_kb` | Repo state |
+| `pushed_at`, `updated_at` | Last push / metadata update |
+| `watchers_count`, `subscribers_count`, `network_count`, `open_issues_count` | Activity counters |
+| `avatar_url` | Owner avatar |
+| `license_name`, `license_url` | License (also `schema:license`) |
+| `has_wiki`, `has_pages`, `has_discussions`, `has_issues`, `has_projects` | Enabled GitHub features |
+
+## CI, coverage & community health
+
+| Field | Source |
+|---|---|
+| `has_ci` | repo-root listing (`.github/`, `.travis.yml`, …) |
+| `test_coverage` | README coverage badge / text (LLM fallback via `repo_signals` refiner) |
+| `community_health_percentage` | `GET /community/profile` |
+| `has_code_of_conduct`, `has_issue_template`, `has_pull_request_template` | community profile |
+
+## Releases & tags
+
+| Field | Meaning |
+|---|---|
+| `releases` | Raw GitHub releases list (full detail) |
+| `latest_version` | Newest release tag |
+| `release_count`, `first_release_date`, `latest_release_date` | Flat scalars for **release frequency** |
+| `git_tags`, `git_tag_count` | Git tags (for repos that tag without cutting Releases) |
+
+> The raw `releases` list-of-objects collapses to blank nodes on RDF expansion;
+> the flat `release_count` / `first_release_date` / `latest_release_date` triples
+> are the queryable form.
+
+## Container distribution
+
+| Field | Meaning |
+|---|---|
+| `docker_hub_url` | Docker Hub repo parsed from README / compose |
+| `container_images` | Raw GHCR container packages (needs `read:packages` scope) |
+| `package_count`, `package_names`, `package_image_refs`, `package_tags`, `latest_package_updated_at` | Flat GHCR scalars |
+
+## Published packages (per registry)
+
+For each ecosystem **`<eco>` ∈ {`npm`, `pypi`, `conda`, `crates`, `rubygems`, `maven`, `go`, `nuget`}**:
+
+| Field | Meaning |
+|---|---|
+| `<eco>_package` | Package / coordinate name (Go: module path; Maven: `group:artifact`) |
+| `<eco>_latest_version` | Newest published version |
+| `<eco>_versions` | All versions (capped) |
+| `<eco>_latest_release_date` | Latest release timestamp |
+| `<eco>_registry_url` | Human-facing registry page |
+| `<eco>_link` | `verified` (registry's repo URL back-references this repo) or `name_only` |
+
+Extras: `conda_channel`, `maven_group_id`, `maven_artifact_id`.
+
+**Discovery sources:** npm/PyPI from `package.json` / `pyproject.toml` (+ badge
+fallback); conda/RubyGems/NuGet from README badges; crates from `cargo.toml` (+
+badge); Maven from `pom.xml` (+ badge); Go from `go.mod`. A registry result is
+**dropped** when its declared repository URL points at a *different* repo
+(name-collision guard).
+
+## Documentation, badges & governance
+
+| Field | Meaning |
+|---|---|
+| `documentation_urls` | Documentation-site URLs (`gme-internal:hasDocumentation`; README + LLM `repo_signals` refiner) |
+| `badges`, `badge_count` | Parsed README badges (`{label, image_url, link_url}`) |
+| `funding_urls` | Sponsorship URLs from `.github/FUNDING.yml` (GitHub Sponsors, Patreon, Open Collective, …) |
+| `citation_cff` | Parsed `CITATION.cff` payload |
+| `publiccode` | Parsed `publiccode.yml` payload (scalars also hoisted to `publiccode:*`) |
+| `citation_cff_url`, `authors_url`, `contributing_url`, `code_of_conduct_url`, `security_url`, `publiccode_url` | URL pointers to repo-root governance files |
+
+## Not captured (by design)
+
+- `is_template` / `allow_forking` — trivial booleans, negligible signal.
+- `security_and_analysis` (Dependabot / secret-scanning state) — requires a
+  push/admin token scope, so not collected.
+- npm/PyPI for GitHub's own `npm.pkg.github.com` registry — we target the public
+  registries (npmjs.com / PyPI / etc.) instead.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
   - V2 Extraction Service:
       - V2 API Reference: v2-api-reference.md
       - API and CLI Quick Reference: api-and-cli.md
+      - Repository Enrichment Fields: repository-enrichment-fields.md
       - Migration V1 to V2: migration-v1-to-v2.md
   - RAG Indices:
       - Overview: rag-indices.md


### PR DESCRIPTION
Documentation catch-up for the enrichment work merged in #130–#143.

- **New `docs/repository-enrichment-fields.md`** (in nav under *V2 Extraction Service*) — a single reference for every `gme-internal:*` field the repository pipeline emits under `?include_internal_fields=true`: repo metadata, CI/coverage/community health, releases & git tags, container distribution, published packages across all **8 registries** (npm/PyPI/conda/crates/RubyGems/Maven/Go/NuGet), badges, funding, and governance-file URL pointers — with discovery sources and the `verified`/`name_only` link semantics, plus the "how to see them" flag note and the deliberately-skipped list.
- **CHANGELOG `[Unreleased]`** — documents the full repository-enrichment layer.

Docs-only; `mkdocs build --strict` adds **zero** new warnings (the 4 pre-existing aborts are in unrelated files — `v2-pipeline.md`, `epfl-graph-disciplines.md`).