### PR TITLE
feat(v2): gimie-api sidecar client behind GIMIE_API_URL (Phase 1, opt-in)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -55,6 +55,22 @@ services:
     restart: unless-stopped
     networks:
       - dev
+  # gimie-api sidecar (Phase 1 spike): runs gimie out-of-process so the v2
+  # provider can call it over HTTP instead of importing gimie. OPT-IN — the app
+  # uses it only when `GIMIE_API_URL=http://gme-gimie-api:15400` is set (left
+  # unset by default, so in-process gimie stays the default). Pin a digest for
+  # reproducibility before relying on it in CI/prod.
+  gme-gimie-api:
+    image: ghcr.io/sdsc-ordes/gimie-api:latest
+    container_name: gme-gimie-api
+    environment:
+      # gimie-api reads the GitHub token from ACCESS_TOKEN.
+      ACCESS_TOKEN: ${GME_GITHUB_TOKEN:-}
+    ports:
+      - "${GIMIE_API_PORT:-7000}:15400"
+    restart: unless-stopped
+    networks:
+      - dev
 
 networks:
   dev:

--- a/docs/superpowers/specs/2026-06-07-gimie-api-sidecar-plan.md
+++ b/docs/superpowers/specs/2026-06-07-gimie-api-sidecar-plan.md
@@ -1,0 +1,111 @@
+# Plan — replace in-process `gimie` with a `gimie-api` sidecar
+
+**Date:** 2026-06-07
+**Status:** plan (spike-first)
+**Motivation:** `gimie==0.7.2` (the only release) and its `calamus` dependency
+hard-pin `python-dotenv<0.22` and `marshmallow<3.24`, blocking 3 Dependabot
+alerts that can't be fixed any other way. Moving gimie out of our Python process
+into a sidecar HTTP service (`ghcr.io/sdsc-ordes/gimie-api`) lets us **drop
+`gimie` from `pyproject.toml`** entirely, freeing those transitive pins — and
+decouples a heavy, rarely-updated dependency from our tree.
+
+## What gimie-api gives us (verified from `sdsc-ordes/gimie-api`)
+- `GET /gimie/jsonld/{full_path:path}` → `{"link": <url>, "output": "<json-ld string>"}`.
+  Internally `Project(full_path).extract().serialize(format='json-ld')` — i.e.
+  **identical to our `extract_gimie`** (same gimie 0.7.2), except `output` is the
+  serialized JSON-LD **string** (we already `json.loads` that string today).
+- Also `/gimie/ttl/{path}` and `/`. Listens on **:15400** (uvicorn). GitHub token
+  via env **`ACCESS_TOKEN`**.
+- ⚠️ **Error contract:** on failure it returns **HTTP 200** with `output` set to
+  the *error message string* (not valid JSON-LD, no error status). The client
+  MUST detect this.
+
+## Current seam (what we swap)
+- `src/v1/gimie_utils/gimie_methods.py::extract_gimie(full_path, fmt)` →
+  `json.loads(Project(full_path).extract().serialize("json-ld"))`. The single
+  Project-based entry point.
+- v2: `RealGitHubProvider._resolve_gimie_extractor()` lazy-imports `extract_gimie`
+  and stores it as `self._gimie_extractor` (a `(url, fmt) -> dict` callable). The
+  provider consumes the JSON-LD `@graph`.
+- v1: `src/v1/analysis/repositories.py::run_gimie_analysis` calls `extract_gimie`.
+- ⚠️ **Deeper imports:** `gimie_methods.py` also imports
+  `gimie.extractors.github.GithubExtractor` and `gimie.parsers.cff.CffParser`
+  directly. To fully drop the `gimie` package these must also be removed/replaced
+  — see Phase 3.
+
+## Phase 1 — Spike & parity test (no production change, low risk)
+Goal: prove the API path returns byte-for-parity JSON-LD vs in-process gimie.
+
+1. Add a **dev-only** `gme-gimie-api` service to `.devcontainer/docker-compose.yml`
+   (mirror `gme-qdrant`/`gme-selenium-firefox`): image
+   `ghcr.io/sdsc-ordes/gimie-api@<digest>` (pin a digest, not `:latest`),
+   `networks: [dev]`, `environment: { ACCESS_TOKEN: ${GME_GITHUB_TOKEN} }`,
+   no host port needed (internal `http://gme-gimie-api:15400`).
+2. Add a thin client `extract_gimie_via_api(full_path, fmt="json-ld")` (new module,
+   e.g. `src/v2/ingest/providers/gimie_api_client.py`):
+   - `GET {GIMIE_API_URL}/gimie/jsonld/{full_path}` (full_path is the repo URL with
+     scheme — the `:path` converter handles `https://…`). Generous timeout
+     (gimie extraction is slow: 30–120s) + bounded retry, mirroring the existing
+     `_run_with_rate_limit` / malformed-JSON retry.
+   - Parse: `payload = resp.json(); out = json.loads(payload["output"])`. If
+     `payload["output"]` is not valid JSON / lacks `@graph` → treat as failure
+     (the HTTP-200-error gotcha) and return `None`/`{}` exactly like the current
+     extractor degrades.
+3. **Parity harness** (throwaway script): for ~10 diverse repos, call both
+   `extract_gimie` (in-process) and `extract_gimie_via_api`, normalise (sort
+   `@graph` by `@id`) and diff. Expect zero semantic diff (same gimie version).
+   Record any differences (ordering, blank-node ids).
+
+Exit criteria: parity confirmed on the sample; client handles the error contract.
+
+## Phase 2 — Wire behind a flag (opt-in)
+- Gate the seam in `RealGitHubProvider._resolve_gimie_extractor()`: if
+  `GIMIE_API_URL` is set → use `extract_gimie_via_api`; else keep the in-process
+  `extract_gimie` (default, unchanged). Same for the v1 caller.
+- Add `gme-gimie-api` to the **deploy** compose / k8s (wherever `gme-qdrant` is
+  provisioned in prod — confirm with ops; the repo ships only the dev compose and
+  the app image, so the production manifest lives outside this repo).
+- Run the full `tests/v2` gate with the flag both off (unchanged) and on
+  (client mocked — no real sidecar in CI). Add unit tests for
+  `extract_gimie_via_api` (success, error-string-as-200, timeout) with a fake
+  session, mirroring the registry-provider tests.
+- Soak in dev/staging with `GIMIE_API_URL` pointed at the sidecar.
+
+## Phase 3 — Drop the dependency (the actual win)
+Once the API path is proven in prod:
+1. Replace the remaining **direct gimie imports** in
+   `src/v1/gimie_utils/gimie_methods.py` (`GithubExtractor`, `CffParser`) — either
+   route them through the API too, or move that CFF parsing to our own
+   `src/v2/parsers/citation_cff.py` (which already exists). Audit every
+   `import gimie` / `from gimie` site (Phase-0 grep found them in v1 only).
+2. Remove `"gimie==0.7.2"` from `pyproject.toml` `dependencies`. Make the
+   in-process `extract_gimie` import gimie lazily and raise a clear error if
+   `GIMIE_API_URL` is unset and gimie isn't installed (so the fallback degrades
+   gracefully rather than ImportError at module load).
+3. `uv lock` → `python-dotenv` and `marshmallow` are now free to upgrade. Bump
+   them (`python-dotenv>=1.2.2`, and let `marshmallow` resolve to ≥3.26.2) →
+   the 3 remaining Dependabot alerts clear.
+4. Full `tests/v2` + `tests/index` gate.
+
+## Risks & open questions
+- **Latency / availability:** every repo extraction is now a network round-trip to
+  a slow service. Need a sane timeout + retry, and a **fallback** when the sidecar
+  is down (degrade to empty gimie payload, like today's error path — the v2
+  pipeline already tolerates an empty gimie graph).
+- **Token:** gimie-api reads `ACCESS_TOKEN`; map our `GME_GITHUB_TOKEN` to it in
+  compose. (No token pooling/rotation inside the sidecar — single token.)
+- **Image pinning:** pin `gimie-api` by digest; `:latest` is gimie 0.7.2 today but
+  could drift.
+- **Prod topology:** the production deployment compose/k8s is not in this repo —
+  Phase 2 needs an ops change to run the sidecar alongside the API.
+- **v1 surface:** v1 still imports gimie submodules directly; Phase 3 must cover
+  those or the package can't be removed.
+- **Parity:** same gimie version ⇒ expected identical output, but blank-node ids
+  and `@graph` ordering may differ run-to-run — normalise before diffing and in
+  any downstream assumptions.
+
+## Payoff
+- Drops `gimie` + `calamus` from the dependency tree → unblocks the last 3
+  Dependabot alerts (`python-dotenv`, `marshmallow`).
+- Decouples a heavy, single-release, rarely-updated dependency; gimie upgrades
+  become a sidecar image bump, not a Python re-resolve.

