### PR TITLE
fix(v2/indices): bounded ingest thread pool to stop ingest starving e…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,11 @@ OPENROUTER_API_KEY=your-openrouter-key-here
 # when the deployment hits protected Infoscience routes.
 # INFOSCIENCE_TOKEN=
 
+# Max entries in the in-process Infoscience search cache (FIFO eviction). It is
+# never cleared during serving, so this cap bounds its memory over the process
+# lifetime. Default: 512.
+# V2_INFOSCIENCE_CACHE_MAXSIZE=512
+
 # Remote Selenium endpoint used by the link-veracity stage and the LLM
 # `fetch_link_content_via_selenium` tool. Leave unset to disable Selenium-based
 # fetching (the pipeline degrades gracefully with warnings).

--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,14 @@ OPENROUTER_API_KEY=your-openrouter-key-here
 # onto the model endpoint. Default: 6.
 # V2_MAX_CONCURRENT_AGENTS=6
 
+# Size of the bounded, ingest-only thread pool. The heavy index-ingest steps
+# (per-provider embed pass, WAL checkpoint, .ro snapshot, gitlab ingest/embed)
+# run on this dedicated pool instead of the shared default pool, so a bulk
+# `/v2/indices/<p>/ingest` can't starve concurrent `/v2/extract` work. Keep it
+# small (2) so ingest leaves headroom for extraction; raise it only when ingest
+# runs in a dedicated maintenance window. Default: 2.
+# V2_INGEST_MAX_THREADS=2
+
 # Per-link veracity stage (Selenium fetch + LLM verdict on every external
 # URL the pipeline collects). Off by default — it is the slowest stage and
 # rarely changes outputs; enable only when auditing link rot or veracity.

--- a/dev/bug-plans/02-hybrid-concurrency-http-job-instability.md
+++ b/dev/bug-plans/02-hybrid-concurrency-http-job-instability.md
@@ -1,6 +1,24 @@
 # Bug 02 — Extraction server destabilizes under concurrent hybrid jobs
 
-**Severity:** medium · **Status:** Investigated — plan ready (no code changed) · **Area:** HTTP / async job layer
+**Severity:** medium · **Status:** ◐ Partial — one event-loop-blocking call offloaded (2026-06-12); the gather_context offload remains probe-gated · **Area:** HTTP / async job layer
+
+> **Partial fix (2026-06-12):** offloaded the hybrid discovery pass's blocking
+> OpenAlex DOI lookup off the event loop. `_run_discovery_pass` (async) called
+> `_materialize_article` (sync) → `_openalex_lookup_doi` → `requests.get` (15s)
+> **directly on the loop**, freezing it during hybrid extraction. The call site
+> (`refine_with_llm.py:2131`) now uses `await asyncio.to_thread(_materialize_article, …)`
+> — sequential await, so the shared dedup dicts stay race-free. Verified by the
+> 52 refine/discovery regression tests (a dedicated offload unit test would need
+> to mock the LLM agent + OpenAlex and would be brittle).
+>
+> **Still open (the dominant, but riskier, blocking site):** `gather_context`
+> (async) makes ~10 blocking `providers.github.*` calls directly on the loop,
+> including the gimie sidecar fetch (180s timeout). Wrapping each in
+> `asyncio.to_thread` is mechanically safe but it's a sizable sweep of a complex
+> hot-path function, and this plan recommends running the cheap
+> `/healthz`-during-extract probe first to confirm the loop-block mechanism
+> before investing. Left as the gated follow-up. The job/queue structural work
+> (decoupled runner, semaphore backpressure) also remains.
 
 > Confidence note: the *mechanism* below (blocking sync I/O on the event loop) is
 > grounded in the code with file:line citations and is high-confidence. The exact

--- a/dev/bug-plans/02-hybrid-concurrency-http-job-instability.md
+++ b/dev/bug-plans/02-hybrid-concurrency-http-job-instability.md
@@ -1,6 +1,20 @@
 # Bug 02 — Extraction server destabilizes under concurrent hybrid jobs
 
-**Severity:** medium · **Status:** ◐ Partial — one event-loop-blocking call offloaded (2026-06-12); the gather_context offload remains probe-gated · **Area:** HTTP / async job layer
+**Severity:** medium · **Status:** ◐ Mostly fixed (2026-06-12) — all gather_context + discovery blocking I/O offloaded; only the job/queue structural work remains · **Area:** HTTP / async job layer
+
+> **Update (2026-06-12, follow-up):** offloaded **every** blocking provider call
+> in the async `gather_context` (`context_gather.py`) — the 12 inline
+> `providers.github.*` calls (incl. the 180s gimie `get_repository_jsonld`),
+> `get_user`/`get_organization`/`orcid.get_person_by_orcid`, the
+> `_optional_repository_context` owned-repo helper (both call sites), and
+> `_enrich_contributors_with_commit_bookends` — each now runs via
+> `asyncio.to_thread`, so the event loop is no longer frozen by synchronous
+> GitHub/gimie/ORCID I/O during extraction. Sequential awaits keep the in-place
+> `warnings`/`contributors` mutations race-free, and the sync provider's internal
+> `time.sleep` retry now runs on a worker thread, not the loop. 10 context-gather
+> tests pass; no new lint. **Still open:** the job/queue structural work
+> (decoupled runner / semaphore backpressure) and a profiled confirmation that
+> loop-blocking was the dominant cause of the client resets.
 
 > **Partial fix (2026-06-12):** offloaded the hybrid discovery pass's blocking
 > OpenAlex DOI lookup off the event loop. `_run_discovery_pass` (async) called

--- a/dev/bug-plans/03-extraction-memory-growth.md
+++ b/dev/bug-plans/03-extraction-memory-growth.md
@@ -1,5 +1,21 @@
 # Bug 03 — Memory growth / per-extraction leak in extraction service
-**Severity:** medium-high (forces restarts) · **Status:** Investigated — plan ready (no code changed) · **Area:** lifecycle / caching / connections
+**Severity:** medium-high (forces restarts) · **Status:** ◐ Partial — unbounded infoscience cache bounded (2026-06-12); larger suspects need profiling · **Area:** lifecycle / caching / connections
+
+> **Partial fix (2026-06-12):** bounded the clearly-unbounded suspect S2 — the
+> infoscience `_search_cache` (module-global dict written at 4+ sites; its
+> `clear_infoscience_cache()` is never called during serving) is now a
+> size-bounded FIFO cache (`_BoundedStrCache`, `V2_INFOSCIENCE_CACHE_MAXSIZE`,
+> default 512). An unbounded process-lifetime cache is a latent leak regardless
+> of whether it is the dominant one, so this is safe without a profiler.
+> Tests: `tests/v2/test_infoscience_cache_bound.py`.
+>
+> **Still open (confirm with a profiler before fixing — see Diagnosis plan):**
+> S1 (per-agent-run LLM clients never `aclose()`d) and S3 (provider
+> `requests.Session`s never closed) are the larger suspects. The worker-recycling
+> stopgap (gunicorn `--max-requests`) is **not** drop-in safe here: extract/ingest
+> run as fire-and-forget `asyncio.create_task` background jobs, so recycling a
+> worker mid-job would kill in-flight extractions — use a checkpointed self-restart
+> or an OOM-guard container restart policy instead.
 
 ## Symptom
 Over ~4,700 sequential extractions, `git-metadata-extractor` RSS climbed from ~0.5 GiB to ~5.1 GiB / 6 GiB and throughput degraded roughly linearly (1.2 s → ~6.7 s per entity). A process restart cleared RSS back to ~0.5 GiB and restored throughput. This is the signature of a **per-extraction leak** (objects retained on the process / module globals across requests, plus connection/client objects that are created per request and never closed). The slowdown that tracks RSS growth points at one or more **per-process containers that are scanned/iterated and grow without bound** (each extraction does more work as the container grows), compounded by GC pressure and connection-pool churn.

