### PR TITLE
docs(env): add API_TOKEN + GIMIE_API_URL to .env.example and README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,13 @@
 # Required credentials
 # ---------------------------------------------------------------------------
 
+# Bearer token guarding every `/v1/*` route plus `/v2/extract` and
+# `/v2/jobs/{id}`. Clients authenticate with `Authorization: Bearer <API_TOKEN>`.
+# **Fails closed**: if this is unset the server returns 503 on every protected
+# route (no dev bypass); a wrong token returns 401. Generate one with:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+API_TOKEN=your-api-token-here
+
 # GitHub API token. Required for v2 preflight (`/v2/health` flips to
 # `degraded` without it), for all real GitHub provider calls, and for the
 # `src/index/github/` indexer (REST metadata + README fetches).
@@ -27,6 +34,20 @@ GME_GITHUB_TOKEN=your-github-token-here
 # Set to 0 to disable. Non-transient errors (NOT_FOUND, UnicodeDecodeError)
 # never retry — UnicodeDecodeError falls back to a minimal payload instead.
 # V2_GITHUB_REPO_MAX_RETRIES=3
+
+# ---------------------------------------------------------------------------
+# Gimie extraction backend (repository metadata harvesting)
+# ---------------------------------------------------------------------------
+
+# GIMIE runs as the `gme-gimie-api` sidecar — the `gimie` package was removed
+# from the image. Point this at the running sidecar to enable repository
+# extraction; the devcontainer compose sets it to the value below for you.
+# **Required for repository extraction:** when unset, callers fall back to
+# in-process gimie, which is no longer installed → repository extraction raises
+# RuntimeError. Outside the devcontainer, either run the sidecar (set this) or
+# `pip install gimie==0.7.2` for in-process extraction.
+# See docs/OPERATIONS_RUNBOOK.md §8.
+GIMIE_API_URL=http://gme-gimie-api:15400
 
 # ---------------------------------------------------------------------------
 # LLM provider credentials (only the one(s) referenced by your model config

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A single GitHub URL → a typed graph you can SPARQL. The pipeline combines dete
 git clone https://github.com/Imaging-Plaza/git-metadata-extractor.git
 cd git-metadata-extractor
 just install-dev
-cp .env.example .env   # fill in GME_GITHUB_TOKEN + one LLM credential
+cp .env.example .env   # fill in API_TOKEN, GME_GITHUB_TOKEN + one LLM credential
 
 # 2. Run
 just serve-dev         # starts on http://localhost:1234
@@ -154,7 +154,9 @@ docs/                    # MkDocs site source
 
 Everything is in `.env` — copy `.env.example` and fill in what you need. Required minimum:
 
+- `API_TOKEN` — bearer token guarding `/v1/*`, `/v2/extract`, and `/v2/jobs/{id}`. **Fails closed** (unset → `503` on every protected route). Generate with `python -c "import secrets; print(secrets.token_urlsafe(32))"`.
 - `GME_GITHUB_TOKEN` — required for any real GitHub call.
+- `GIMIE_API_URL` — points at the `gme-gimie-api` sidecar (e.g. `http://gme-gimie-api:15400`); **required for repository extraction** (the `gimie` package was removed from the image).
 - **One LLM credential** — `RCP_TOKEN` (EPFL), `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`.
 
 Optional (only when you use the feature): `INFOSCIENCE_TOKEN`, `SELENIUM_REMOTE_URL`, `HF_TOKEN`, `ZENODO_TOKEN`, `OPENALEX_MAILTO`, `EPFL_GRAPH_USERNAME` / `EPFL_GRAPH_PASSWORD`.


### PR DESCRIPTION
…ommit 1 of 6 for v2.2.0)

Foundation for the v2.2.0 URL-identifiers migration (see
`.internal/plan-2.2.0-url-identifiers.md`). Zero behaviour change —
the helpers are not yet used anywhere outside their own tests.

Helpers shipped:

  - `src/v2/canonicalization/doi.py` — re-exports `doi_iri` and
    `parse_doi` from `src/index/_shared/doi.py` (the existing shared
    helper used by every catalog backend since
    `feat/all-catalogs-doi-urls`). Lets v2 code import from
    `src.v2.canonicalization` without reaching into the index
    subsystem.
  - `src/v2/canonicalization/infoscience.py` — three URL constructors:
    `infoscience_person_iri`, `infoscience_org_iri` (→ `/entities/
    orgunit/`, not `organization` — that's Infoscience's URL
    convention), `infoscience_article_iri` (→ `/entities/publication/`).
    Plus `parse_infoscience_iri` returning `(kind, uuid)`. UUID4-strict.
    Tolerates bare UUID + canonical URL + trailing slash. Rejects
    cross-kind URL inputs (passing an org URL to `person_iri`
    surfaces the type mismatch loudly).
  - `src/v2/canonicalization/github.py` — three URL constructors:
    `github_user_iri`, `github_org_iri` (alias of user — same URL
    shape, separate name for caller-side readability), `github_repo_iri`
    for `owner/repo`. Plus three parse functions. Enforces GitHub's
    handle regex (1-39 chars, alphanumeric + single hyphens,
    no leading/trailing hyphen, no double hyphens). Tolerates bare
    handle / canonical URL / leading `@` / trailing slash.

Every helper follows the established contract from `doi_iri` /
`orcid_iri`: idempotent on canonical input, tolerates every
on-the-wire shape we've seen, returns None on malformed input,
case-insensitive scheme/host.

Tests (95 total):
  - 5 in `tests/v2/test_doi_canonicalization_v2.py` (re-export smoke)
  - 31 in `tests/v2/test_infoscience_canonicalization.py` (all three
    kinds, type-mismatch rejection, UUID4 strict, parse round-trip)
  - 32 in `tests/v2/test_github_canonicalization.py` (user/org/repo,
    URL + bare + dotted-repo-names, handle-regex rejection paths)
  - (27 existing in `tests/v2/test_orcid_canonicalization.py` — from
    `feat/v2-orcid-url-canonicalization`)

Next commits per the plan: schema + ontology + emit-site updates for
each identifier type (DOI, ORCID, Infoscience, GitHub), then version
bump to 2.2.0 with CHANGELOG migration note.