--- a/scripts/v2/gimie_api_parity.py
+++ b/scripts/v2/gimie_api_parity.py
@@ -1,0 +1,89 @@
+# ruff: noqa: INP001
+"""Phase-1 parity harness: in-process gimie vs the gimie-api sidecar.
+
+Runs both extractors on a set of repos and diffs the JSON-LD `@graph` (normalised
+by `@id`). Same gimie version on both sides ⇒ expect zero semantic diff.
+
+Prereqs:
+  - the sidecar running and reachable, e.g.:
+      docker compose -f .devcontainer/docker-compose.yml up -d gme-gimie-api
+  - GIMIE_API_URL set, e.g. GIMIE_API_URL=http://localhost:7000
+  - GME_GITHUB_TOKEN exported (the sidecar reads ACCESS_TOKEN; this process uses
+    in-process gimie which reads the usual token env).
+
+Usage:
+  GIMIE_API_URL=http://localhost:7000 python scripts/v2/gimie_api_parity.py \
+      sdsc-ordes/gimie CSBDeep/CSBDeep psf/requests
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+from src.v1.gimie_utils.gimie_methods import extract_gimie
+from src.v2.ingest.providers.gimie_api_client import (
+    extract_gimie_via_api,
+    gimie_api_base,
+)
+
+_DEFAULT_REPOS = ["sdsc-ordes/gimie", "CSBDeep/CSBDeep", "psf/requests"]
+
+
+def _nodes_by_id(payload: Any) -> dict[str, Any]:
+    graph = payload.get("@graph") if isinstance(payload, dict) else payload
+    if not isinstance(graph, list):
+        return {}
+    out: dict[str, Any] = {}
+    for node in graph:
+        if isinstance(node, dict):
+            out[str(node.get("@id", f"_blank_{len(out)}"))] = node
+    return out
+
+
+def _diff(a: Any, b: Any) -> list[str]:
+    ai, bi = _nodes_by_id(a), _nodes_by_id(b)
+    msgs: list[str] = []
+    only_a = sorted(set(ai) - set(bi))
+    only_b = sorted(set(bi) - set(ai))
+    if only_a:
+        msgs.append(f"  only in-process: {only_a}")
+    if only_b:
+        msgs.append(f"  only api:        {only_b}")
+    msgs.extend(
+        f"  differs: {key}"
+        for key in sorted(set(ai) & set(bi))
+        if json.dumps(ai[key], sort_keys=True) != json.dumps(bi[key], sort_keys=True)
+    )
+    return msgs
+
+
+def main(repos: list[str]) -> int:
+    if gimie_api_base() is None:
+        print("ERROR: set GIMIE_API_URL to the sidecar, e.g. http://localhost:7000")
+        return 2
+    full = 0
+    for repo in repos:
+        url = repo if repo.startswith("http") else f"https://github.com/{repo}"
+        print(f"\n=== {url} ===")
+        in_proc = extract_gimie(url)
+        via_api = extract_gimie_via_api(url)
+        if via_api is None:
+            print("  API returned None (sidecar error/timeout) — investigate")
+            continue
+        diffs = _diff(in_proc, via_api)
+        if diffs:
+            print(f"  {len(diffs)} difference(s):")
+            print("\n".join(diffs))
+        else:
+            full += 1
+            print("  PARITY ✓ (identical @graph)")
+    print(f"\n{full}/{len(repos)} fully identical")
+    return 0
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:] or _DEFAULT_REPOS
+    os.environ.setdefault("GIMIE_API_URL", os.getenv("GIMIE_API_URL", ""))
+    raise SystemExit(main(args))

--- a/src/v2/ingest/providers/gimie_api_client.py
+++ b/src/v2/ingest/providers/gimie_api_client.py
@@ -1,0 +1,117 @@
+"""HTTP client for the ``gimie-api`` sidecar (``ghcr.io/sdsc-ordes/gimie-api``).
+
+A drop-in replacement for the in-process ``extract_gimie`` that calls a sidecar
+service running the same gimie version, so the heavy ``gimie`` (+ ``calamus``)
+dependency can eventually leave this project's Python tree. Enabled by setting
+``GIMIE_API_URL`` (e.g. ``http://gme-gimie-api:15400``); when unset, callers fall
+back to in-process gimie.
+
+The sidecar's ``GET /gimie/jsonld/{full_path}`` returns
+``{"link": <url>, "output": "<json-ld string>"}``. NOTE its error contract:
+failures come back as **HTTP 200** with ``output`` set to the error *message*
+(not valid JSON), so we validate that ``output`` parses to JSON-LD and return
+``None`` otherwise — matching the in-process extractor's degrade-to-None
+behaviour.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_HTTP_OK = 200
+_DEFAULT_TIMEOUT_SECONDS = 180.0  # gimie extraction is slow (many GitHub calls).
+_ERROR_OUTPUT_PREVIEW = 200
+
+
+def gimie_api_base() -> str | None:
+    """Return the configured gimie-api base URL (no trailing slash), or None
+    when ``GIMIE_API_URL`` is unset/blank (→ callers use in-process gimie)."""
+    base = os.getenv("GIMIE_API_URL", "").strip()
+    return base.rstrip("/") or None
+
+
+def _timeout() -> float:
+    raw = os.getenv("GIMIE_API_TIMEOUT_SECONDS", "").strip()
+    try:
+        return float(raw) if raw else _DEFAULT_TIMEOUT_SECONDS
+    except ValueError:
+        return _DEFAULT_TIMEOUT_SECONDS
+
+
+def extract_gimie_via_api(  # noqa: PLR0911 — guard-heavy network fetch; flat returns read clearer
+    full_path: str,
+    serialization_format: str = "json-ld",
+    *,
+    session: Any = None,
+) -> Any:
+    """Fetch a repo's gimie JSON-LD from the gimie-api sidecar.
+
+    Signature-compatible with ``src.v1.gimie_utils.gimie_methods.extract_gimie``:
+    returns the parsed JSON-LD (``dict`` with ``@graph`` / ``@context``) for
+    ``serialization_format="json-ld"``, the TTL string for ``"ttl"``, or ``None``
+    on any failure (sidecar down, non-200, the HTTP-200 error contract, or a
+    response that doesn't parse to JSON-LD).
+    """
+    base = gimie_api_base()
+    if base is None:
+        return None
+    http = session if session is not None else requests
+    kind = "ttl" if serialization_format == "ttl" else "jsonld"
+    url = f"{base}/gimie/{kind}/{full_path}"
+
+    try:
+        resp = http.get(url, timeout=_timeout())
+    except Exception:  # noqa: BLE001 — best-effort; degrade to None like in-process.
+        logger.warning("gimie-api request failed: %s", full_path)
+        return None
+
+    if getattr(resp, "status_code", None) != _HTTP_OK:
+        logger.warning(
+            "gimie-api returned %s for %s",
+            getattr(resp, "status_code", "?"), full_path,
+        )
+        return None
+
+    try:
+        payload = resp.json()
+    except ValueError:
+        logger.warning("gimie-api response was not JSON: %s", full_path)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    output = payload.get("output")
+
+    if serialization_format == "ttl":
+        return output if isinstance(output, str) and output.strip() else None
+    return _parse_jsonld_output(output, full_path)
+
+
+def _parse_jsonld_output(output: Any, full_path: str) -> Any:
+    """Coerce the sidecar's ``output`` into parsed JSON-LD, or None.
+
+    ``output`` is normally the serialized JSON-LD *string*; we defensively accept
+    an already-parsed dict/list too. The sidecar's error path puts a plain error
+    message here, which won't parse → None.
+    """
+    if isinstance(output, (dict, list)):
+        return output
+    if not isinstance(output, str) or not output.strip():
+        return None
+    try:
+        parsed = json.loads(output)
+    except ValueError:
+        logger.warning(
+            "gimie-api returned a non-JSON output for %s (likely an error): %.*s",
+            full_path, _ERROR_OUTPUT_PREVIEW, output,
+        )
+        return None
+    return parsed if isinstance(parsed, (dict, list)) else None
+
+
+__all__ = ["extract_gimie_via_api", "gimie_api_base"]

--- a/src/v2/ingest/providers/github_provider.py
+++ b/src/v2/ingest/providers/github_provider.py
@@ -497,6 +497,18 @@ class RealGitHubProvider(GitHubProvider):
     def _resolve_gimie_extractor(self) -> GimieExtractor:
         if self._gimie_extractor is not None:
             return self._gimie_extractor
+        # When GIMIE_API_URL is set, call the gimie-api sidecar over HTTP
+        # instead of running gimie in-process (lets the `gimie` dependency
+        # eventually leave our tree). Unset → in-process gimie (default).
+        from src.v2.ingest.providers.gimie_api_client import (  # noqa: PLC0415
+            extract_gimie_via_api,
+            gimie_api_base,
+        )
+
+        if gimie_api_base() is not None:
+            self._gimie_extractor = extract_gimie_via_api
+            return extract_gimie_via_api
+
         from src.v1.gimie_utils.gimie_methods import extract_gimie  # noqa: PLC0415
 
         self._gimie_extractor = extract_gimie

--- a/tests/v2/test_gimie_api_client.py
+++ b/tests/v2/test_gimie_api_client.py
@@ -1,0 +1,141 @@
+"""Tests for the gimie-api sidecar client + the provider seam.
+
+No real network — a fake session is injected, and env is monkeypatched.
+"""
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from src.v1.gimie_utils.gimie_methods import extract_gimie
+from src.v2.ingest.providers.gimie_api_client import (
+    extract_gimie_via_api,
+    gimie_api_base,
+)
+from src.v2.ingest.providers.github_provider import RealGitHubProvider
+
+if TYPE_CHECKING:
+    import pytest
+
+_JSONLD = {
+    "@context": {"schema": "https://schema.org/"},
+    "@graph": [{"@id": "https://github.com/acme/tool", "@type": "schema:SoftwareSourceCode"}],
+}
+_BASE = "http://gme-gimie-api:15400"
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        if isinstance(self._payload, ValueError):
+            raise self._payload
+        return self._payload
+
+
+class _FakeSession:
+    def __init__(self, resp: Any) -> None:
+        self._resp = resp
+        self.urls: list[str] = []
+
+    def get(self, url: str, timeout: float | None = None) -> Any:  # noqa: ARG002
+        self.urls.append(url)
+        if isinstance(self._resp, Exception):
+            raise self._resp
+        return self._resp
+
+
+def _enable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GIMIE_API_URL", _BASE)
+
+
+# ---------------------------------------------------------------------------
+# gimie_api_base
+# ---------------------------------------------------------------------------
+
+
+def test_gimie_api_base_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GIMIE_API_URL", raising=False)
+    assert gimie_api_base() is None
+
+
+def test_gimie_api_base_strips_trailing_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GIMIE_API_URL", _BASE + "/")
+    assert gimie_api_base() == _BASE
+
+
+# ---------------------------------------------------------------------------
+# extract_gimie_via_api
+# ---------------------------------------------------------------------------
+
+
+def test_extract_unset_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GIMIE_API_URL", raising=False)
+    assert extract_gimie_via_api("https://github.com/acme/tool", session=object()) is None
+
+
+def test_extract_success_parses_output_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(monkeypatch)
+    session = _FakeSession(_FakeResp(200, {"link": "x", "output": json.dumps(_JSONLD)}))
+    out = extract_gimie_via_api("https://github.com/acme/tool", session=session)
+    assert out == _JSONLD
+    assert session.urls == [f"{_BASE}/gimie/jsonld/https://github.com/acme/tool"]
+
+
+def test_extract_accepts_already_parsed_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(monkeypatch)
+    session = _FakeSession(_FakeResp(200, {"output": _JSONLD}))
+    assert extract_gimie_via_api("https://github.com/acme/tool", session=session) == _JSONLD
+
+
+def test_extract_error_string_as_http_200_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # gimie-api's error contract: HTTP 200 with `output` = an error message.
+    _enable(monkeypatch)
+    session = _FakeSession(_FakeResp(200, {"output": "Exception: repo not found"}))
+    assert extract_gimie_via_api("https://github.com/acme/missing", session=session) is None
+
+
+def test_extract_non_200_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(monkeypatch)
+    session = _FakeSession(_FakeResp(500, None))
+    assert extract_gimie_via_api("https://github.com/acme/tool", session=session) is None
+
+
+def test_extract_transport_error_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(monkeypatch)
+    session = _FakeSession(TimeoutError("boom"))
+    assert extract_gimie_via_api("https://github.com/acme/tool", session=session) is None
+
+
+def test_extract_ttl_returns_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(monkeypatch)
+    session = _FakeSession(_FakeResp(200, {"output": "@prefix schema: <...> ."}))
+    out = extract_gimie_via_api("https://github.com/acme/tool", "ttl", session=session)
+    assert out == "@prefix schema: <...> ."
+    assert session.urls == [f"{_BASE}/gimie/ttl/https://github.com/acme/tool"]
+
+
+# ---------------------------------------------------------------------------
+# provider seam — GIMIE_API_URL flips the resolved extractor
+# ---------------------------------------------------------------------------
+
+
+def test_seam_uses_api_client_when_url_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(monkeypatch)
+    provider = RealGitHubProvider()
+    assert provider._resolve_gimie_extractor() is extract_gimie_via_api  # noqa: SLF001
+
+
+def test_seam_uses_in_process_when_url_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GIMIE_API_URL", raising=False)
+    provider = RealGitHubProvider()
+    assert provider._resolve_gimie_extractor() is extract_gimie  # noqa: SLF001
+
+
+def test_seam_explicit_extractor_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(monkeypatch)
+    sentinel = object()
+    provider = RealGitHubProvider(gimie_extractor=sentinel)  # type: ignore[arg-type]
+    assert provider._resolve_gimie_extractor() is sentinel  # noqa: SLF001


### PR DESCRIPTION
Phase 1 of moving **gimie out-of-process** so the `gimie`/`calamus` dependency — which pins `python-dotenv<0.22` + `marshmallow<3.24` (the last 3 Dependabot alerts that can't otherwise be fixed; `gimie 0.7.2` is the only release) — can eventually leave our Python tree. Full plan in `docs/superpowers/specs/2026-06-07-gimie-api-sidecar-plan.md`.

**No default behavior change** — in-process gimie stays the default; the sidecar is used only when `GIMIE_API_URL` is set. Safe to land and validate before any cutover.

## What's here
- **`gimie_api_client.py`** — `extract_gimie_via_api(full_path, fmt)`: calls the sidecar's `GET /gimie/jsonld/{path}`, parses the serialized `output` string, and handles its **error contract** (failures come back as **HTTP 200** with an error message in `output`) by degrading to `None`, exactly like in-process gimie. Timeout via `GIMIE_API_TIMEOUT_SECONDS` (default 180s).
- **Provider seam** — `_resolve_gimie_extractor()`: `GIMIE_API_URL` set → HTTP client; unset → in-process `extract_gimie` (unchanged). Explicitly-injected extractors still win.
- **Dev compose** — opt-in `gme-gimie-api` sidecar (`ghcr.io/sdsc-ordes/gimie-api`, `:15400`, `ACCESS_TOKEN` ← `GME_GITHUB_TOKEN`).
- **Parity harness** — `scripts/v2/gimie_api_parity.py` diffs in-process vs API JSON-LD `@graph` (run with the sidecar up; same gimie version ⇒ expect zero diff).

## Tests
`tests/v2/test_gimie_api_client.py` (12): success, the HTTP-200-error contract, non-200, transport error, TTL, env gating, and the provider seam (URL set → API client; unset → in-process; explicit injection wins). Full `tests/v2` green (**1629 passed**); new files ruff-clean.

## Next (separate PRs, per the plan)
2. Flag-on soak in staging + add sidecar to the prod deploy. 3. Replace the deeper v1 gimie submodule imports, drop `gimie` from `pyproject.toml`, bump `python-dotenv`/`marshmallow` → last 3 alerts clear.

> I couldn't run the live parity test here (no Docker in the sandbox) — that's the first thing to run once the sidecar is up.