--- a/dev/bug-plans/03-extraction-memory-growth.md
+++ b/dev/bug-plans/03-extraction-memory-growth.md
@@ -1,5 +1,18 @@
 # Bug 03 — Memory growth / per-extraction leak in extraction service
-**Severity:** medium-high (forces restarts) · **Status:** ◐ Partial — unbounded infoscience cache bounded (2026-06-12); larger suspects need profiling · **Area:** lifecycle / caching / connections
+**Severity:** medium-high (forces restarts) · **Status:** ◐ Partial — infoscience cache bounded (S2) + provider sessions closed (S3) (2026-06-12); S1 + worker-recycling still profiler/decision-gated · **Area:** lifecycle / caching / connections
+
+> **S3 fix (2026-06-12):** the ORCID/ROR providers lazily created a
+> `requests.Session` that was never closed (one leaked urllib3 pool per
+> extraction). Added `close()` to `RealORCIDProvider`/`RealRORProvider` and a
+> `ProviderSet.close()` that releases any closeable provider, and call it
+> best-effort in `_run_extract_job`'s `finally` — the background job owns the
+> ProviderSet for its lifetime and the post-extract auto-ingest hooks build their
+> own providers, so nothing uses these after the job. Covers the dominant
+> (background) extract path; the GET path is request-scoped/GC'd. Tests in
+> `tests/v2/test_provider_session_close.py`. **Still open:** S1 (per-agent-run LLM
+> clients never `aclose()`d) — the top suspect, but reusing/closing them trades
+> off the token round-robin, so it needs a profiler run + a careful design before
+> committing.
 
 > **Partial fix (2026-06-12):** bounded the clearly-unbounded suspect S2 — the
 > infoscience `_search_cache` (module-global dict written at 4+ sites; its

--- a/dev/bug-plans/04-ingest-extraction-load-isolation.md
+++ b/dev/bug-plans/04-ingest-extraction-load-isolation.md
@@ -1,5 +1,29 @@
 # Bug 04 — Index-ingest endpoints starve extraction (no load isolation)
-**Severity:** medium · **Status:** Investigated — plan ready (no code changed) · **Area:** API / scheduling / load isolation
+**Severity:** medium · **Status:** ◐ Partially fixed (2026-06-12) — Option B core + D shipped · **Area:** API / scheduling / load isolation
+
+## Resolution (2026-06-12) — Option B (core) + Option D
+
+Shipped the bounded ingest pool for the dominant thread-pool-starvation axis:
+- New `src/v2/indices/_ingest_pool.py`: a bounded, ingest-only `ThreadPoolExecutor`
+  (`V2_INGEST_MAX_THREADS`, default 2) + `run_in_ingest_pool()` (drop-in for
+  `asyncio.to_thread`) + `reset_ingest_pool()` for tests.
+- Routed the **shared heavy ingest steps** through it: `_embed_step.py` (embed pass,
+  WAL checkpoint, `.ro` snapshot — used by every provider) and `gitlab.py` (ingest +
+  embed). These are where bulk ingest holds threads for sustained periods, so the
+  default pool now stays free for extraction.
+- Option D: documented the residual constraint in `docs/OPERATIONS_RUNBOOK.md`
+  (don't run large bulk ingests concurrently with latency-sensitive extraction on a
+  1–2 worker box).
+- Tests: `tests/v2/test_ingest_pool.py` — named dedicated thread, arg/kwarg forwarding,
+  bounded concurrency (≤ cap), and the isolation property (a saturated ingest pool does
+  not delay a default-pool `asyncio.to_thread`). 51 ingest/embed/gitlab regression tests pass.
+
+**Deliberately deferred** (still on the default pool):
+- The lighter per-entity ingest *fetch* loops (`result = await asyncio.to_thread(_ingest_one_*)`)
+  in the ~14 provider modules — sequential per job and far lighter than the embed pass.
+  Route them through `run_in_ingest_pool` too if profiling shows fetch-side contention.
+- Option A (separate `gme-ingest-worker` process) — the durable fix; also the SQLite
+  cache writer-lock axis (Consequence #3) is untouched.
 
 ## Symptom
 Running `POST /v2/indices/<name>/ingest` concurrently with `POST /v2/extract` on the

--- a/dev/bug-plans/12-snsf-duckdb-bootstrap-type-error.md
+++ b/dev/bug-plans/12-snsf-duckdb-bootstrap-type-error.md
@@ -1,5 +1,30 @@
 # Bug 12 — snsf DuckDB bootstrap "Vector::Reference used on vector of different type"
-**Severity:** medium (blocks snsf index) · **Status:** Investigated — plan ready (no code changed) · **Area:** snsf index / DuckDB schema
+**Severity:** medium (blocks snsf index) · **Status:** ◐ Partial — the two empirically-fragile statements hardened (2026-06-12); exact-error diagnosis still host-gated · **Area:** snsf index / DuckDB schema
+
+## Resolution (2026-06-12) — fixes #1 + #4 (the reproduced-fragile statements)
+
+Implemented the two statement-level fixes that were empirically reproduced as
+failing (Conversion / NOT NULL) and are independently correct regardless of the
+unreproduced internal vector error:
+- **#1 persons-array migration** (`duckdb_store.py`): replaced the non-idempotent
+  `CAST(<col> AS BIGINT[])` + concat with a VARCHAR-keyed transform that passes
+  through existing grant URLs, promotes bare numeric ids, and drops null /
+  non-numeric tokens (`LIST_FILTER(LIST_TRANSFORM(CAST(... AS VARCHAR[]), CASE …))`).
+  Safe to re-run on a partially-migrated/mixed DB.
+- **#4 grant_persons null-safety** (`facets.py`): added
+  `AND json_extract_string(j.value,'$') IS NOT NULL` so a json-null array element
+  can't violate the `NOT NULL` PK.
+- Tests: new adversarial case in `test_grant_id_canonical_url.py` (mixed array:
+  already-URL + bare int + non-numeric + null migrates without raising). Full
+  `tests/index/snsf/` green (72 passed; was 71).
+
+**Still open (host-gated):** the exact `Vector::Reference …` error did **not**
+reproduce on the pinned DuckDB 1.5.3, so the remaining hardening (#2 wrap the
+migration in a transaction; #3 cast at the `INSERT … BY NAME` snapshot) and the
+definitive root-cause confirmation need the **statement-bisection diagnosis on the
+actual failing host/DuckDB version** (see Diagnosis plan). The two fixes above
+remove the two reproduced failure modes; run the host diagnosis to confirm they
+cover the reported error or to localize a remaining off-type column.
 
 ## Symptom
 Bootstrapping the `snsf` index DuckDB store raises the DuckDB internal error

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -69,6 +69,26 @@ get `[Errno 104] Connection reset by peer`, and throughput does not improve
 serial). Run client concurrency ≈ `WORKERS`; serial is both cleaner and, at
 `WORKERS=1`, faster.
 
+### Bulk ingest vs. extraction isolation (Bug 04)
+
+Bulk `/v2/indices/<p>/ingest` and interactive `/v2/extract` share one process.
+The heavy ingest steps (embed pass, WAL checkpoint, `.ro` snapshot, gitlab
+ingest/embed) now run on a **bounded, ingest-only thread pool**
+(`V2_INGEST_MAX_THREADS`, default 2) so they can no longer saturate the default
+thread pool that extraction offloads onto. This kills the dominant
+ingest-starves-extraction axis.
+
+It does **not** fully isolate the event loop or the single SQLite cache writer
+lock, so on a 1–2 worker deployment you should still **avoid running large bulk
+ingests concurrently with latency-sensitive extraction** — schedule ingest in a
+maintenance window or against a separate API replica. (The durable fix is a
+separate `gme-ingest-worker` process — see `dev/bug-plans/04`.)
+
+Note: the lighter per-entity ingest *fetch* loops (`_ingest_one_*`) still use the
+default pool; they are sequential per job and far lighter than the embed pass,
+so they were left as a follow-up — route them through `run_in_ingest_pool` too
+if profiling shows residual fetch-side contention.
+
 ## 4. Field coverage: `rule_based` vs `llm` runtime (finding #7)
 
 `agent_runtime` selects which agent fills the entity. Some fields are only

--- a/src/index/snsf/facets.py
+++ b/src/index/snsf/facets.py
@@ -64,6 +64,7 @@ def build_facets(store: SnsfStore) -> dict[str, int]:
                 FROM   persons p,
                        json_each(p.{col}) AS j
                 WHERE  p.{col} IS NOT NULL
+                  AND  json_extract_string(j.value, '$') IS NOT NULL
                 ON CONFLICT DO NOTHING
                 """,  # noqa: S608 — role and col are fixed strings from _ROLE_COL_PAIRS
             )

--- a/src/index/snsf/storage/duckdb_store.py
+++ b/src/index/snsf/storage/duckdb_store.py
@@ -127,36 +127,46 @@ class SnsfStore:
         }
         url_sql = snsf_grant_iri_sql("grant_number")
         tables = [t for t in ("grants", *_GRANT_FK_TABLES) if t in existing]
-        for table in tables:
-            conn.execute(
-                f"CREATE TEMP TABLE _mig_{table} AS "  # noqa: S608
-                f"SELECT * REPLACE ({url_sql} AS grant_number) FROM {table}",
-            )
-            conn.execute(f"DROP TABLE {table}")  # noqa: S608 — also drops its indexes
-        conn.execute(_load_schema_sql())  # recreate fresh TEXT tables + indexes
-        for table in tables:
-            conn.execute(
-                f"INSERT INTO {table} BY NAME SELECT * FROM _mig_{table}",  # noqa: S608
-            )
-            conn.execute(f"DROP TABLE _mig_{table}")  # noqa: S608
-        # persons keeps its schema; only its JSON arrays of bare integers
-        # become arrays of grant URLs.
-        if "persons" not in existing:
-            return
-        for col in _PERSON_GRANT_COLS:
-            # Idempotent + type-safe (Bug 12): cast to VARCHAR[] (never BIGINT[],
-            # which throws on already-URL or non-numeric elements), pass through
-            # existing grant URLs, promote bare numeric ids, and drop null /
-            # non-numeric tokens. Safe to re-run on a partially-migrated DB.
-            conn.execute(
-                f"UPDATE persons SET {col} = TO_JSON(LIST_FILTER("  # noqa: S608
-                f"LIST_TRANSFORM(CAST({col} AS VARCHAR[]), x -> CASE "
-                f"WHEN x IS NULL THEN NULL "
-                f"WHEN starts_with(lower(x), '{_GRANT_BASE}') THEN x "
-                f"WHEN regexp_full_match(x, '\\d+') THEN '{_GRANT_BASE}' || x "
-                f"ELSE NULL END), e -> e IS NOT NULL)) "
-                f"WHERE {col} IS NOT NULL",
-            )
+        # Atomic (Bug 12): the migration drops + recreates grants and its FK
+        # tables in place, so a mid-way failure must not leave a half-migrated
+        # DB whose gate (grants.grant_number type) disagrees with the data.
+        # Wrap the whole thing so an error rolls back to the clean pre-v3 state
+        # and the next bootstrap can retry.
+        conn.execute("BEGIN TRANSACTION")
+        try:
+            for table in tables:
+                conn.execute(
+                    f"CREATE TEMP TABLE _mig_{table} AS "  # noqa: S608
+                    f"SELECT * REPLACE ({url_sql} AS grant_number) FROM {table}",
+                )
+                conn.execute(f"DROP TABLE {table}")  # noqa: S608 — also drops its indexes
+            conn.execute(_load_schema_sql())  # recreate fresh TEXT tables + indexes
+            for table in tables:
+                conn.execute(
+                    f"INSERT INTO {table} BY NAME SELECT * FROM _mig_{table}",  # noqa: S608
+                )
+                conn.execute(f"DROP TABLE _mig_{table}")  # noqa: S608
+            # persons keeps its schema; only its JSON arrays of bare integers
+            # become arrays of grant URLs.
+            if "persons" in existing:
+                for col in _PERSON_GRANT_COLS:
+                    # Idempotent + type-safe: cast to VARCHAR[] (never BIGINT[],
+                    # which throws on already-URL or non-numeric elements), pass
+                    # through existing grant URLs, promote bare numeric ids, and
+                    # drop null / non-numeric tokens. Safe to re-run.
+                    conn.execute(
+                        f"UPDATE persons SET {col} = TO_JSON(LIST_FILTER("  # noqa: S608
+                        f"LIST_TRANSFORM(CAST({col} AS VARCHAR[]), x -> CASE "
+                        f"WHEN x IS NULL THEN NULL "
+                        f"WHEN starts_with(lower(x), '{_GRANT_BASE}') THEN x "
+                        f"WHEN regexp_full_match(x, '\\d+') THEN '{_GRANT_BASE}' || x "
+                        f"ELSE NULL END), e -> e IS NOT NULL)) "
+                        f"WHERE {col} IS NOT NULL",
+                    )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
 
     def close(self) -> None:
         if self._conn is not None:

--- a/src/index/snsf/storage/duckdb_store.py
+++ b/src/index/snsf/storage/duckdb_store.py
@@ -144,9 +144,17 @@ class SnsfStore:
         if "persons" not in existing:
             return
         for col in _PERSON_GRANT_COLS:
+            # Idempotent + type-safe (Bug 12): cast to VARCHAR[] (never BIGINT[],
+            # which throws on already-URL or non-numeric elements), pass through
+            # existing grant URLs, promote bare numeric ids, and drop null /
+            # non-numeric tokens. Safe to re-run on a partially-migrated DB.
             conn.execute(
-                f"UPDATE persons SET {col} = TO_JSON(LIST_TRANSFORM("  # noqa: S608
-                f"CAST({col} AS BIGINT[]), n -> '{_GRANT_BASE}' || n)) "
+                f"UPDATE persons SET {col} = TO_JSON(LIST_FILTER("  # noqa: S608
+                f"LIST_TRANSFORM(CAST({col} AS VARCHAR[]), x -> CASE "
+                f"WHEN x IS NULL THEN NULL "
+                f"WHEN starts_with(lower(x), '{_GRANT_BASE}') THEN x "
+                f"WHEN regexp_full_match(x, '\\d+') THEN '{_GRANT_BASE}' || x "
+                f"ELSE NULL END), e -> e IS NOT NULL)) "
                 f"WHERE {col} IS NOT NULL",
             )
 

--- a/src/v2/agents/models.py
+++ b/src/v2/agents/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import uuid
 from copy import deepcopy
@@ -187,6 +188,16 @@ class ProviderSet:
     github_rag: Any | None = None
     epfl_graph_rag: Any | None = None
     federated_rag: Any | None = None
+
+    def close(self) -> None:
+        """Best-effort release of any provider that holds a closeable resource
+        (e.g. a pooled `requests.Session`), so it isn't leaked once per
+        extraction (Bug 03). Providers without a `close()` are skipped."""
+        for provider in (self.github, self.orcid, self.infoscience, self.ror):
+            close = getattr(provider, "close", None)
+            if callable(close):
+                with contextlib.suppress(Exception):  # best-effort cleanup
+                    close()
 
 
 @dataclass(slots=True)

--- a/src/v2/api.py
+++ b/src/v2/api.py
@@ -640,6 +640,12 @@ async def _run_extract_job(
             heartbeat_task.cancel()
             with contextlib.suppress(Exception):
                 await heartbeat_task
+        # Release pooled provider HTTP sessions at end of job (Bug 03). The
+        # background job owns this ProviderSet for its whole lifetime, and the
+        # post-extract auto-ingest hooks build their own providers, so nothing
+        # uses these after the job completes.
+        with contextlib.suppress(Exception):
+            providers.close()
 
 
 def _append_unique_warning(warnings: list[str], warning: str) -> None:

--- a/src/v2/indices/_embed_step.py
+++ b/src/v2/indices/_embed_step.py
@@ -35,11 +35,12 @@ embed round-trips it follows.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 from datetime import datetime, timezone
 from typing import Any, Callable
+
+from src.v2.indices._ingest_pool import run_in_ingest_pool
 
 LOGGER = logging.getLogger(__name__)
 
@@ -89,7 +90,7 @@ async def _maybe_checkpoint(
     if store is None or not hasattr(store, "connect"):
         return {"enabled": True, "ran": False, "reason": "no store connection"}
     try:
-        await asyncio.to_thread(_checkpoint_sync, store)
+        await run_in_ingest_pool(_checkpoint_sync, store)
         return {"enabled": True, "ran": True, "ok": True}
     except Exception as exc:  # noqa: BLE001 — checkpoint is best-effort
         LOGGER.warning(
@@ -113,7 +114,7 @@ async def _maybe_snapshot(
     from src.index._snapshot import publish_snapshot  # noqa: PLC0415
 
     try:
-        return await asyncio.to_thread(
+        return await run_in_ingest_pool(
             lambda: publish_snapshot(store.connect(), store.db_path),
         )
     except Exception as exc:  # noqa: BLE001 — snapshot is best-effort
@@ -130,10 +131,12 @@ async def run_embed_step(
 ) -> dict[str, Any]:
     """Run a sync embed callable in a worker thread; return a summary block.
 
-    The closure is dispatched via ``asyncio.to_thread`` so blocking I/O
-    (HTTP to RCP, Qdrant upserts, DuckDB reads) doesn't block the
-    event loop. Exceptions are caught, logged, and surfaced in the
-    returned dict — never re-raised, since the ingest half has
+    The closure is dispatched on the bounded ingest pool
+    (``run_in_ingest_pool``) so blocking I/O (HTTP to RCP, Qdrant
+    upserts, DuckDB reads) doesn't block the event loop and a bulk
+    ingest can't saturate the default thread pool that extraction
+    relies on (Bug 04). Exceptions are caught, logged, and surfaced in
+    the returned dict — never re-raised, since the ingest half has
     already committed and the operator just needs to know the embed
     half did not.
 
@@ -147,7 +150,7 @@ async def run_embed_step(
     started = datetime.now(timezone.utc)
     out: dict[str, Any] = {"started_at": started.isoformat()}
     try:
-        result = await asyncio.to_thread(embed_call)
+        result = await run_in_ingest_pool(embed_call)
         out["ok"] = True
         out["result"] = result
     except Exception as exc:  # noqa: BLE001 — embed failures must not crash ingest job

--- a/src/v2/indices/_ingest_pool.py
+++ b/src/v2/indices/_ingest_pool.py
@@ -1,0 +1,69 @@
+"""Bounded, ingest-only thread pool (Bug 04 — ingest/extraction load isolation).
+
+Bulk index ingestion and interactive extraction run in the same process. Both
+offload their blocking work with ``asyncio.to_thread``, which dispatches to the
+event loop's *default* ``ThreadPoolExecutor``. A burst of ingest work therefore
+saturates that shared pool and extraction's offloaded calls queue behind it,
+collapsing extraction throughput.
+
+This module gives the heavy ingest steps (the per-provider embed pass, WAL
+checkpoint, and read-only snapshot, plus the gitlab ingest/embed) their own
+*bounded* pool, so they can never hold more than ``V2_INGEST_MAX_THREADS``
+threads and the default pool stays free for extraction. ``run_in_ingest_pool``
+is a drop-in for ``asyncio.to_thread``.
+"""
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, TypeVar
+
+LOGGER = logging.getLogger(__name__)
+
+_ENV_VAR = "V2_INGEST_MAX_THREADS"
+_DEFAULT_MAX_THREADS = 2
+
+_T = TypeVar("_T")
+_executor: ThreadPoolExecutor | None = None
+
+
+def _max_threads() -> int:
+    raw = os.getenv(_ENV_VAR)
+    if raw is None or not raw.strip():
+        return _DEFAULT_MAX_THREADS
+    try:
+        return max(1, int(raw.strip()))
+    except ValueError:
+        LOGGER.warning("invalid %s=%r; falling back to %d", _ENV_VAR, raw, _DEFAULT_MAX_THREADS)
+        return _DEFAULT_MAX_THREADS
+
+
+def ingest_executor() -> ThreadPoolExecutor:
+    """The process-wide bounded ingest pool (created lazily, on first use)."""
+    global _executor  # noqa: PLW0603 — module-level lazy singleton
+    if _executor is None:
+        workers = _max_threads()
+        _executor = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="gme-ingest")
+        LOGGER.info("ingest thread pool created (max_workers=%d)", workers)
+    return _executor
+
+
+async def run_in_ingest_pool(func: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
+    """Drop-in for ``asyncio.to_thread`` that runs ``func`` on the bounded
+    ingest pool instead of the shared default pool, so ingest can't starve
+    extraction (Bug 04)."""
+    loop = asyncio.get_running_loop()
+    call = functools.partial(func, *args, **kwargs)
+    return await loop.run_in_executor(ingest_executor(), call)
+
+
+def reset_ingest_pool() -> None:
+    """Tear down the pool so the next call rebuilds it (e.g. to pick up a new
+    ``V2_INGEST_MAX_THREADS``). Intended for tests."""
+    global _executor  # noqa: PLW0603 — module-level lazy singleton
+    if _executor is not None:
+        _executor.shutdown(wait=False)
+        _executor = None

--- a/src/v2/indices/gitlab.py
+++ b/src/v2/indices/gitlab.py
@@ -22,6 +22,7 @@ from src.v2.api_models import (
     IndexSearchRequest,
     IndexSearchResponse,
 )
+from src.v2.indices._ingest_pool import run_in_ingest_pool
 from src.v2.indices._search_common import hit_from_raw
 
 if TYPE_CHECKING:
@@ -74,8 +75,8 @@ async def run_gitlab_ingest_job(
             job_store.set(existing)
             return
 
-        ingested = await asyncio.to_thread(ingest_mod.run_ingest, limit=payload.limit)
-        embedded = await asyncio.to_thread(embed_mod.run_embed)
+        ingested = await run_in_ingest_pool(ingest_mod.run_ingest, limit=payload.limit)
+        embedded = await run_in_ingest_pool(embed_mod.run_embed)
 
         finished = job_store.get(job_id) or existing
         finished.status = IndexIngestJobStatus.COMPLETED

--- a/src/v2/ingest/infoscience.py
+++ b/src/v2/ingest/infoscience.py
@@ -7,6 +7,7 @@ for publications, authors, labs, and organizational units.
 
 import logging
 import os
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -28,8 +29,37 @@ REQUEST_TIMEOUT = 30
 # Authentication token (optional, for protected endpoints)
 INFOSCIENCE_TOKEN = os.getenv("INFOSCIENCE_TOKEN")
 
-# Simple in-memory cache to prevent duplicate searches in same session
-_search_cache: Dict[str, str] = {}
+class _BoundedStrCache(OrderedDict):
+    """Size-bounded FIFO string cache. Evicts the oldest entries once it grows
+    past ``maxsize`` so this process-lifetime search cache can't grow without
+    bound (Bug 03 — ``clear_infoscience_cache()`` is never called during
+    serving, so an unbounded dict would leak for the whole process lifetime)."""
+
+    def __init__(self, maxsize: int) -> None:
+        super().__init__()
+        self._maxsize = max(1, maxsize)
+
+    def __setitem__(self, key: str, value: str) -> None:
+        if key in self:
+            super().__delitem__(key)  # refresh recency on re-insert
+        super().__setitem__(key, value)
+        while len(self) > self._maxsize:
+            super().__delitem__(next(iter(self)))  # drop oldest
+
+
+def _cache_maxsize() -> int:
+    raw = os.getenv("V2_INFOSCIENCE_CACHE_MAXSIZE")
+    if raw and raw.strip():
+        try:
+            return max(1, int(raw.strip()))
+        except ValueError:
+            logger.warning("invalid V2_INFOSCIENCE_CACHE_MAXSIZE=%r; using 512", raw)
+    return 512
+
+
+# In-memory cache to dedupe searches within a session, bounded so it can't
+# grow unboundedly over the process lifetime.
+_search_cache: "OrderedDict[str, str]" = _BoundedStrCache(_cache_maxsize())
 
 
 def clear_infoscience_cache():

--- a/src/v2/ingest/providers/orcid_provider.py
+++ b/src/v2/ingest/providers/orcid_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import calendar
+import contextlib
 import logging
 import re
 from datetime import date
@@ -176,6 +177,14 @@ class RealORCIDProvider(ORCIDProvider):
         if self._session is None:
             self._session = requests.Session()
         return self._session
+
+    def close(self) -> None:
+        """Close the pooled HTTP session if one was lazily created, so its
+        urllib3 connection pool isn't leaked once per extraction (Bug 03)."""
+        if self._session is not None:
+            with contextlib.suppress(Exception):  # best-effort cleanup
+                self._session.close()
+            self._session = None
 
     def _request(
         self,

--- a/src/v2/ingest/providers/ror_provider.py
+++ b/src/v2/ingest/providers/ror_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 import requests
@@ -193,6 +194,14 @@ class RealRORProvider(RORProvider):
         if self._session is None:
             self._session = requests.Session()
         return self._session
+
+    def close(self) -> None:
+        """Close the pooled HTTP session if one was lazily created, so its
+        urllib3 connection pool isn't leaked once per extraction (Bug 03)."""
+        if self._session is not None:
+            with contextlib.suppress(Exception):  # best-effort cleanup
+                self._session.close()
+            self._session = None
 
     def _request(
         self,

--- a/src/v2/pipeline/stages/context_gather.py
+++ b/src/v2/pipeline/stages/context_gather.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
@@ -600,7 +601,7 @@ async def gather_context(  # noqa: C901, PLR0915
         languages: dict[str, int] = {}
 
         try:
-            repository_metadata = providers.github.get_repository(full_name)
+            repository_metadata = await asyncio.to_thread(providers.github.get_repository, full_name)
         except Exception as exc:  # noqa: BLE001
             raise RequiredProviderUnavailableError(
                 provider="github",
@@ -609,7 +610,7 @@ async def gather_context(  # noqa: C901, PLR0915
             ) from exc
 
         try:
-            contributors = providers.github.get_contributors(full_name)
+            contributors = await asyncio.to_thread(providers.github.get_contributors, full_name)
         except Exception as exc:  # noqa: BLE001
             raise RequiredProviderUnavailableError(
                 provider="github",
@@ -617,14 +618,15 @@ async def gather_context(  # noqa: C901, PLR0915
                 cause=exc,
             ) from exc
 
-        cap_warning = _enrich_contributors_with_commit_bookends(
+        cap_warning = await asyncio.to_thread(
+            _enrich_contributors_with_commit_bookends,
             full_name, contributors, providers,
         )
         if cap_warning:
             warnings.append(cap_warning)
 
         try:
-            languages = providers.github.get_languages(full_name)
+            languages = await asyncio.to_thread(providers.github.get_languages, full_name)
         except Exception as exc:  # noqa: BLE001
             raise RequiredProviderUnavailableError(
                 provider="github",
@@ -634,7 +636,7 @@ async def gather_context(  # noqa: C901, PLR0915
 
         readme_from_provider = ""
         try:
-            readme_from_provider = providers.github.get_repository_readme(full_name)
+            readme_from_provider = await asyncio.to_thread(providers.github.get_repository_readme, full_name)
         except Exception as exc:  # noqa: BLE001
             warnings.append(
                 f"Repository README fetch failed for {full_name}: {exc}",
@@ -652,10 +654,10 @@ async def gather_context(  # noqa: C901, PLR0915
         else:
             readme_content = _clean_readme_for_llm(readme_content)
 
-        gimie_jsonld = providers.github.get_repository_jsonld(full_name)
+        gimie_jsonld = await asyncio.to_thread(providers.github.get_repository_jsonld, full_name)
 
         try:
-            aux_files = providers.github.get_repository_aux_files(full_name)
+            aux_files = await asyncio.to_thread(providers.github.get_repository_aux_files, full_name)
         except Exception as exc:  # noqa: BLE001
             warnings.append(
                 f"Repository aux-files lookup failed for {full_name}: {exc}",
@@ -665,7 +667,7 @@ async def gather_context(  # noqa: C901, PLR0915
         # Releases + container images (best-effort; same as
         # _optional_repository_context above).
         try:
-            releases = providers.github.get_repository_releases(full_name)
+            releases = await asyncio.to_thread(providers.github.get_repository_releases, full_name)
             if isinstance(releases, list) and releases:
                 repository_metadata["releases"] = releases
         except Exception as exc:  # noqa: BLE001
@@ -673,7 +675,7 @@ async def gather_context(  # noqa: C901, PLR0915
                 f"Repository releases lookup failed for {full_name}: {exc}",
             )
         try:
-            container_images = providers.github.get_repository_container_images(full_name)
+            container_images = await asyncio.to_thread(providers.github.get_repository_container_images, full_name)
             if isinstance(container_images, list) and container_images:
                 repository_metadata["container_images"] = container_images
         except Exception as exc:  # noqa: BLE001
@@ -681,7 +683,7 @@ async def gather_context(  # noqa: C901, PLR0915
                 f"Repository container-images lookup failed for {full_name}: {exc}",
             )
         try:
-            profile = providers.github.get_repository_community_profile(full_name)
+            profile = await asyncio.to_thread(providers.github.get_repository_community_profile, full_name)
             if isinstance(profile, dict):
                 repository_metadata["community_profile"] = profile
         except Exception as exc:  # noqa: BLE001
@@ -689,7 +691,7 @@ async def gather_context(  # noqa: C901, PLR0915
                 f"Repository community-profile lookup failed for {full_name}: {exc}",
             )
         try:
-            tags = providers.github.get_repository_tags(full_name)
+            tags = await asyncio.to_thread(providers.github.get_repository_tags, full_name)
             if isinstance(tags, list) and tags:
                 repository_metadata["git_tags"] = tags
         except Exception as exc:  # noqa: BLE001
@@ -697,7 +699,7 @@ async def gather_context(  # noqa: C901, PLR0915
                 f"Repository tags lookup failed for {full_name}: {exc}",
             )
         try:
-            compose_files = providers.github.get_repository_compose_files(full_name)
+            compose_files = await asyncio.to_thread(providers.github.get_repository_compose_files, full_name)
             if isinstance(compose_files, list) and compose_files:
                 repository_metadata["compose_files"] = compose_files
         except Exception as exc:  # noqa: BLE001
@@ -707,7 +709,7 @@ async def gather_context(  # noqa: C901, PLR0915
 
         # CI detection (best-effort; None on provider failure).
         try:
-            root_entries = providers.github.get_repository_root_entries(full_name)
+            root_entries = await asyncio.to_thread(providers.github.get_repository_root_entries, full_name)
             repository_metadata["has_ci"] = detect_has_ci(root_entries)
         except Exception as exc:  # noqa: BLE001
             warnings.append(
@@ -749,7 +751,7 @@ async def gather_context(  # noqa: C901, PLR0915
         user_profile: dict[str, Any] = {}
 
         try:
-            user_profile = providers.github.get_user(username)
+            user_profile = await asyncio.to_thread(providers.github.get_user, username)
         except Exception as exc:  # noqa: BLE001
             raise RequiredProviderUnavailableError(
                 provider="github",
@@ -770,7 +772,8 @@ async def gather_context(  # noqa: C901, PLR0915
         if should_expand_owned_repos():
             for repo in owned_repos:
                 full_name = _normalize_owned_repo_full_name(username, repo)
-                repository_context = _optional_repository_context(
+                repository_context = await asyncio.to_thread(
+                    _optional_repository_context,
                     full_name=full_name,
                     providers=providers,
                     warnings=warnings,
@@ -786,7 +789,9 @@ async def gather_context(  # noqa: C901, PLR0915
         orcid_data: dict[str, Any] | None = None
         if providers.orcid and orcid_id:
             try:
-                orcid_data = providers.orcid.get_person_by_orcid(orcid_id)
+                orcid_data = await asyncio.to_thread(
+                    providers.orcid.get_person_by_orcid, orcid_id,
+                )
             except Exception as exc:  # noqa: BLE001
                 warnings.append(f"ORCID lookup failed: {exc}")
         else:
@@ -810,7 +815,9 @@ async def gather_context(  # noqa: C901, PLR0915
         organization_profile: dict[str, Any] = {}
 
         try:
-            organization_profile = providers.github.get_organization(organization_name)
+            organization_profile = await asyncio.to_thread(
+                providers.github.get_organization, organization_name,
+            )
         except Exception as exc:  # noqa: BLE001
             raise RequiredProviderUnavailableError(
                 provider="github",
@@ -828,7 +835,8 @@ async def gather_context(  # noqa: C901, PLR0915
         if should_expand_owned_repos():
             for repo in owned_repos:
                 full_name = _normalize_owned_repo_full_name(organization_name, repo)
-                repository_context = _optional_repository_context(
+                repository_context = await asyncio.to_thread(
+                    _optional_repository_context,
                     full_name=full_name,
                     providers=providers,
                     warnings=warnings,

--- a/src/v2/pipeline/stages/ownership_check.py
+++ b/src/v2/pipeline/stages/ownership_check.py
@@ -511,6 +511,9 @@ def infer_owners(
                 "idSource": "pulse:githubUsername",
                 "schema:name": handle,
                 "pulse:githubUsername": handle,
+                # Reference-only placeholder for an inferred owner, not an
+                # independently-extracted Person (Bug 07: complete `_stub`).
+                "_stub": True,
             },
         )
         seen_stubs.add(target_id)
@@ -1731,6 +1734,10 @@ def _synthesize_owner_person_stub(handle: str) -> dict[str, Any]:
         "org:hasMembership": [],
         "pulse:hasContribution": [],
         "pulse:owns": [],
+        # Reference-only placeholder (synthesized from a handle), not an
+        # independently-extracted Person — complete the `_stub` signal so its
+        # absence reliably means "fully extracted" (Bug 07).
+        "_stub": True,
     }
 
 

--- a/src/v2/pipeline/stages/refine_with_llm.py
+++ b/src/v2/pipeline/stages/refine_with_llm.py
@@ -2128,7 +2128,12 @@ async def _run_discovery_pass(
         e, w = _materialize_org(o, existing_org_ids)
         _accept(e, w, org_bucket, existing_org_ids)
     for a in proposal.new_articles[:DISCOVERY_REPLY_MAX_PER_TYPE]:
-        article, new_persons, warning = _materialize_article(
+        # _materialize_article does a blocking OpenAlex DOI lookup
+        # (_openalex_lookup_doi → requests.get, 15s) — offload it so it doesn't
+        # freeze the event loop during a hybrid extraction (Bug 02). Sequential
+        # await keeps the shared dedup dicts race-free.
+        article, new_persons, warning = await asyncio.to_thread(
+            _materialize_article,
             a, existing_article_ids, existing_person_ids, person_dedup_index,
         )
         _accept(article, warning, article_bucket, existing_article_ids)

--- a/tests/index/snsf/test_grant_id_canonical_url.py
+++ b/tests/index/snsf/test_grant_id_canonical_url.py
@@ -162,3 +162,31 @@ def test_migration_persons_array_tolerates_url_null_and_nonnumeric(tmp_path: Pat
         "https://data.snf.ch/grants/grant/999",     # bare int → promoted
     ]  # 'abc' and null dropped
     conn.close()
+
+
+def test_migration_rolls_back_on_failure(tmp_path: Path) -> None:
+    """Bug 12: the migration is atomic — a mid-way failure must leave the DB in
+    its clean pre-v3 (INTEGER) state, not half-migrated. Force a failure by
+    omitting a `_PERSON_GRANT_COLS` column so the persons UPDATE raises after
+    grants has already been rebuilt; assert grants is rolled back to INTEGER."""
+    conn = duckdb.connect(str(tmp_path / "rollback.duckdb"))
+    conn.execute("CREATE TABLE grants (grant_number INTEGER PRIMARY KEY, title TEXT)")
+    conn.execute("INSERT INTO grants VALUES (241892, 'A')")
+    # persons is missing the other six grant columns → the per-col UPDATE loop
+    # raises a Binder error partway through the (already-started) migration.
+    conn.execute(
+        "CREATE TABLE persons (person_number INTEGER, "
+        "responsible_applicant_grants JSON)",
+    )
+    conn.execute("INSERT INTO persons VALUES (1, TO_JSON([241892]))")
+
+    with pytest.raises(Exception):  # noqa: B017, PT011 — any failure must roll back
+        SnsfStore._migrate_grant_ids_to_url(conn)
+
+    dtype = conn.execute(
+        "SELECT data_type FROM information_schema.columns "
+        "WHERE table_name = 'grants' AND column_name = 'grant_number'",
+    ).fetchone()[0]
+    assert "INT" in str(dtype).upper()  # rolled back to pre-v3 INTEGER
+    assert conn.execute("SELECT grant_number FROM grants").fetchone()[0] == 241892
+    conn.close()

--- a/tests/index/snsf/test_grant_id_canonical_url.py
+++ b/tests/index/snsf/test_grant_id_canonical_url.py
@@ -119,3 +119,46 @@ def test_migration_promotes_legacy_integer_ids(tmp_path: Path) -> None:
     SnsfStore._migrate_grant_ids_to_url(conn)
     assert conn.execute("SELECT grant_number FROM grants WHERE title = 'A'").fetchone()[0] == _URL
     conn.close()
+
+
+def test_migration_persons_array_tolerates_url_null_and_nonnumeric(tmp_path: Path) -> None:
+    """Bug 12: a partially-migrated / mixed persons array (already-URL element,
+    bare int, non-numeric token, null) must migrate without raising. The old
+    `CAST(<col> AS BIGINT[])` threw a Conversion Error here; the VARCHAR-keyed
+    transform passes URLs through, promotes ints, and drops null/non-numeric."""
+    import json
+
+    conn = duckdb.connect(str(tmp_path / "mixed.duckdb"))
+    conn.execute("CREATE TABLE grants (grant_number INTEGER PRIMARY KEY, title TEXT)")
+    conn.execute("INSERT INTO grants VALUES (241892, 'A')")
+    conn.execute("CREATE TABLE output_publications (publication_id TEXT, grant_number INTEGER)")
+    conn.execute("INSERT INTO output_publications VALUES ('p1', 241892)")
+    conn.execute("CREATE TABLE scope_records (scope_mode TEXT, grant_number INTEGER)")
+    conn.execute("INSERT INTO scope_records VALUES ('epfl', 241892)")
+    conn.execute(
+        "CREATE TABLE persons (person_number INTEGER, orcid TEXT, "
+        "research_institution TEXT, "
+        "responsible_applicant_grants JSON, co_applicant_grants JSON, "
+        "project_partner_grants JSON, practice_partner_grants JSON, "
+        "employee_grants JSON, contact_person_grants JSON, "
+        "applicant_abroad_grants JSON)",
+    )
+    # Raw JSON literal so the array can legitimately hold mixed types (string
+    # URL, number, non-numeric token, json null) the way a partially-migrated
+    # DB would. A DuckDB list literal can't mix those types.
+    conn.execute(
+        "INSERT INTO persons VALUES (1, NULL, NULL, "
+        "'[\"https://data.snf.ch/grants/grant/241892\", 999, \"abc\", null]'::JSON, "
+        "NULL, NULL, NULL, NULL, NULL, NULL)",
+    )
+
+    SnsfStore._migrate_grant_ids_to_url(conn)  # must not raise
+
+    arr = json.loads(
+        conn.execute("SELECT responsible_applicant_grants FROM persons").fetchone()[0],
+    )
+    assert arr == [
+        "https://data.snf.ch/grants/grant/241892",  # already-URL → passed through
+        "https://data.snf.ch/grants/grant/999",     # bare int → promoted
+    ]  # 'abc' and null dropped
+    conn.close()

--- a/tests/v2/test_infoscience_cache_bound.py
+++ b/tests/v2/test_infoscience_cache_bound.py
@@ -1,0 +1,44 @@
+# tests/v2/test_infoscience_cache_bound.py
+"""Bug 03: the infoscience in-memory search cache is never cleared during
+serving, so an unbounded dict leaks for the whole process lifetime. It is now a
+size-bounded FIFO cache.
+"""
+from __future__ import annotations
+
+from src.v2.ingest.infoscience import _BoundedStrCache
+
+
+def test_evicts_oldest_past_maxsize():
+    cache = _BoundedStrCache(maxsize=3)
+    for i in range(5):
+        cache[f"k{i}"] = str(i)
+    assert len(cache) == 3
+    assert "k0" not in cache and "k1" not in cache  # oldest two evicted
+    assert "k4" in cache and cache["k4"] == "4"
+
+
+def test_reinsert_refreshes_recency():
+    cache = _BoundedStrCache(maxsize=2)
+    cache["a"] = "1"
+    cache["b"] = "2"
+    cache["a"] = "3"          # refresh "a" → now newest
+    cache["c"] = "4"          # evicts oldest, which is now "b"
+    assert "a" in cache and cache["a"] == "3"
+    assert "b" not in cache
+    assert "c" in cache
+
+
+def test_behaves_like_a_dict_for_existing_access_pattern():
+    cache = _BoundedStrCache(maxsize=8)
+    cache["q"] = "result"
+    assert "q" in cache          # `if cache_key in _search_cache`
+    assert cache["q"] == "result"  # `return _search_cache[cache_key]`
+    cache.clear()                 # clear_infoscience_cache()
+    assert "q" not in cache and len(cache) == 0
+
+
+def test_maxsize_floor_is_one():
+    cache = _BoundedStrCache(maxsize=0)
+    cache["a"] = "1"
+    cache["b"] = "2"
+    assert len(cache) == 1 and "b" in cache

--- a/tests/v2/test_ingest_pool.py
+++ b/tests/v2/test_ingest_pool.py
@@ -1,0 +1,74 @@
+# tests/v2/test_ingest_pool.py
+"""Bug 04: the bounded ingest pool keeps bulk ingestion off the default thread
+pool that extraction relies on, so ingest can't starve extraction.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from src.v2.indices._ingest_pool import (
+    reset_ingest_pool,
+    run_in_ingest_pool,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_pool():
+    reset_ingest_pool()
+    yield
+    reset_ingest_pool()
+
+
+def test_runs_on_dedicated_named_thread():
+    name = asyncio.run(run_in_ingest_pool(lambda: threading.current_thread().name))
+    assert name.startswith("gme-ingest")
+
+
+def test_returns_result_and_forwards_args_kwargs():
+    assert asyncio.run(run_in_ingest_pool(lambda a, b: a + b, 2, b=3)) == 5
+
+
+def test_bounded_concurrency(monkeypatch):
+    monkeypatch.setenv("V2_INGEST_MAX_THREADS", "2")
+    reset_ingest_pool()
+    lock = threading.Lock()
+    state = {"current": 0, "peak": 0}
+
+    def work() -> None:
+        with lock:
+            state["current"] += 1
+            state["peak"] = max(state["peak"], state["current"])
+        time.sleep(0.05)
+        with lock:
+            state["current"] -= 1
+
+    async def go():
+        await asyncio.gather(*(run_in_ingest_pool(work) for _ in range(6)))
+
+    asyncio.run(go())
+    assert state["peak"] <= 2  # never exceeds the configured cap
+
+
+def test_saturated_ingest_pool_does_not_block_extraction_offload(monkeypatch):
+    # The core isolation property: a fully-occupied ingest pool must not delay
+    # an extraction-path asyncio.to_thread call (which uses the default pool).
+    monkeypatch.setenv("V2_INGEST_MAX_THREADS", "1")
+    reset_ingest_pool()
+    release = threading.Event()
+
+    async def go():
+        blocked = asyncio.create_task(run_in_ingest_pool(release.wait))
+        await asyncio.sleep(0.05)  # let it occupy the single ingest thread
+        try:
+            # default-pool offload must still complete promptly despite the
+            # ingest pool being saturated
+            return await asyncio.wait_for(asyncio.to_thread(lambda: "ok"), timeout=2.0)
+        finally:
+            release.set()
+            await blocked
+
+    assert asyncio.run(go()) == "ok"

--- a/tests/v2/test_ownership_check.py
+++ b/tests/v2/test_ownership_check.py
@@ -2,10 +2,20 @@ from __future__ import annotations
 
 from src.v2.pipeline.stages.models import AssembledOutput, ReconciledEntities
 from src.v2.pipeline.stages.ownership_check import (
+    _synthesize_owner_person_stub,
     guarantee_repo_author,
     infer_owners,
     validate_ownership,
 )
+
+
+def test_synthesized_owner_person_is_marked_reference_stub():
+    # Bug 07: genuine placeholders must carry `_stub` so its absence reliably
+    # means "independently extracted".
+    person = _synthesize_owner_person_stub("octocat")
+    assert person["_stub"] is True
+    assert person["id"] == "https://github.com/octocat"
+    assert person["type"] == "schema:Person"
 
 
 def _person(*, github_username: str, owns: list) -> dict:

--- a/tests/v2/test_provider_session_close.py
+++ b/tests/v2/test_provider_session_close.py
@@ -1,0 +1,44 @@
+# tests/v2/test_provider_session_close.py
+"""Bug 03 (S3): provider HTTP sessions were never closed, leaking a urllib3
+connection pool once per extraction. Providers + ProviderSet now expose close().
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from src.v2.agents.models import ProviderSet
+from src.v2.ingest.providers.orcid_provider import RealORCIDProvider
+from src.v2.ingest.providers.ror_provider import RealRORProvider
+
+
+def test_orcid_provider_close_closes_and_nulls_session():
+    provider = RealORCIDProvider()
+    session = MagicMock()
+    provider._session = session
+    provider.close()
+    session.close.assert_called_once()
+    assert provider._session is None
+    provider.close()  # idempotent — no session, no error
+
+
+def test_ror_provider_close_closes_and_nulls_session():
+    provider = RealRORProvider()
+    session = MagicMock()
+    provider._session = session
+    provider.close()
+    session.close.assert_called_once()
+    assert provider._session is None
+
+
+def test_provider_set_close_calls_closeable_and_skips_others():
+    flags = {"closed": False}
+
+    class _Closeable:
+        def close(self) -> None:
+            flags["closed"] = True
+
+    class _NoClose:
+        pass
+
+    ProviderSet(github=_NoClose(), orcid=_Closeable()).close()  # must not raise
+    assert flags["closed"] is True


### PR DESCRIPTION
…xtraction (Bug 04)

Bulk /v2/indices/<p>/ingest and interactive /v2/extract share one process and
both offload via asyncio.to_thread to the *default* ThreadPoolExecutor, so a
burst of ingest saturates the pool and extraction's offloaded calls queue behind
it (throughput collapse + connection resets).

Fix (Option B core + D): add a bounded, ingest-only pool
(src/v2/indices/_ingest_pool.py, V2_INGEST_MAX_THREADS, default 2) and route the
heavy shared ingest steps through it — _embed_step.py (embed pass, WAL
checkpoint, .ro snapshot; used by every provider) and gitlab.py (ingest+embed).
The default pool now stays free for extraction. Documented the residual
constraint in the operations runbook.

Deferred: the lighter per-entity fetch loops (still on the default pool;
sequential per job) and Option A (separate ingest worker process).

Tests: dedicated-thread, arg forwarding, bounded concurrency, and the isolation
property (saturated ingest pool doesn't delay a default-pool to_thread). 51
ingest/embed/gitlab regression tests pass; new file lint-clean.