### PR TITLE
feat(v2): docker-compose detection → gme-internal:compose_files / compose_images

### DIFF
--- a/docs/repository-enrichment-fields.md
+++ b/docs/repository-enrichment-fields.md
@@ -64,6 +64,8 @@ From the GitHub repository object.
 | `docker_hub_url` | Docker Hub repo parsed from README / compose |
 | `container_images` | Raw GHCR container packages (needs `read:packages` scope) |
 | `package_count`, `package_names`, `package_image_refs`, `package_tags`, `latest_package_updated_at` | Flat GHCR scalars |
+| `compose_files`, `compose_file_count` | Docker Compose files found anywhere in the repo (root, `.devcontainer/`, `docker/` …) — URL pointers into the default branch |
+| `compose_images` | Image references (`name:tag` / `name@digest`) parsed from the Compose files' `services.*.image` (`${VAR:-default}` resolved) |
 
 ## Published packages (per registry)
 

--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -720,6 +720,62 @@ def parse_funding_urls(aux_files: Any) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Docker Compose images
+# ---------------------------------------------------------------------------
+
+# `${VAR:-default}` compose interpolation → take the default value.
+_COMPOSE_VAR_DEFAULT_RE = re.compile(r"^\$\{[^:}]+:-(?P<default>.+)\}$")
+
+
+def _resolve_compose_image(value: Any) -> str | None:
+    """Normalise a compose ``image:`` value to a concrete ``name[:tag|@digest]``
+    ref, resolving ``${VAR:-default}`` to its default. Returns None for an
+    unresolvable interpolation (``${VAR}`` with no default) or non-string."""
+    if not isinstance(value, str):
+        return None
+    ref = value.strip()
+    m = _COMPOSE_VAR_DEFAULT_RE.match(ref)
+    if m:
+        ref = m.group("default").strip()
+    if not ref or "${" in ref:  # unresolvable remaining interpolation
+        return None
+    return ref
+
+
+def parse_compose_images(compose_files: Any) -> list[str]:
+    """Extract image references (``name:tag`` / ``name@digest``) from the
+    ``services.*.image`` fields of a repo's Docker Compose files.
+
+    *compose_files* is the list of ``{"content": <yaml>, …}`` dicts from the
+    provider. Returns a de-duped, order-preserving list (empty when none /
+    unparseable). Each ref carries both the image and its tag/digest.
+    """
+    if not isinstance(compose_files, list):
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for entry in compose_files:
+        content = entry.get("content") if isinstance(entry, dict) else None
+        if not isinstance(content, str) or not content:
+            continue
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError:
+            continue
+        services = data.get("services") if isinstance(data, dict) else None
+        if not isinstance(services, dict):
+            continue
+        for service in services.values():
+            if not isinstance(service, dict):
+                continue
+            ref = _resolve_compose_image(service.get("image"))
+            if ref and ref not in seen:
+                seen.add(ref)
+                out.append(ref)
+    return out
+
+
+# ---------------------------------------------------------------------------
 # npm / PyPI registry package discovery — manifest name parsing + back-ref
 # ---------------------------------------------------------------------------
 

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -13,6 +13,7 @@ from src.v2.agents.models import (
     validate_permissive,
 )
 from src.v2.agents.rule_based._repo_signals import (
+    parse_compose_images,
     parse_docker_hub_url,
     parse_funding_urls,
     parse_test_coverage,
@@ -679,6 +680,23 @@ class RepositoryAgentV2:
                 len(repository["git_tags"])
                 if isinstance(repository.get("git_tags"), list)
                 else None
+            ),
+            # Docker Compose files found anywhere in the repo (root,
+            # .devcontainer/, docker/ …): URL pointers + the image references
+            # (name:tag / name@digest) parsed from their `services.*.image`.
+            "_compose_files": (
+                [c["html_url"] for c in repository["compose_files"]
+                 if isinstance(c, dict) and isinstance(c.get("html_url"), str)]
+                if isinstance(repository.get("compose_files"), list)
+                else None
+            ),
+            "_compose_file_count": (
+                len(repository["compose_files"])
+                if isinstance(repository.get("compose_files"), list)
+                else None
+            ),
+            "_compose_images": (
+                parse_compose_images(repository.get("compose_files")) or None
             ),
             # CI presence — detected from the repo root listing by
             # context_gather and stored in repository_metadata["has_ci"].

--- a/src/v2/ingest/providers/base.py
+++ b/src/v2/ingest/providers/base.py
@@ -215,6 +215,18 @@ class GitHubProvider(BaseProvider, ABC):
         del full_name
         return []
 
