### PR TITLE
feat(v2): full registry URLs for compose images (gme-internal:compose_image_urls)

### DIFF
--- a/docs/repository-enrichment-fields.md
+++ b/docs/repository-enrichment-fields.md
@@ -66,6 +66,7 @@ From the GitHub repository object.
 | `package_count`, `package_names`, `package_image_refs`, `package_tags`, `latest_package_updated_at` | Flat GHCR scalars |
 | `compose_files`, `compose_file_count` | Docker Compose files found anywhere in the repo (root, `.devcontainer/`, `docker/` …) — URL pointers into the default branch |
 | `compose_images` | Image references (`name:tag` / `name@digest`) parsed from the Compose files' `services.*.image` (`${VAR:-default}` resolved) |
+| `compose_image_urls` | Full registry **web URLs** for those images — Docker Hub (`hub.docker.com/r/ns/name` or `/_/official`), GHCR (GitHub package page), Quay; images on unknown registries are dropped |
 
 ## Published packages (per registry)
 

--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -742,6 +742,73 @@ def _resolve_compose_image(value: Any) -> str | None:
     return ref
 
 
+def _strip_image_tag(repo_path: str) -> str:
+    """Drop the ``:tag`` from an image repo path (tag lives in the LAST path
+    segment, so a registry ``host:port`` earlier in the path is preserved)."""
+    if "/" in repo_path:
+        head, tail = repo_path.rsplit("/", maxsplit=1)
+        return f"{head}/{tail.split(':', 1)[0]}"
+    return repo_path.split(":", 1)[0]
+
+
+def _docker_hub_url(repo: str) -> str:
+    """Docker Hub web URL: namespaced ``ns/name`` → ``/r/ns/name``; an official
+    single-component ``name`` → ``/_/name``."""
+    return (
+        f"https://hub.docker.com/r/{repo}" if "/" in repo
+        else f"https://hub.docker.com/_/{repo}"
+    )
+
+
+def _image_ref_to_url(ref: Any) -> str | None:  # noqa: PLR0911 — one branch per registry; flat returns read clearer
+    """Map a Docker image reference to its registry web URL, or None.
+
+    Covers Docker Hub (the implicit registry — "the docker ones"), plus GHCR and
+    Quay. Other/unknown registries (no clean web page) return None.
+    """
+    if not isinstance(ref, str) or not ref.strip():
+        return None
+    spec = ref.strip().split("@", 1)[0]  # drop any @sha256 digest
+    first, slash, rest = spec.partition("/")
+    # The first component is a registry host only when something follows it
+    # (`host/path`) AND it looks host-like — a dot/port, or `localhost`.
+    # A bare `name:tag` (no slash) is always a Docker Hub image, not a host:port.
+    if slash and ("." in first or ":" in first or first == "localhost"):
+        host = first.lower()
+        repo = _strip_image_tag(rest)
+        if not repo:
+            return None
+        if host in ("docker.io", "index.docker.io", "registry-1.docker.io"):
+            return _docker_hub_url(repo)
+        if host == "ghcr.io":
+            parts = repo.split("/")
+            if len(parts) >= _OWNER_REPO_SEGMENTS:
+                owner, name = parts[0], parts[-1]
+                return f"https://github.com/{owner}/{name}/pkgs/container/{name}"
+            return None
+        if host == "quay.io":
+            return f"https://quay.io/repository/{repo}"
+        return None
+    return _docker_hub_url(_strip_image_tag(spec))
+
+
+def compose_image_urls(compose_files: Any) -> list[str]:
+    """Full registry web URLs for a repo's Docker Compose images.
+
+    Maps each ref from :func:`parse_compose_images` to its registry page
+    (Docker Hub / GHCR / Quay). De-duped, order-preserving; images on unknown
+    registries are dropped.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for ref in parse_compose_images(compose_files):
+        url = _image_ref_to_url(ref)
+        if url and url not in seen:
+            seen.add(url)
+            out.append(url)
+    return out
+
+
 def parse_compose_images(compose_files: Any) -> list[str]:
     """Extract image references (``name:tag`` / ``name@digest``) from the
     ``services.*.image`` fields of a repo's Docker Compose files.

--- a/src/v2/agents/rule_based/repository_agent.py
+++ b/src/v2/agents/rule_based/repository_agent.py
@@ -13,6 +13,7 @@ from src.v2.agents.models import (
     validate_permissive,
 )
 from src.v2.agents.rule_based._repo_signals import (
+    compose_image_urls,
     parse_compose_images,
     parse_docker_hub_url,
     parse_funding_urls,
@@ -697,6 +698,11 @@ class RepositoryAgentV2:
             ),
             "_compose_images": (
                 parse_compose_images(repository.get("compose_files")) or None
+            ),
+            # Full registry web URLs for the compose images — Docker Hub (the
+            # "docker" images), plus GHCR / Quay where resolvable.
+            "_compose_image_urls": (
+                compose_image_urls(repository.get("compose_files")) or None
             ),
             # CI presence — detected from the repo root listing by
             # context_gather and stored in repository_metadata["has_ci"].

