### PR TITLE
docs(v2): document V2_RATE_LIMIT_PER_MINUTE rate limiting

### DIFF
--- a/docs/v2-api-reference.md
+++ b/docs/v2-api-reference.md
@@ -26,6 +26,20 @@ The check uses `hmac.compare_digest` for constant-time comparison.
 `/v1/*` routes share the same `API_TOKEN` and behave the same way.
 Implementation lives in `src/v2/auth.py` (`verify_token` dependency).
 
+## Rate limiting
+
+Disabled by default. Set `V2_RATE_LIMIT_PER_MINUTE` to a positive integer to
+cap requests per client on the compute-/cost-heavy routes:
+
+- `POST /v2/extract` and `POST /v2/indices/{provider}/ingest`
+- `GET /v2/extract/{full_path}` and the `/v1/{org,user,repository}/*` routes
+
+Clients are keyed by bearer token (falling back to client IP). Exceeding the
+limit returns `429 Too Many Requests` with a `Retry-After` header. The window
+is a fixed 60 s. State is in-memory and **per worker**, so under gunicorn with
+N workers the effective limit is ~N × the configured value — use a shared store
+(e.g. Redis) for a true global cap. Implementation: `src/v2/rate_limit.py`.
+
 ## Endpoints
 
 ### `GET /v2/health`
@@ -313,6 +327,7 @@ The most-touched knobs (full list in `.env.example` and `CLAUDE.md`):
 | Variable | Default | Notes |
 | --- | --- | --- |
 | `API_TOKEN` | unset | Bearer token guarding `/v1/*` and protected `/v2/*` routes. Missing → 503 (no dev bypass). See [Authentication](#authentication). |
+| `V2_RATE_LIMIT_PER_MINUTE` | unset (off) | Opt-in per-client request cap on the compute-heavy routes (`POST /v2/extract`, `/v2/indices/*/ingest`, the `GET` extract + `/v1/{org,user,repository}/*` routes). Keyed by bearer token (else IP); in-memory & per-worker. Over limit → `429` + `Retry-After`. See [Rate limiting](#rate-limiting). |
 | `V2_AGENT_RUNTIME_DEFAULT` | `llm` | Default runtime when `/v2/extract` omits `agent_runtime` |
 | `V2_USE_MOCK_PROVIDERS` | `true` | Swap in mock GitHub/ORCID/Infoscience/ROR providers |
 | `V2_LINK_VERACITY_ENABLED` | `true` | Skip the link-veracity stage in LLM mode (rule-based skips unconditionally) |


### PR DESCRIPTION
…ommit 1 of 6 for v2.2.0)

Foundation for the v2.2.0 URL-identifiers migration (see
`.internal/plan-2.2.0-url-identifiers.md`). Zero behaviour change —
the helpers are not yet used anywhere outside their own tests.

Helpers shipped:

  - `src/v2/canonicalization/doi.py` — re-exports `doi_iri` and
    `parse_doi` from `src/index/_shared/doi.py` (the existing shared
    helper used by every catalog backend since
    `feat/all-catalogs-doi-urls`). Lets v2 code import from
    `src.v2.canonicalization` without reaching into the index
    subsystem.
  - `src/v2/canonicalization/infoscience.py` — three URL constructors:
    `infoscience_person_iri`, `infoscience_org_iri` (→ `/entities/
    orgunit/`, not `organization` — that's Infoscience's URL
    convention), `infoscience_article_iri` (→ `/entities/publication/`).
    Plus `parse_infoscience_iri` returning `(kind, uuid)`. UUID4-strict.
    Tolerates bare UUID + canonical URL + trailing slash. Rejects
    cross-kind URL inputs (passing an org URL to `person_iri`
    surfaces the type mismatch loudly).
  - `src/v2/canonicalization/github.py` — three URL constructors:
    `github_user_iri`, `github_org_iri` (alias of user — same URL
    shape, separate name for caller-side readability), `github_repo_iri`
    for `owner/repo`. Plus three parse functions. Enforces GitHub's
    handle regex (1-39 chars, alphanumeric + single hyphens,
    no leading/trailing hyphen, no double hyphens). Tolerates bare
    handle / canonical URL / leading `@` / trailing slash.

Every helper follows the established contract from `doi_iri` /
`orcid_iri`: idempotent on canonical input, tolerates every
on-the-wire shape we've seen, returns None on malformed input,
case-insensitive scheme/host.

Tests (95 total):
  - 5 in `tests/v2/test_doi_canonicalization_v2.py` (re-export smoke)
  - 31 in `tests/v2/test_infoscience_canonicalization.py` (all three
    kinds, type-mismatch rejection, UUID4 strict, parse round-trip)
  - 32 in `tests/v2/test_github_canonicalization.py` (user/org/repo,
    URL + bare + dotted-repo-names, handle-regex rejection paths)
  - (27 existing in `tests/v2/test_orcid_canonicalization.py` — from
    `feat/v2-orcid-url-canonicalization`)

Next commits per the plan: schema + ontology + emit-site updates for
each identifier type (DOI, ORCID, Infoscience, GitHub), then version
bump to 2.2.0 with CHANGELOG migration note.…ommit 1 of 6 for v2.2.0)

