### PR TITLE
feat(v2): link compose_image_urls to the specific tag when present

### DIFF
--- a/docs/repository-enrichment-fields.md
+++ b/docs/repository-enrichment-fields.md
@@ -66,7 +66,7 @@ From the GitHub repository object.
 | `package_count`, `package_names`, `package_image_refs`, `package_tags`, `latest_package_updated_at` | Flat GHCR scalars |
 | `compose_files`, `compose_file_count` | Docker Compose files found anywhere in the repo (root, `.devcontainer/`, `docker/` …) — URL pointers into the default branch |
 | `compose_images` | Image references (`name:tag` / `name@digest`) parsed from the Compose files' `services.*.image` (`${VAR:-default}` resolved) |
-| `compose_image_urls` | Full registry **web URLs** for those images — Docker Hub (`hub.docker.com/r/ns/name` or `/_/official`), GHCR (GitHub package page), Quay; images on unknown registries are dropped |
+| `compose_image_urls` | Full registry **web URLs** for those images, linking to the specific tag when present — Docker Hub (`hub.docker.com/r/ns/name/tags?name=<tag>` or `/_/official/tags?name=<tag>`), Quay (`…?tab=tags&tag=<tag>`), GHCR (GitHub package page; no per-tag URL). Images on unknown registries are dropped |
 
 ## Published packages (per registry)
 

--- a/src/v2/agents/rule_based/_repo_signals.py
+++ b/src/v2/agents/rule_based/_repo_signals.py
@@ -742,44 +742,51 @@ def _resolve_compose_image(value: Any) -> str | None:
     return ref
 
 
-def _strip_image_tag(repo_path: str) -> str:
-    """Drop the ``:tag`` from an image repo path (tag lives in the LAST path
-    segment, so a registry ``host:port`` earlier in the path is preserved)."""
+def _split_repo_tag(repo_path: str) -> tuple[str, str | None]:
+    """Split ``name[:tag]`` (registry already removed) into ``(name, tag|None)``.
+    The tag lives in the LAST path segment, so a ``host:port`` earlier in the
+    path is never mistaken for a tag."""
     if "/" in repo_path:
         head, tail = repo_path.rsplit("/", maxsplit=1)
