### PR TITLE
chore(deploy): add production docker-compose with the gme-gimie-api sidecar

### DIFF
--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -182,31 +182,21 @@ Behaviour:
 Pin the sidecar image by digest for reproducibility. Validate a new image with
 `scripts/v2/gimie_api_parity.py` (diffs sidecar vs in-process output).
 
-The dev stack (`.devcontainer/docker-compose.yml`) wires this already (the
-`gme-gimie-api` service + `GIMIE_API_URL` on the devcontainer, image pinned by
-digest). **Production compose/k8s — outside this repo — needs the equivalent.**
-Ready-to-copy compose service + app wiring:
+Both stacks in this repo wire it already:
 
-```yaml
-services:
-  gme-api:
-    image: ghcr.io/imaging-plaza/git-metadata-extractor:<tag>
-    environment:
-      GIMIE_API_URL: http://gme-gimie-api:15400
-    depends_on: [gme-gimie-api]
-    networks: [gme]
+- **Dev:** `.devcontainer/docker-compose.yml` (the `gme-gimie-api` service +
+  `GIMIE_API_URL` on the devcontainer).
+- **Production:** **`tools/deploy/docker-compose.yml`** — a ready-to-run stack
+  (gme-api + gme-gimie-api + qdrant + selenium, image digest-pinned, persistent
+  volumes):
 
-  gme-gimie-api:
-    # pin by digest; == :latest resolved 2026-06-07 (gimie 0.7.2)
-    image: ghcr.io/sdsc-ordes/gimie-api@sha256:7a8a59b70d0787e1d265ff08f24328dd2d518f25dcc504b0420f8648ce99ecdb
-    environment:
-      ACCESS_TOKEN: ${GME_GITHUB_TOKEN}   # gimie-api reads the GitHub token here
-    restart: unless-stopped
-    networks: [gme]
+  ```bash
+  docker compose -f tools/deploy/docker-compose.yml --env-file .env up -d
+  ```
 
-networks:
-  gme:
-```
+  Override the app image with `GME_IMAGE` (defaults to
+  `ghcr.io/imaging-plaza/git-metadata-extractor:latest`) or uncomment its
+  `build:` block to build locally.
 
 (For k8s: a `gimie-api` Deployment + Service on `:15400` with `ACCESS_TOKEN`
 from the GitHub-token secret, and `GIMIE_API_URL=http://gimie-api:15400` on the

--- a/tools/deploy/docker-compose.yml
+++ b/tools/deploy/docker-compose.yml
@@ -1,0 +1,85 @@
+# Production-oriented deployment stack for git-metadata-extractor.
+#
+#   docker compose -f tools/deploy/docker-compose.yml --env-file .env up -d
+#
+# Services:
+#   gme-api          the extraction API (gunicorn on :1234; bootstraps index
+#                    stores at startup via the on_starting hook)
+#   gme-gimie-api    REQUIRED sidecar — the `gimie` Python dep was removed, so
+#                    repository extraction calls this over HTTP. See
+#                    docs/OPERATIONS_RUNBOOK.md §8.
+#   gme-qdrant       vector store for the RAG indices
+#   gme-selenium     headless Firefox for link-veracity + Selenium-backed RAG
+#                    ingest (SWISSUbase, ORCID scraping). Optional — drop it and
+#                    unset SELENIUM_REMOTE_URL if you don't need those.
+#
+# Secrets/config come from `.env` (see .env.example): API_TOKEN,
+# GME_GITHUB_TOKEN, RCP_TOKEN (or an LLM key), etc. The inter-service URLs below
+# are set explicitly so they don't need to live in .env.
+services:
+  gme-api:
+    image: ${GME_IMAGE:-ghcr.io/imaging-plaza/git-metadata-extractor:latest}
+    # To build locally instead of pulling, comment `image:` and uncomment:
+    # build:
+    #   context: ../..
+    #   dockerfile: tools/image/Dockerfile
+    container_name: gme-api
+    env_file:
+      - ../../.env
+    environment:
+      # GIMIE is served by the sidecar (gimie is no longer in the image).
+      GIMIE_API_URL: http://gme-gimie-api:15400
+      INDEX_QDRANT_URL: http://gme-qdrant:6333
+      SELENIUM_REMOTE_URL: http://gme-selenium:4444
+      WORKERS: ${WORKERS:-2}
+    ports:
+      - "${APP_PORT:-1234}:1234"
+    volumes:
+      # Persist index DuckDB stores + provider cache across restarts.
+      - gme-data:/app/data
+    depends_on:
+      - gme-gimie-api
+      - gme-qdrant
+    restart: unless-stopped
+    networks:
+      - gme
+
+  gme-gimie-api:
+    # Pinned by digest for reproducibility (== :latest resolved 2026-06-07,
+    # gimie 0.7.2). Re-resolve + re-validate (scripts/v2/gimie_api_parity.py)
+    # when bumping; or set GIMIE_API_IMAGE to follow the moving tag.
+    image: ${GIMIE_API_IMAGE:-ghcr.io/sdsc-ordes/gimie-api@sha256:7a8a59b70d0787e1d265ff08f24328dd2d518f25dcc504b0420f8648ce99ecdb}
+    container_name: gme-gimie-api
+    environment:
+      # gimie-api reads the GitHub token from ACCESS_TOKEN.
+      ACCESS_TOKEN: ${GME_GITHUB_TOKEN:-}
+    restart: unless-stopped
+    networks:
+      - gme
+
+  gme-qdrant:
+    image: qdrant/qdrant:latest
+    container_name: gme-qdrant
+    volumes:
+      - gme-qdrant-storage:/qdrant/storage
+    restart: unless-stopped
+    networks:
+      - gme
+
+  gme-selenium:
+    image: selenium/standalone-firefox
+    container_name: gme-selenium
+    shm_size: "2g"
+    environment:
+      SE_NODE_MAX_SESSIONS: "5"
+      SE_NODE_SESSION_TIMEOUT: "300"
+    restart: unless-stopped
+    networks:
+      - gme
+
+volumes:
+  gme-data:
+  gme-qdrant-storage:
+
+networks:
+  gme:


### PR DESCRIPTION
Brings the **production deploy stack into the repo** (it was "outside this repo"), so the `gme-gimie-api` sidecar is version-controlled on `develop` rather than living only as a runbook snippet.

## `tools/deploy/docker-compose.yml`
A ready-to-run production stack:
- **`gme-api`** — the published image (`ghcr.io/imaging-plaza/git-metadata-extractor:latest`, override via `GME_IMAGE`, or uncomment `build:`), with `GIMIE_API_URL` / `INDEX_QDRANT_URL` / `SELENIUM_REMOTE_URL` wired to the internal services, persistent `/app/data` + qdrant volumes, and the startup index-bootstrap hook.
- **`gme-gimie-api`** — the **required** sidecar (digest-pinned to gimie 0.7.2; `ACCESS_TOKEN` ← `GME_GITHUB_TOKEN`).
- **`gme-qdrant`** + **`gme-selenium`** (the latter optional, for link-veracity / Selenium-backed RAG ingest).

```bash
docker compose -f tools/deploy/docker-compose.yml --env-file .env up -d
```

`OPERATIONS_RUNBOOK §8` now points at this concrete file instead of an inline snippet. Compose YAML validated; `mkdocs --strict` still passes. No code change.

This closes the last open item from the gimie→sidecar migration: the prod deployment now ships the sidecar by default.