### PR TITLE
docs: GIMIE sidecar (GIMIE_API_URL) + Runbook in nav + fix 4 broken links (unblocks --strict)

### DIFF
--- a/docs/epfl-graph-disciplines.md
+++ b/docs/epfl-graph-disciplines.md
@@ -77,7 +77,7 @@ python -m src.index.epfl_graph search "<query>" --top-k 10 --candidate-k 50 --mi
 
 ## Configuration
 
-Static settings live in [`config/index/epfl_graph.yaml`](../config/index/epfl_graph.yaml).
+Static settings live in [`config/index/epfl_graph.yaml`](https://github.com/Imaging-Plaza/git-metadata-extractor/blob/main/config/index/epfl_graph.yaml).
 The ones worth tuning per deployment:
 
 | Path | Default | Purpose |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,6 +61,12 @@ and `.env.example`):
   `ZENODO`, `ORCID`, `ROR`).
 - `INDEX_QDRANT_URL` — Qdrant endpoint. **Inside the devcontainer use
   `http://gme-qdrant:6333`**, not `localhost:6333`.
+- `GIMIE_API_URL` — **required for repository extraction.** GIMIE runs as the
+  `gme-gimie-api` sidecar (the `gimie` package was removed from the image); the
+  devcontainer compose sets this to `http://gme-gimie-api:15400` for you. Outside
+  the devcontainer, either point it at a running sidecar or `pip install
+  gimie==0.7.2` for in-process extraction. See
+  [operations runbook §8](OPERATIONS_RUNBOOK.md#8-gimie-now-runs-as-a-sidecar-gimie_api_url-is-required).
 
 ## 3. Run the API locally
 

--- a/docs/v2-api-reference.md
+++ b/docs/v2-api-reference.md
@@ -329,3 +329,5 @@ The most-touched knobs (full list in `.env.example` and `CLAUDE.md`):
 | `GME_GITHUB_TOKEN` | unset | Required for healthy provider preflight |
 | `RCP_TOKEN` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` | unset | At least one required in LLM mode |
 | `SELENIUM_REMOTE_URL` | unset | Enables link-veracity + the `fetch_link_content_via_selenium` tool |
+| `GIMIE_API_URL` | unset | **Required for repository extraction.** Points at the `gimie-api` sidecar (e.g. `http://gme-gimie-api:15400`); the `gimie` package was removed from the image. Unset → in-process gimie, which is no longer installed → `RuntimeError`. See [operations runbook §8](OPERATIONS_RUNBOOK.md#8-gimie-now-runs-as-a-sidecar-gimie_api_url-is-required). |
+| `GIMIE_API_TIMEOUT_SECONDS` | `180` | Per-request timeout for the gimie-api sidecar call. |

--- a/docs/v2-pipeline.md
+++ b/docs/v2-pipeline.md
@@ -2,7 +2,7 @@
 
 The v2 pipeline turns a GitHub URL into a JSON-LD graph aligned with [Open Pulse Ontology v2.1.2](https://open-pulse.epfl.ch/ontology). This doc is the operator-facing tour: what each stage does, what assumptions hold across the pipeline, and where to dig deeper.
 
-**Deep reference:** [`.internal/v2-pipeline-reference.md`](../.internal/v2-pipeline-reference.md) — every stage, every gate, every cache layer.
+**Deep reference:** `.internal/v2-pipeline-reference.md` (repo-internal) — every stage, every gate, every cache layer.
 
 ---
 
@@ -174,13 +174,13 @@ Both namespaces register in `@context` only when `include_internal_fields=true`,
 | `V2_LINK_VERACITY_ENABLED` | `false` | Stage 14 (Selenium + LLM URL verification). |
 | `V2_PIPELINE_CACHE_ENABLED` | `true` | Outer `/extract` cache. Set to `false` to force a fresh pipeline run. |
 
-Full list: [`.env.example`](../.env.example).
+Full list: [`.env.example`](https://github.com/Imaging-Plaza/git-metadata-extractor/blob/main/.env.example).
 
 ---
 
 ## Where to go next
 
-- **Per-stage detail** → [`.internal/v2-pipeline-reference.md`](../.internal/v2-pipeline-reference.md)
+- **Per-stage detail** → `.internal/v2-pipeline-reference.md` (repo-internal)
 - **Schema source-of-truth** → `src/v2/schema/json/` (agent + strict) and `src/v2/schema/ontology/open-pulse-ontology.ttl`
 - **Pipeline entry** → `src/v2/api.py` (the `_run_pipeline` function ties every stage together)
 - **Orchestrator** → `src/v2/pipeline/orchestrator.py` (phases 1–5)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - V2 API Reference: v2-api-reference.md
       - API and CLI Quick Reference: api-and-cli.md
       - Repository Enrichment Fields: repository-enrichment-fields.md
+      - Operations Runbook: OPERATIONS_RUNBOOK.md
       - Migration V1 to V2: migration-v1-to-v2.md
   - RAG Indices:
       - Overview: rag-indices.md


### PR DESCRIPTION
Documents the gimie-sidecar change and fixes the long-standing `mkdocs build --strict` blocker.

- **`v2-api-reference.md`** — `GIMIE_API_URL` (required for repository extraction) + `GIMIE_API_TIMEOUT_SECONDS` added to the env-var table, linking the runbook.
- **`getting-started.md`** — `GIMIE_API_URL` note in the environment section (devcontainer sets it; outside, point at the sidecar or `pip install gimie`).
- **`mkdocs.yml`** — the **Operations Runbook** (with §8 on the gimie sidecar requirement) is now in the nav; it was published-but-unlinked before.
- **Fixed the 4 pre-existing broken links** that aborted `mkdocs build --strict` (`epfl_graph.yaml` + `.env.example` → absolute GitHub URLs; the non-existent `.internal/v2-pipeline-reference.md` → plain code span). **`mkdocs build --strict` now passes (exit 0)** — the docs-publish workflow on `main` is no longer blocked.