-        return f"{head}/{tail.split(':', 1)[0]}"
-    return repo_path.split(":", 1)[0]
+        name, _, tag = tail.partition(":")
+        return (f"{head}/{name}", tag or None)
+    name, _, tag = repo_path.partition(":")
+    return (name, tag or None)
 
 
-def _docker_hub_url(repo: str) -> str:
-    """Docker Hub web URL: namespaced ``ns/name`` → ``/r/ns/name``; an official
-    single-component ``name`` → ``/_/name``."""
-    return (
+def _docker_hub_url(repo: str, tag: str | None) -> str:
+    """Docker Hub web URL: namespaced ``ns/name`` → ``/r/ns/name``; official
+    single-component ``name`` → ``/_/name``. When *tag* is set, link to that tag
+    (``/tags?name=<tag>``)."""
+    base = (
         f"https://hub.docker.com/r/{repo}" if "/" in repo
         else f"https://hub.docker.com/_/{repo}"
     )
+    return f"{base}/tags?name={tag}" if tag else base
 
 
 def _image_ref_to_url(ref: Any) -> str | None:  # noqa: PLR0911 — one branch per registry; flat returns read clearer
     """Map a Docker image reference to its registry web URL, or None.
 
     Covers Docker Hub (the implicit registry — "the docker ones"), plus GHCR and
-    Quay. Other/unknown registries (no clean web page) return None.
+    Quay. The ``:tag`` is appended where the registry supports a per-tag page
+    (Docker Hub, Quay). Digest-pinned refs (``@sha256:…``) carry no tag.
+    Other/unknown registries (no clean web page) return None.
     """
     if not isinstance(ref, str) or not ref.strip():
         return None
-    spec = ref.strip().split("@", 1)[0]  # drop any @sha256 digest
+    spec = ref.strip().split("@", 1)[0]  # drop any @sha256 digest (not a tag)
     first, slash, rest = spec.partition("/")
     # The first component is a registry host only when something follows it
     # (`host/path`) AND it looks host-like — a dot/port, or `localhost`.
     # A bare `name:tag` (no slash) is always a Docker Hub image, not a host:port.
     if slash and ("." in first or ":" in first or first == "localhost"):
         host = first.lower()
-        repo = _strip_image_tag(rest)
+        repo, tag = _split_repo_tag(rest)
         if not repo:
             return None
         if host in ("docker.io", "index.docker.io", "registry-1.docker.io"):
-            return _docker_hub_url(repo)
+            return _docker_hub_url(repo, tag)
         if host == "ghcr.io":
             parts = repo.split("/")
             if len(parts) >= _OWNER_REPO_SEGMENTS:
@@ -787,9 +794,11 @@ def _image_ref_to_url(ref: Any) -> str | None:  # noqa: PLR0911 — one branch p
                 return f"https://github.com/{owner}/{name}/pkgs/container/{name}"
             return None
         if host == "quay.io":
-            return f"https://quay.io/repository/{repo}"
+            base = f"https://quay.io/repository/{repo}"
+            return f"{base}?tab=tags&tag={tag}" if tag else base
         return None
-    return _docker_hub_url(_strip_image_tag(spec))
+    repo, tag = _split_repo_tag(spec)
+    return _docker_hub_url(repo, tag)
 
 
 def compose_image_urls(compose_files: Any) -> list[str]:

--- a/tests/v2/test_compose_images.py
+++ b/tests/v2/test_compose_images.py
@@ -110,14 +110,24 @@ def test_parse_compose_images_dedupes_and_handles_bad_input() -> None:
 
 
 def test_image_ref_to_url() -> None:
-    assert _image_ref_to_url("qdrant/qdrant:latest") == "https://hub.docker.com/r/qdrant/qdrant"
-    assert _image_ref_to_url("postgres:15") == "https://hub.docker.com/_/postgres"   # official
-    assert _image_ref_to_url("python") == "https://hub.docker.com/_/python"
-    assert _image_ref_to_url("docker.io/acme/api:1") == "https://hub.docker.com/r/acme/api"
+    # tag appended where the registry supports a per-tag page
+    assert _image_ref_to_url("qdrant/qdrant:latest") == (
+        "https://hub.docker.com/r/qdrant/qdrant/tags?name=latest"
+    )
+    assert _image_ref_to_url("postgres:15") == (
+        "https://hub.docker.com/_/postgres/tags?name=15"  # official + tag
+    )
+    assert _image_ref_to_url("python") == "https://hub.docker.com/_/python"  # no tag
+    assert _image_ref_to_url("docker.io/acme/api:1") == (
+        "https://hub.docker.com/r/acme/api/tags?name=1"
+    )
+    assert _image_ref_to_url("quay.io/org/name:2") == (
+        "https://quay.io/repository/org/name?tab=tags&tag=2"
+    )
+    # GHCR has no clean per-tag page → base package page (digest carries no tag)
     assert _image_ref_to_url("ghcr.io/acme/api@sha256:x") == (
         "https://github.com/acme/api/pkgs/container/api"
     )
-    assert _image_ref_to_url("quay.io/org/name:2") == "https://quay.io/repository/org/name"
     # unknown registry / localhost → no clean web URL
     assert _image_ref_to_url("registry.gitlab.com/x/y:1") is None
     assert _image_ref_to_url("localhost:5000/foo:dev") is None
@@ -132,7 +142,7 @@ def test_compose_image_urls() -> None:
         "  c:\n    image: registry.gitlab.com/x/y:1\n"   # dropped (unknown)
     )
     assert compose_image_urls([{"content": compose}]) == [
-        "https://hub.docker.com/r/qdrant/qdrant",
+        "https://hub.docker.com/r/qdrant/qdrant/tags?name=latest",
         "https://github.com/acme/api/pkgs/container/api",
     ]
     assert compose_image_urls(None) == []
@@ -220,7 +230,7 @@ def test_agent_emits_compose_fields() -> None:
     assert raw["_compose_file_count"] == 1
     assert raw["_compose_images"] == ["qdrant/qdrant:latest", "ghcr.io/acme/api@sha256:abc"]
     assert raw["_compose_image_urls"] == [
-        "https://hub.docker.com/r/qdrant/qdrant",
+        "https://hub.docker.com/r/qdrant/qdrant/tags?name=latest",
         "https://github.com/acme/api/pkgs/container/api",
     ]
 


### PR DESCRIPTION
Per request — `gme-internal:compose_image_urls` now links to the **specific tag** when the ref has one and the registry supports a per-tag page.

| Ref | → URL |
|---|---|
| `qdrant/qdrant:latest` | `https://hub.docker.com/r/qdrant/qdrant/tags?name=latest` |
| `postgres:15` (official) | `https://hub.docker.com/_/postgres/tags?name=15` |
| `python` (no tag) | `https://hub.docker.com/_/python` |
| `quay.io/keycloak/keycloak:24` | `https://quay.io/repository/keycloak/keycloak?tab=tags&tag=24` |
| `ghcr.io/…@sha256:…` (digest) | `https://github.com/…/pkgs/container/…` (GHCR has no per-tag page) |

`_split_repo_tag` pulls the tag from the **last** path segment so a `host:port` is never mistaken for a tag. All tagged forms **verified to resolve (HTTP 200)**. Tests + doc updated; full `tests/v2` green (**1639**).