### PR TITLE
chore(compose): wire gimie-api sidecar into the dev stack (digest-pinned) + prod snippet

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,6 +21,10 @@ services:
       # Avoid ~/.cache/uv (often root-owned after sshd/common-utils); workspace is bind-mounted as vscode.
       UV_CACHE_DIR: /workspaces/project/.uv-cache
       SELENIUM_REMOTE_URL: ${SELENIUM_REMOTE_URL:-http://gme-selenium-firefox:4444}
+      # GIMIE runs as the gme-gimie-api sidecar (the `gimie` Python dep was
+      # removed). Required for repository extraction — unset → in-process gimie,
+      # which is no longer installed (RuntimeError). Mirror this in prod.
+      GIMIE_API_URL: ${GIMIE_API_URL:-http://gme-gimie-api:15400}
     ports:
       - "${SSH_PORT:-2222}:2222"
       - "${APP_PORT:-1234}:1234"
@@ -55,13 +59,16 @@ services:
     restart: unless-stopped
     networks:
       - dev
-  # gimie-api sidecar (Phase 1 spike): runs gimie out-of-process so the v2
-  # provider can call it over HTTP instead of importing gimie. OPT-IN — the app
-  # uses it only when `GIMIE_API_URL=http://gme-gimie-api:15400` is set (left
-  # unset by default, so in-process gimie stays the default). Pin a digest for
-  # reproducibility before relying on it in CI/prod.
+  # gimie-api sidecar: runs gimie out-of-process so the app calls it over HTTP
+  # (the `gimie` Python dependency was removed — see OPERATIONS_RUNBOOK §8). The
+  # app reaches it via GIMIE_API_URL (set on the devcontainer above). REQUIRED
+  # for repository extraction; mirror this service in the production deploy.
+  #
+  # Image pinned by digest for reproducibility (== :latest resolved 2026-06-07,
+  # gimie 0.7.2). Re-resolve + re-validate with scripts/v2/gimie_api_parity.py
+  # when bumping. To follow the moving tag instead, set GIMIE_API_IMAGE=:latest.
   gme-gimie-api:
-    image: ghcr.io/sdsc-ordes/gimie-api:latest
+    image: ${GIMIE_API_IMAGE:-ghcr.io/sdsc-ordes/gimie-api@sha256:7a8a59b70d0787e1d265ff08f24328dd2d518f25dcc504b0420f8648ce99ecdb}
     container_name: gme-gimie-api
     environment:
       # gimie-api reads the GitHub token from ACCESS_TOKEN.

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -181,3 +181,33 @@ Behaviour:
 
 Pin the sidecar image by digest for reproducibility. Validate a new image with
 `scripts/v2/gimie_api_parity.py` (diffs sidecar vs in-process output).
+
+The dev stack (`.devcontainer/docker-compose.yml`) wires this already (the
+`gme-gimie-api` service + `GIMIE_API_URL` on the devcontainer, image pinned by
+digest). **Production compose/k8s — outside this repo — needs the equivalent.**
+Ready-to-copy compose service + app wiring:
+
+```yaml
+services:
+  gme-api:
+    image: ghcr.io/imaging-plaza/git-metadata-extractor:<tag>
+    environment:
+      GIMIE_API_URL: http://gme-gimie-api:15400
+    depends_on: [gme-gimie-api]
+    networks: [gme]
+
+  gme-gimie-api:
+    # pin by digest; == :latest resolved 2026-06-07 (gimie 0.7.2)
+    image: ghcr.io/sdsc-ordes/gimie-api@sha256:7a8a59b70d0787e1d265ff08f24328dd2d518f25dcc504b0420f8648ce99ecdb
+    environment:
+      ACCESS_TOKEN: ${GME_GITHUB_TOKEN}   # gimie-api reads the GitHub token here
+    restart: unless-stopped
+    networks: [gme]
+
+networks:
+  gme:
+```
+
+(For k8s: a `gimie-api` Deployment + Service on `:15400` with `ACCESS_TOKEN`
+from the GitHub-token secret, and `GIMIE_API_URL=http://gimie-api:15400` on the
+API Deployment.)


### PR DESCRIPTION
Follow-up to the gimie-sidecar migration (#148–#150). Now that `gimie` is removed and `GIMIE_API_URL` is required, this **wires the sidecar into our compose** and pins the image.

- **`.devcontainer/docker-compose.yml`**
  - `GIMIE_API_URL` set on the devcontainer (default `http://gme-gimie-api:15400`) — extraction needs it now that in-process gimie is gone.
  - `gme-gimie-api` image **pinned by digest** (`sha256:7a8a59b7…` = `:latest` resolved 2026-06-07, gimie 0.7.2; override via `GIMIE_API_IMAGE`). Refreshed the now-stale "opt-in / unset by default" comment.
- **OPERATIONS_RUNBOOK §8** — a ready-to-copy **production compose snippet** (app + `gme-gimie-api` on a shared network, `ACCESS_TOKEN` from the GitHub token) + a k8s note, since the production manifest lives outside this repo.

Image digest resolved via the GHCR registry API (no Docker in the sandbox). CI is unaffected — GitHub Actions doesn't run this compose. Both YAML docs validated as parseable.