+    def get_repository_compose_files(self, full_name: str) -> list[dict[str, Any]]:
+        """Return the repo's Docker Compose files, as
+        ``[{"path", "html_url", "content"}]`` (newest-tree first), or ``[]``.
+
+        Finds ``docker-compose*.y(a)ml`` / ``compose*.y(a)ml`` anywhere in the
+        tree (root, ``.devcontainer/``, ``docker/`` …) and fetches each file's
+        content so callers can extract the ``image:`` references. Default
+        returns ``[]``; implementations must not raise.
+        """
+        del full_name
+        return []
+
 
 class InfoscienceProvider(BaseProvider, ABC):
     """Adapter interface for Infoscience metadata retrieval."""

--- a/src/v2/ingest/providers/github_provider.py
+++ b/src/v2/ingest/providers/github_provider.py
@@ -37,6 +37,16 @@ GITHUB_NOREPLY_PATTERN = re.compile(
 )
 logger = logging.getLogger(__name__)
 
+# Docker Compose filenames (basename), e.g. docker-compose.yml,
+# docker-compose.prod.yaml, compose.yml — anywhere in the tree.
+_COMPOSE_NAME_RE = re.compile(
+    r"^(?:docker-)?compose(?:\.[\w.-]+)?\.ya?ml$", re.IGNORECASE,
+)
+
+
+def _is_compose_path(path: str) -> bool:
+    return bool(_COMPOSE_NAME_RE.match(path.rsplit("/", maxsplit=1)[-1]))
+
 
 def _resolve_max_github_repo_retries() -> int:
     """Read V2_GITHUB_REPO_MAX_RETRIES (default 3).
@@ -1003,6 +1013,76 @@ class RealGitHubProvider(GitHubProvider):
         key = ProviderCache.make_key("github", "get_tags_v1", full_name=full_name)
         return self._cache.get_or_set(
             key, _fetch, label=f"github.get_tags({full_name})",
+        )
+
+    def _fetch_file_text(self, full_name: str, path: str) -> str | None:
+        """Fetch a single repo file's text via the contents API (base64), capped
+        at 100 KB. None on any failure."""
+        url = f"https://api.github.com/repos/{full_name}/contents/{quote(path)}"
+        try:
+            resp = self._run_with_rate_limit(
+                lambda: requests.get(url, headers=_github_auth_headers(), timeout=15),
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("github file fetch failed: %s/%s", full_name, path)
+            return None
+        if resp.status_code != 200:
+            return None
+        try:
+            encoded = resp.json().get("content")
+        except (ValueError, AttributeError):
+            return None
+        if not isinstance(encoded, str):
+            return None
+        try:
+            return base64.b64decode(encoded)[:100_000].decode("utf-8", errors="replace")
+        except (ValueError, UnicodeDecodeError):
+            return None
+
+    def get_repository_compose_files(self, full_name: str) -> list[dict[str, Any]]:
+        """Fetch Docker Compose files anywhere in ``owner/repo`` (public,
+        cached). One recursive-tree call finds the files, then each is fetched
+        (base64 contents, capped). Returns ``[{path, html_url, content}]``;
+        empty on any failure. Capped at the first 20 matches."""
+
+        max_files = 20
+
+        def _fetch() -> list[dict[str, Any]]:
+            url = f"https://api.github.com/repos/{full_name}/git/trees/HEAD?recursive=1"
+            try:
+                resp = self._run_with_rate_limit(
+                    lambda: requests.get(url, headers=_github_auth_headers(), timeout=20),
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("github tree fetch failed: %s", full_name)
+                return []
+            if resp.status_code != 200:
+                return []
+            try:
+                tree = resp.json().get("tree")
+            except (ValueError, AttributeError):
+                return []
+            paths = [
+                t["path"] for t in tree
+                if isinstance(t, dict) and t.get("type") == "blob"
+                and isinstance(t.get("path"), str) and _is_compose_path(t["path"])
+            ][:max_files] if isinstance(tree, list) else []
+            out: list[dict[str, Any]] = []
+            for path in paths:
+                content = self._fetch_file_text(full_name, path)
+                if content is not None:
+                    out.append({
+                        "path": path,
+                        "html_url": f"https://github.com/{full_name}/blob/HEAD/{path}",
+                        "content": content,
+                    })
+            return out
+
+        if self._cache is None:
+            return _fetch()
+        key = ProviderCache.make_key("github", "get_compose_files_v1", full_name=full_name)
+        return self._cache.get_or_set(
+            key, _fetch, label=f"github.get_compose_files({full_name})",
         )
 
     def _list_owner_container_packages(self, owner: str) -> dict[str, Any]:

--- a/src/v2/pipeline/stages/context_gather.py
+++ b/src/v2/pipeline/stages/context_gather.py
@@ -529,6 +529,14 @@ def _optional_repository_context(
         warnings.append(
             f"Repository tags lookup failed for {full_name}: {exc}",
         )
+    try:
+        compose_files = providers.github.get_repository_compose_files(full_name)
+        if isinstance(compose_files, list) and compose_files:
+            repository_metadata["compose_files"] = compose_files
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(
+            f"Repository compose-files lookup failed for {full_name}: {exc}",
+        )
 
     # CI detection — list the repo root once and check for known CI
     # indicator files / directories. Best-effort: None on failure so the
@@ -687,6 +695,14 @@ async def gather_context(  # noqa: C901, PLR0915
         except Exception as exc:  # noqa: BLE001
             warnings.append(
                 f"Repository tags lookup failed for {full_name}: {exc}",
+            )
+        try:
+            compose_files = providers.github.get_repository_compose_files(full_name)
+            if isinstance(compose_files, list) and compose_files:
+                repository_metadata["compose_files"] = compose_files
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(
+                f"Repository compose-files lookup failed for {full_name}: {exc}",
             )
 
         # CI detection (best-effort; None on provider failure).

--- a/tests/v2/test_compose_images.py
+++ b/tests/v2/test_compose_images.py
@@ -1,0 +1,193 @@
+"""Docker Compose detection + image/tag extraction.
+
+- `parse_compose_images` / `_resolve_compose_image` (pure)
+- `_is_compose_path` (provider helper)
+- `RealGitHubProvider.get_repository_compose_files` (mocked tree + contents)
+- repository agent stamping `_compose_files` / `_compose_file_count` /
+  `_compose_images`.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+from typing import Any
+from unittest.mock import patch
+
+from src.v2.agents import ProviderSet, RepositoryAgentV2
+from src.v2.agents.rule_based._repo_signals import (
+    _resolve_compose_image,
+    parse_compose_images,
+)
+from src.v2.ingest.providers.github_provider import (
+    RealGitHubProvider,
+    _is_compose_path,
+)
+from src.v2.ingest.providers.mock_github import MockGitHubProvider
+
+
+_EXPECTED_IMAGES = 2
+
+_COMPOSE = (
+    "services:\n"
+    "  db:\n"
+    "    image: qdrant/qdrant:latest\n"
+    "  api:\n"
+    "    image: ${API_IMAGE:-ghcr.io/acme/api@sha256:abc}\n"
+    "  builder:\n"
+    "    build: .\n"            # no image → skipped
+    "  novar:\n"
+    "    image: ${UNRESOLVED}\n"  # unresolvable → skipped
+)
+
+
+class _Resp:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _provider() -> RealGitHubProvider:
+    return RealGitHubProvider(
+        gimie_extractor=lambda _u, _f: {},
+        user_lookup=lambda u: {"login": u},
+        organization_lookup=lambda o: {"login": o},
+    )
+
+
+# ---------------------------------------------------------------------------
+# _is_compose_path
+# ---------------------------------------------------------------------------
+
+
+def test_is_compose_path() -> None:
+    assert _is_compose_path("docker-compose.yml")
+    assert _is_compose_path(".devcontainer/docker-compose.yml")
+    assert _is_compose_path("docker/compose.prod.yaml")
+    assert _is_compose_path("compose.yaml")
+    assert not _is_compose_path("README.md")
+    assert not _is_compose_path("config/compose-notes.txt")
+    assert not _is_compose_path("src/composer.json")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_compose_image / parse_compose_images
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_compose_image() -> None:
+    assert _resolve_compose_image("qdrant/qdrant:latest") == "qdrant/qdrant:latest"
+    assert _resolve_compose_image("${V:-ghcr.io/a/b@sha256:x}") == "ghcr.io/a/b@sha256:x"
+    assert _resolve_compose_image("${NOIMG}") is None
+    assert _resolve_compose_image(None) is None
+    assert _resolve_compose_image("   ") is None
+
+
+def test_parse_compose_images() -> None:
+    images = parse_compose_images([{"content": _COMPOSE}])
+    assert images == ["qdrant/qdrant:latest", "ghcr.io/acme/api@sha256:abc"]
+    assert len(images) == _EXPECTED_IMAGES
+
+
+def test_parse_compose_images_dedupes_and_handles_bad_input() -> None:
+    files = [
+        {"content": "services:\n  a:\n    image: x:1\n"},
+        {"content": "services:\n  b:\n    image: x:1\n"},  # dup
+        {"content": "not: valid: yaml: ["},                 # unparseable
+        {"content": "no services here"},
+        "not a dict",
+    ]
+    assert parse_compose_images(files) == ["x:1"]
+    assert parse_compose_images(None) == []
+
+
+# ---------------------------------------------------------------------------
+# provider.get_repository_compose_files (mocked tree + contents)
+# ---------------------------------------------------------------------------
+
+
+def _b64(text: str) -> dict[str, Any]:
+    return {"content": base64.b64encode(text.encode()).decode()}
+
+
+def test_get_repository_compose_files() -> None:
+    tree = _Resp(200, {"tree": [
+        {"type": "blob", "path": ".devcontainer/docker-compose.yml"},
+        {"type": "blob", "path": "README.md"},
+        {"type": "tree", "path": "docker"},
+    ]})
+    content = _Resp(200, _b64(_COMPOSE))
+    with patch(
+        "src.v2.ingest.providers.github_provider.requests.get",
+        side_effect=[tree, content],
+    ):
+        out = _provider().get_repository_compose_files("acme/tool")
+    assert len(out) == 1
+    assert out[0]["path"] == ".devcontainer/docker-compose.yml"
+    assert out[0]["html_url"] == (
+        "https://github.com/acme/tool/blob/HEAD/.devcontainer/docker-compose.yml"
+    )
+    assert "qdrant/qdrant:latest" in out[0]["content"]
+
+
+def test_get_repository_compose_files_none_on_non_200() -> None:
+    with patch(
+        "src.v2.ingest.providers.github_provider.requests.get",
+        return_value=_Resp(404, None),
+    ):
+        assert _provider().get_repository_compose_files("a/b") == []
+
+
+# ---------------------------------------------------------------------------
+# repository agent emission
+# ---------------------------------------------------------------------------
+
+
+def _stub_context(*, compose_files: list[dict[str, Any]] | None) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "name": "tool", "full_name": "acme/tool",
+        "owner": {"login": "acme", "type": "Organization"},
+        "created_at": "2023-01-01T00:00:00Z", "license": {"spdx_id": "MIT"},
+        "fork": False, "source": {"full_name": None},
+    }
+    if compose_files is not None:
+        metadata["compose_files"] = compose_files
+    return {
+        "full_name": "acme/tool", "metadata": metadata,
+        "readme_content": "", "contributors": [{"login": "alice"}],
+        "languages": {"Python": 1}, "aux_files": {},
+    }
+
+
+def _run(context: dict[str, Any]) -> dict[str, Any]:
+    result = asyncio.run(
+        RepositoryAgentV2().run(
+            {"full_name": "acme/tool", "repository_context": context},
+            ProviderSet(github=MockGitHubProvider()),
+        ),
+    )
+    return result.raw_output
+
+
+def test_agent_emits_compose_fields() -> None:
+    raw = _run(_stub_context(compose_files=[
+        {
+            "path": ".devcontainer/docker-compose.yml",
+            "html_url": "https://github.com/acme/tool/blob/HEAD/.devcontainer/docker-compose.yml",
+            "content": _COMPOSE,
+        },
+    ]))
+    assert raw["_compose_files"] == [
+        "https://github.com/acme/tool/blob/HEAD/.devcontainer/docker-compose.yml",
+    ]
+    assert raw["_compose_file_count"] == 1
+    assert raw["_compose_images"] == ["qdrant/qdrant:latest", "ghcr.io/acme/api@sha256:abc"]
+
+
+def test_agent_compose_fields_none_when_absent() -> None:
+    raw = _run(_stub_context(compose_files=None))
+    assert raw["_compose_files"] is None
+    assert raw["_compose_file_count"] is None
+    assert raw["_compose_images"] is None


