### PR TITLE
test(v1): fix gimie token-normalization tests for the sidecar migration

### DIFF
--- a/tests/v1/test_gimie_legacy_token_normalization.py
+++ b/tests/v1/test_gimie_legacy_token_normalization.py
@@ -41,6 +41,9 @@ def _clear_env(monkeypatch):
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GME_GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GME_GITHUB_TOKEN_POOL", raising=False)
+    # Force the in-process path: `extract_gimie` short-circuits to the gimie-api
+    # sidecar whenever GIMIE_API_URL is set, bypassing the token-env shim here.
+    monkeypatch.delenv("GIMIE_API_URL", raising=False)
     _StubProject.captured_github_token = None
 
 
@@ -48,7 +51,7 @@ def test_pool_first_token_promoted_to_legacy_env(monkeypatch):
     monkeypatch.setenv("GME_GITHUB_TOKEN_POOL", "ghp_pool_a,ghp_pool_b,ghp_pool_c")
     monkeypatch.setenv("GME_GITHUB_TOKEN", "ghp_pool_a")
 
-    with patch.object(gimie_methods, "Project", _StubProject):
+    with patch.object(gimie_methods, "_ensure_gimie_project", lambda: _StubProject):
         gimie_methods.extract_gimie("https://github.com/owner/repo")
 
     assert _StubProject.captured_github_token == "ghp_pool_a"
@@ -57,7 +60,7 @@ def test_pool_first_token_promoted_to_legacy_env(monkeypatch):
 def test_gme_single_used_when_pool_unset(monkeypatch):
     monkeypatch.setenv("GME_GITHUB_TOKEN", "ghp_solo")
 
-    with patch.object(gimie_methods, "Project", _StubProject):
+    with patch.object(gimie_methods, "_ensure_gimie_project", lambda: _StubProject):
         gimie_methods.extract_gimie("https://github.com/owner/repo")
 
     assert _StubProject.captured_github_token == "ghp_solo"
@@ -66,7 +69,7 @@ def test_gme_single_used_when_pool_unset(monkeypatch):
 def test_legacy_multi_comma_value_collapsed_to_first(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_legacy_a,ghp_legacy_b")
 
-    with patch.object(gimie_methods, "Project", _StubProject):
+    with patch.object(gimie_methods, "_ensure_gimie_project", lambda: _StubProject):
         gimie_methods.extract_gimie("https://github.com/owner/repo")
 
     assert _StubProject.captured_github_token == "ghp_legacy_a"
@@ -78,7 +81,7 @@ def test_prior_legacy_value_restored_on_success(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_prior_legacy")
     monkeypatch.setenv("GME_GITHUB_TOKEN_POOL", "ghp_pool_a,ghp_pool_b")
 
-    with patch.object(gimie_methods, "Project", _StubProject):
+    with patch.object(gimie_methods, "_ensure_gimie_project", lambda: _StubProject):
         gimie_methods.extract_gimie("https://github.com/owner/repo")
 
     assert _StubProject.captured_github_token == "ghp_pool_a"
@@ -88,7 +91,7 @@ def test_prior_legacy_value_restored_on_success(monkeypatch):
 def test_prior_unset_left_unset_on_success(monkeypatch):
     monkeypatch.setenv("GME_GITHUB_TOKEN_POOL", "ghp_pool_a")
 
-    with patch.object(gimie_methods, "Project", _StubProject):
+    with patch.object(gimie_methods, "_ensure_gimie_project", lambda: _StubProject):
         gimie_methods.extract_gimie("https://github.com/owner/repo")
 
     assert _StubProject.captured_github_token == "ghp_pool_a"
@@ -96,7 +99,7 @@ def test_prior_unset_left_unset_on_success(monkeypatch):
 
 
 def test_no_tokens_anywhere_leaves_env_untouched(monkeypatch):
-    with patch.object(gimie_methods, "Project", _StubProject):
+    with patch.object(gimie_methods, "_ensure_gimie_project", lambda: _StubProject):
         gimie_methods.extract_gimie("https://github.com/owner/repo")
 
     assert _StubProject.captured_github_token is None
@@ -114,7 +117,7 @@ def test_env_restored_when_gimie_raises(monkeypatch):
         def extract(self):
             raise RuntimeError("gimie blew up")
 
-    with patch.object(gimie_methods, "Project", _BoomProject):
+    with patch.object(gimie_methods, "_ensure_gimie_project", lambda: _BoomProject):
         with pytest.raises(RuntimeError, match="gimie blew up"):
             gimie_methods.extract_gimie("https://github.com/owner/repo")
 


### PR DESCRIPTION
…ommit 1 of 6 for v2.2.0)

Foundation for the v2.2.0 URL-identifiers migration (see
`.internal/plan-2.2.0-url-identifiers.md`). Zero behaviour change —
the helpers are not yet used anywhere outside their own tests.

Helpers shipped:

  - `src/v2/canonicalization/doi.py` — re-exports `doi_iri` and
    `parse_doi` from `src/index/_shared/doi.py` (the existing shared
    helper used by every catalog backend since
    `feat/all-catalogs-doi-urls`). Lets v2 code import from
    `src.v2.canonicalization` without reaching into the index
    subsystem.
  - `src/v2/canonicalization/infoscience.py` — three URL constructors:
    `infoscience_person_iri`, `infoscience_org_iri` (→ `/entities/
    orgunit/`, not `organization` — that's Infoscience's URL
    convention), `infoscience_article_iri` (→ `/entities/publication/`).
    Plus `parse_infoscience_iri` returning `(kind, uuid)`. UUID4-strict.
    Tolerates bare UUID + canonical URL + trailing slash. Rejects
    cross-kind URL inputs (passing an org URL to `person_iri`
    surfaces the type mismatch loudly).
  - `src/v2/canonicalization/github.py` — three URL constructors:
    `github_user_iri`, `github_org_iri` (alias of user — same URL
    shape, separate name for caller-side readability), `github_repo_iri`
    for `owner/repo`. Plus three parse functions. Enforces GitHub's
    handle regex (1-39 chars, alphanumeric + single hyphens,
    no leading/trailing hyphen, no double hyphens). Tolerates bare
    handle / canonical URL / leading `@` / trailing slash.

Every helper follows the established contract from `doi_iri` /
`orcid_iri`: idempotent on canonical input, tolerates every
on-the-wire shape we've seen, returns None on malformed input,
case-insensitive scheme/host.

Tests (95 total):
  - 5 in `tests/v2/test_doi_canonicalization_v2.py` (re-export smoke)
  - 31 in `tests/v2/test_infoscience_canonicalization.py` (all three
    kinds, type-mismatch rejection, UUID4 strict, parse round-trip)
  - 32 in `tests/v2/test_github_canonicalization.py` (user/org/repo,
    URL + bare + dotted-repo-names, handle-regex rejection paths)
  - (27 existing in `tests/v2/test_orcid_canonicalization.py` — from
    `feat/v2-orcid-url-canonicalization`)

Next commits per the plan: schema + ontology + emit-site updates for
each identifier type (DOI, ORCID, Infoscience, GitHub), then version
bump to 2.2.0 with CHANGELOG migration note.