### PR TITLE
refactor(gimie): single API-aware intermediate + lazy gimie (Phase 2)

### DIFF
--- a/scripts/v2/gimie_api_parity.py
+++ b/scripts/v2/gimie_api_parity.py
@@ -31,6 +31,17 @@ from src.v2.ingest.providers.gimie_api_client import (
 _DEFAULT_REPOS = ["sdsc-ordes/gimie", "CSBDeep/CSBDeep", "psf/requests"]
 
 
+def _canon(x: Any) -> Any:
+    """Canonicalise for order-insensitive comparison — gimie does not stably
+    order list values (e.g. the author/contributor list), and those are sets of
+    `@id` references where order carries no meaning."""
+    if isinstance(x, dict):
+        return {k: _canon(v) for k, v in sorted(x.items())}
+    if isinstance(x, list):
+        return sorted((_canon(i) for i in x), key=lambda v: json.dumps(v, sort_keys=True))
+    return x
+
+
 def _nodes_by_id(payload: Any) -> dict[str, Any]:
     graph = payload.get("@graph") if isinstance(payload, dict) else payload
     if not isinstance(graph, list):
@@ -38,7 +49,7 @@ def _nodes_by_id(payload: Any) -> dict[str, Any]:
     out: dict[str, Any] = {}
     for node in graph:
         if isinstance(node, dict):
-            out[str(node.get("@id", f"_blank_{len(out)}"))] = node
+            out[str(node.get("@id", f"_blank_{len(out)}"))] = _canon(node)
     return out
 
 
@@ -67,7 +78,14 @@ def main(repos: list[str]) -> int:
     for repo in repos:
         url = repo if repo.startswith("http") else f"https://github.com/{repo}"
         print(f"\n=== {url} ===")
-        in_proc = extract_gimie(url)
+        # `extract_gimie` now routes to the sidecar when GIMIE_API_URL is set, so
+        # force the in-process side by clearing it just for that call.
+        saved = os.environ.pop("GIMIE_API_URL", None)
+        try:
+            in_proc = extract_gimie(url)
+        finally:
+            if saved is not None:
+                os.environ["GIMIE_API_URL"] = saved
         via_api = extract_gimie_via_api(url)
         if via_api is None:
             print("  API returned None (sidecar error/timeout) — investigate")

--- a/src/v1/gimie_utils/gimie_methods.py
+++ b/src/v1/gimie_utils/gimie_methods.py
@@ -28,13 +28,11 @@ import json
 import logging
 import os
 import re
+from functools import cache
 from http import HTTPStatus
 from typing import Any
 
-import gimie.extractors.github as gimie_github
 import requests
-from gimie.extractors.github import GithubExtractor
-from gimie.parsers.cff import CffParser
 
 logger = logging.getLogger(__name__)
 
@@ -131,51 +129,75 @@ def _normalize_cff_calendar_dates(data: bytes) -> bytes:
     return new_text.encode("utf-8")
 
 
-_original_cff_parse = CffParser.parse
+# gimie is imported LAZILY (below) so this module loads even when the `gimie`
+# package isn't installed — the in-process path is only one of two backends
+# (the other is the gimie-api sidecar, selected by GIMIE_API_URL). Our gimie
+# monkeypatches (CFF-date normalisation + GitHub 204/empty-repo resilience) are
+# applied once on first in-process use (the @cache on `_ensure_gimie_project`
+# guarantees once-only).
 
 
-def _patched_cff_parse(self: CffParser, data: bytes) -> Any:
-    return _original_cff_parse(self, _normalize_cff_calendar_dates(data))
+def _apply_gimie_patches() -> None:
+    """Apply our CFF-date + GitHub-resilience monkeypatches to gimie."""
+    import gimie.extractors.github as gimie_github  # noqa: PLC0415
+    from gimie.extractors.github import GithubExtractor  # noqa: PLC0415
+    from gimie.parsers.cff import CffParser  # noqa: PLC0415
+
+    _original_cff_parse = CffParser.parse
+
+    def _patched_cff_parse(self: Any, data: bytes) -> Any:
+        return _original_cff_parse(self, _normalize_cff_calendar_dates(data))
+
+    CffParser.parse = _patched_cff_parse  # type: ignore[method-assign]
+
+    _original_send_rest_query = gimie_github.send_rest_query
+
+    def _patched_send_rest_query(
+        api: str, query: str, headers: dict[str, str],
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Treat GitHub 204 (empty body) as an empty JSON list (no contributors)."""
+        resp = requests.get(url=f"{api}/{query}", headers=headers, timeout=30)
+        if resp.status_code == HTTPStatus.NO_CONTENT:
+            return []
+        return _original_send_rest_query(api, query, headers)
+
+    _original_list_files = GithubExtractor.list_files
+
+    def _patched_list_files(self: Any) -> Any:
+        """Skip file listing when the repo has no ``HEAD`` tree (empty repo)."""
+        repo = self._repo_data
+        obj = repo.get("object") if isinstance(repo, dict) else None
+        if obj is None:
+            logger.info(
+                "GIMIE: repository has no HEAD tree (empty repo); skipping file parsers",
+            )
+            return []
+        return _original_list_files(self)
+
+    gimie_github.send_rest_query = _patched_send_rest_query
+    GithubExtractor.list_files = _patched_list_files  # type: ignore[method-assign]
 
 
-CffParser.parse = _patched_cff_parse  # type: ignore[method-assign]
+@cache
+def _ensure_gimie_project() -> Any:
+    """Lazily import gimie (applying our patches once) and return ``Project``.
 
-_original_send_rest_query = gimie_github.send_rest_query
-_original_list_files = GithubExtractor.list_files
-
-
-def _patched_send_rest_query(
-    api: str,
-    query: str,
-    headers: dict[str, str],
-) -> list[dict[str, Any]] | dict[str, Any]:
-    """Treat GitHub 204 (empty body) as an empty JSON list (e.g. no contributors)."""
-    resp = requests.get(
-        url=f"{api}/{query}",
-        headers=headers,
-        timeout=30,
-    )
-    if resp.status_code == HTTPStatus.NO_CONTENT:
-        return []
-    return _original_send_rest_query(api, query, headers)
-
-
-def _patched_list_files(self: GithubExtractor):
-    """Skip file listing when the repo has no ``HEAD`` tree (empty GitHub repo)."""
-    repo = self._repo_data
-    obj = repo.get("object") if isinstance(repo, dict) else None
-    if obj is None:
-        logger.info(
-            "GIMIE: repository has no HEAD tree (empty repo); skipping file parsers",
+    Raises ``RuntimeError`` with actionable guidance when ``gimie`` isn't
+    installed — the deployment is expected to set ``GIMIE_API_URL`` (sidecar)
+    instead of running gimie in-process. ``@cache`` makes the import + patches
+    run exactly once.
+    """
+    try:
+        _apply_gimie_patches()
+        from gimie.project import Project  # noqa: PLC0415
+    except ImportError as exc:
+        message = (
+            "in-process gimie extraction requires the `gimie` package, which is "
+            "not installed. Set GIMIE_API_URL to use the gimie-api sidecar, or "
+            "`pip install gimie==0.7.2` for in-process extraction."
         )
-        return []
-    return _original_list_files(self)
-
-
-gimie_github.send_rest_query = _patched_send_rest_query
-GithubExtractor.list_files = _patched_list_files
-
-from gimie.project import Project  # noqa: E402  # import after monkeypatches
+        raise RuntimeError(message) from exc
+    return Project
 
 
 def _first_non_empty_token(raw: str) -> str | None:
@@ -214,20 +236,33 @@ def _gimie_legacy_github_token_env():
 
 
 def extract_gimie(full_path: str, serialization_format: str = "json-ld"):
-    """
-    Extracts the GIMIE project from the given URL.
+    """Extract a repo's GIMIE metadata — via the gimie-api sidecar when
+    ``GIMIE_API_URL`` is set, otherwise in-process gimie.
+
+    This is the single **intermediate** every caller (v1 + v2) goes through, so
+    the in-process gimie dependency can be swapped for the sidecar in one place.
+    When the sidecar is configured it is authoritative (returns ``None`` on its
+    own failure, matching the in-process degrade path); there is no silent
+    in-process fallback (the sidecar exists precisely so gimie can leave the
+    Python tree).
 
     Args:
-        full_path (str): The full path to the URL.
-        serialization_format (str): Serialize graph as ``json-ld`` (default) or ``ttl``.
-
-    Returns:
-        Project: The GIMIE project object.
+        full_path (str): The repository URL.
+        serialization_format (str): ``json-ld`` (default) or ``ttl``.
     """
-    logger.info(f"Extracting GIMIE metadata for: {full_path}")
+    # Prefer the sidecar when configured (no gimie import needed on this path).
+    from src.v2.ingest.providers.gimie_api_client import (  # noqa: PLC0415
+        extract_gimie_via_api,
+        gimie_api_base,
+    )
 
+    if gimie_api_base() is not None:
+        return extract_gimie_via_api(full_path, serialization_format)
+
+    logger.info("Extracting GIMIE metadata (in-process) for: %s", full_path)
+    project_cls = _ensure_gimie_project()
     with _gimie_legacy_github_token_env():
-        proj = Project(full_path)
+        proj = project_cls(full_path)
         g = proj.extract()
 
     if serialization_format == "json-ld":

--- a/src/v2/ingest/providers/github_provider.py
+++ b/src/v2/ingest/providers/github_provider.py
@@ -497,18 +497,9 @@ class RealGitHubProvider(GitHubProvider):
     def _resolve_gimie_extractor(self) -> GimieExtractor:
         if self._gimie_extractor is not None:
             return self._gimie_extractor
-        # When GIMIE_API_URL is set, call the gimie-api sidecar over HTTP
-        # instead of running gimie in-process (lets the `gimie` dependency
-        # eventually leave our tree). Unset → in-process gimie (default).
-        from src.v2.ingest.providers.gimie_api_client import (  # noqa: PLC0415
-            extract_gimie_via_api,
-            gimie_api_base,
-        )
-
-        if gimie_api_base() is not None:
-            self._gimie_extractor = extract_gimie_via_api
-            return extract_gimie_via_api
-
+        # `extract_gimie` is the single intermediate: it calls the gimie-api
+        # sidecar when GIMIE_API_URL is set, else in-process gimie. Routing lives
+        # there so v1 and v2 share one path (and gimie can leave our tree).
         from src.v1.gimie_utils.gimie_methods import extract_gimie  # noqa: PLC0415
 
         self._gimie_extractor = extract_gimie

--- a/tests/v2/test_gimie_api_client.py
+++ b/tests/v2/test_gimie_api_client.py
@@ -118,20 +118,29 @@ def test_extract_ttl_returns_string(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# provider seam — GIMIE_API_URL flips the resolved extractor
+# provider seam + the extract_gimie intermediate
 # ---------------------------------------------------------------------------
 
 
-def test_seam_uses_api_client_when_url_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    _enable(monkeypatch)
-    provider = RealGitHubProvider()
-    assert provider._resolve_gimie_extractor() is extract_gimie_via_api  # noqa: SLF001
-
-
-def test_seam_uses_in_process_when_url_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_seam_returns_intermediate(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The seam always resolves to the single `extract_gimie` intermediate;
+    # API-vs-in-process routing happens inside it (next test).
     monkeypatch.delenv("GIMIE_API_URL", raising=False)
-    provider = RealGitHubProvider()
-    assert provider._resolve_gimie_extractor() is extract_gimie  # noqa: SLF001
+    assert RealGitHubProvider()._resolve_gimie_extractor() is extract_gimie  # noqa: SLF001
+    _enable(monkeypatch)
+    assert RealGitHubProvider()._resolve_gimie_extractor() is extract_gimie  # noqa: SLF001
+
+
+def test_intermediate_routes_to_api_when_url_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    # With GIMIE_API_URL set, extract_gimie delegates to the sidecar client and
+    # never touches in-process gimie.
+    _enable(monkeypatch)
+    sentinel = {"@graph": []}
+    monkeypatch.setattr(
+        "src.v2.ingest.providers.gimie_api_client.extract_gimie_via_api",
+        lambda full_path, fmt="json-ld": sentinel,  # noqa: ARG005
+    )
+    assert extract_gimie("https://github.com/acme/tool") is sentinel
 
 
 def test_seam_explicit_extractor_wins(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Phase 2 of the gimie-sidecar work (after #148). Makes `extract_gimie` the **single intermediate** every caller (v1 + v2) routes through, and makes gimie imports **lazy** — the prerequisite for dropping the dependency.

## Changes
- **One intermediate** — `extract_gimie` calls the gimie-api sidecar when `GIMIE_API_URL` is set, else in-process gimie (the sidecar is authoritative when configured — no silent in-process fallback). The v2 provider seam now just returns this intermediate.
- **Lazy gimie** — the module's load-time monkeypatches (CFF-date normalisation + GitHub-204/empty-repo resilience) moved into a `@cache`'d `_ensure_gimie_project()`, applied once on first in-process use. `gimie_methods` now imports fine **even when `gimie` is not installed**; a clear `RuntimeError` (set `GIMIE_API_URL` / `pip install gimie`) is raised only if in-process extraction is actually attempted without it.

## Validated end-to-end
Ran the **real `gimie-api` app locally** (same gimie 0.7.2) and diffed it against in-process gimie via the parity harness:
- `sdsc-ordes/gimie`, `CSBDeep/CSBDeep`, `numpy/numpy` → **exact order-insensitive parity** (identical `@id` set + author sets). The only raw difference was gimie's unstable author/contributor list *ordering* — semantically irrelevant (sets of `@id` refs). Harness updated to canonicalise list order.

## Safety
**No default behavior change** — `GIMIE_API_URL` unset → in-process gimie, exactly as before. Full `tests/v2` green (**1629**); ruff-clean.

Next (#3): drop `gimie` from `pyproject.toml`, re-lock, bump `python-dotenv`/`marshmallow` → the last 3 Dependabot alerts clear. (That makes the sidecar mandatory in prod, so it lands once ops provisions `gme-gimie-api` + sets `GIMIE_API_URL`.)