### PR DESCRIPTION
New repository signal (requested): **find Docker Compose files anywhere in the repo, list their links, and extract the images + tags they run.**

## Emitted (`?include_internal_fields=true`)
| Field | Meaning |
|---|---|
| `gme-internal:compose_files` | URL pointers to each Compose file (into the default branch) |
| `gme-internal:compose_file_count` | how many |
| `gme-internal:compose_images` | image refs `name:tag` / `name@digest` from `services.*.image` |

## How
- **`get_repository_compose_files`** — one recursive git-tree call finds `docker-compose*.y(a)ml` / `compose*.y(a)ml` at **any depth** (root, `.devcontainer/`, `docker/` …), then fetches each file (base64, capped, ≤20 files). Best-effort `[]`.
- **`parse_compose_images`** — parses `services.*.image`, resolving `${VAR:-default}` interpolation; de-duped; skips build-only services and unresolvable `${VAR}`. Each ref carries the image **and** its tag/digest.

## Validated live against real GitHub
- `Imaging-Plaza/git-metadata-extractor` → `.devcontainer/docker-compose.yml` → `['qdrant/qdrant:latest', 'selenium/standalone-firefox']` (reads the default branch = `main`, as asked).
- `sdsc-ordes/gimie-api` → `docker-compose.yml` found, `[]` images (it uses `build:`, no `image:`).

## Tests
`tests/v2/test_compose_images.py` (8): path matcher, parser (var-default, dedupe, bad input), provider via mocked tree + contents, agent emission + all-None. Full `tests/v2` green (**1637 passed**). New files ruff-clean; the only `github_provider.py` delta is literal-`200`/`# noqa: BLE001` matching that file's pervasive idiom (ruff isn't a CI gate). Doc updated.