Foundation for the v2.2.0 URL-identifiers migration (see
`.internal/plan-2.2.0-url-identifiers.md`). Zero behaviour change —
the helpers are not yet used anywhere outside their own tests.

Helpers shipped:

  - `src/v2/canonicalization/doi.py` — re-exports `doi_iri` and
    `parse_doi` from `src/index/_shared/doi.py` (the existing shared
    helper used by every catalog backend since
    `feat/all-catalogs-doi-urls`). Lets v2 code import from
    `src.v2.canonicalization` without reaching into the index
    subsystem.
  - `src/v2/canonicalization/infoscience.py` — three URL constructors:
    `infoscience_person_iri`, `infoscience_org_iri` (→ `/entities/
    orgunit/`, not `organization` — that's Infoscience's URL
    convention), `infoscience_article_iri` (→ `/entities/publication/`).
    Plus `parse_infoscience_iri` returning `(kind, uuid)`. UUID4-strict.
    Tolerates bare UUID + canonical URL + trailing slash. Rejects
    cross-kind URL inputs (passing an org URL to `person_iri`
    surfaces the type mismatch loudly).
  - `src/v2/canonicalization/github.py` — three URL constructors:
    `github_user_iri`, `github_org_iri` (alias of user — same URL
    shape, separate name for caller-side readability), `github_repo_iri`
    for `owner/repo`. Plus three parse functions. Enforces GitHub's
    handle regex (1-39 chars, alphanumeric + single hyphens,
    no leading/trailing hyphen, no double hyphens). Tolerates bare
    handle / canonical URL / leading `@` / trailing slash.

Every helper follows the established contract from `doi_iri` /
`orcid_iri`: idempotent on canonical input, tolerates every
on-the-wire shape we've seen, returns None on malformed input,
case-insensitive scheme/host.

Tests (95 total):
  - 5 in `tests/v2/test_doi_canonicalization_v2.py` (re-export smoke)
  - 31 in `tests/v2/test_infoscience_canonicalization.py` (all three
    kinds, type-mismatch rejection, UUID4 strict, parse round-trip)
  - 32 in `tests/v2/test_github_canonicalization.py` (user/org/repo,
    URL + bare + dotted-repo-names, handle-regex rejection paths)
  - (27 existing in `tests/v2/test_orcid_canonicalization.py` — from
    `feat/v2-orcid-url-canonicalization`)

Next commits per the plan: schema + ontology + emit-site updates for
each identifier type (DOI, ORCID, Infoscience, GitHub), then version
bump to 2.2.0 with CHANGELOG migration note.