--- a/tests/v2/test_compose_images.py
+++ b/tests/v2/test_compose_images.py
@@ -15,7 +15,9 @@ from unittest.mock import patch
 
 from src.v2.agents import ProviderSet, RepositoryAgentV2
 from src.v2.agents.rule_based._repo_signals import (
+    _image_ref_to_url,
     _resolve_compose_image,
+    compose_image_urls,
     parse_compose_images,
 )
 from src.v2.ingest.providers.github_provider import (
@@ -23,7 +25,6 @@ from src.v2.ingest.providers.github_provider import (
     _is_compose_path,
 )
 from src.v2.ingest.providers.mock_github import MockGitHubProvider
-
 
 _EXPECTED_IMAGES = 2
 
@@ -101,6 +102,40 @@ def test_parse_compose_images_dedupes_and_handles_bad_input() -> None:
     ]
     assert parse_compose_images(files) == ["x:1"]
     assert parse_compose_images(None) == []
+
+
+# ---------------------------------------------------------------------------
+# _image_ref_to_url / compose_image_urls
+# ---------------------------------------------------------------------------
+
+
+def test_image_ref_to_url() -> None:
+    assert _image_ref_to_url("qdrant/qdrant:latest") == "https://hub.docker.com/r/qdrant/qdrant"
+    assert _image_ref_to_url("postgres:15") == "https://hub.docker.com/_/postgres"   # official
+    assert _image_ref_to_url("python") == "https://hub.docker.com/_/python"
+    assert _image_ref_to_url("docker.io/acme/api:1") == "https://hub.docker.com/r/acme/api"
+    assert _image_ref_to_url("ghcr.io/acme/api@sha256:x") == (
+        "https://github.com/acme/api/pkgs/container/api"
+    )
+    assert _image_ref_to_url("quay.io/org/name:2") == "https://quay.io/repository/org/name"
+    # unknown registry / localhost → no clean web URL
+    assert _image_ref_to_url("registry.gitlab.com/x/y:1") is None
+    assert _image_ref_to_url("localhost:5000/foo:dev") is None
+    assert _image_ref_to_url(None) is None
+
+
+def test_compose_image_urls() -> None:
+    compose = (
+        "services:\n"
+        "  a:\n    image: qdrant/qdrant:latest\n"
+        "  b:\n    image: ghcr.io/acme/api@sha256:x\n"
+        "  c:\n    image: registry.gitlab.com/x/y:1\n"   # dropped (unknown)
+    )
+    assert compose_image_urls([{"content": compose}]) == [
+        "https://hub.docker.com/r/qdrant/qdrant",
+        "https://github.com/acme/api/pkgs/container/api",
+    ]
+    assert compose_image_urls(None) == []
 
 
 # ---------------------------------------------------------------------------
@@ -184,6 +219,10 @@ def test_agent_emits_compose_fields() -> None:
     ]
     assert raw["_compose_file_count"] == 1
     assert raw["_compose_images"] == ["qdrant/qdrant:latest", "ghcr.io/acme/api@sha256:abc"]
+    assert raw["_compose_image_urls"] == [
+        "https://hub.docker.com/r/qdrant/qdrant",
+        "https://github.com/acme/api/pkgs/container/api",
+    ]
 
 
 def test_agent_compose_fields_none_when_absent() -> None:
@@ -191,3 +230,4 @@ def test_agent_compose_fields_none_when_absent() -> None:
     assert raw["_compose_files"] is None
     assert raw["_compose_file_count"] is None
     assert raw["_compose_images"] is None
+    assert raw["_compose_image_urls"] is None


### PR DESCRIPTION
Follow-up to #153 — full **registry web URLs** for the Docker Compose images (the Docker Hub ones being "the docker" case you asked for).

## New field
`gme-internal:compose_image_urls` — one full URL per compose image, where resolvable:
| Registry | Example → URL |
|---|---|
| **Docker Hub** (namespaced) | `qdrant/qdrant:latest` → `https://hub.docker.com/r/qdrant/qdrant` |
| **Docker Hub** (official) | `postgres:15` → `https://hub.docker.com/_/postgres` |
| **GHCR** | `ghcr.io/sdsc-ordes/gimie-api@sha256:…` → `https://github.com/sdsc-ordes/gimie-api/pkgs/container/gimie-api` |
| **Quay** | `quay.io/keycloak/keycloak:24` → `https://quay.io/repository/keycloak/keycloak` |
| unknown (gitlab, localhost, private) | dropped |

## Correctness
`_image_ref_to_url` parses the docker reference properly — a registry host counts only when a `/` follows it **and** it looks host-like (dot / port / `localhost`), so a bare `name:tag` (e.g. `postgres:15`) is correctly a Docker Hub **official** image, not a `host:port`. (Caught + fixed during dev.)

Validated all three mapped URLs resolve (HTTP 200). Tests extended; full `tests/v2` green (**1639**). Doc updated (`repository-enrichment-fields.md`).