### PR TITLE
chore(docker): keep 4.1GB of local state out of the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,6 +39,9 @@ extraction_results/
 .venv/
 .venv-win/
 .cache/
+.uv-cache/
+.claude/
+.internal/
 site/
 dev/
 .staging/


### PR DESCRIPTION
`.dockerignore` already excluded the obvious offenders — `data/` (36 GB), both
venvs, `.git/` — but three directories of the same class were still shipped to
the Docker daemon on every image build:

| Directory | Size | What it is |
|---|---|---|
| `.uv-cache/` | **3.3 GB** | uv's package cache — created by the devcontainer `postCreateCommand`, so it exists in every dev checkout |
| `.claude/` | 836 MB | agent session state |
| `.internal/` | 31 MB | internal working notes |

`tools/image/Dockerfile` copies specific paths and never `. .`, so **image
contents do not change**. This only stops the client transferring ~4.1 GB of
context the build cannot use.

**Left in deliberately:** `tests/` (39 MB). The Dockerfile does not copy it
today, but the mock providers need `tests/v2/fixtures/` and shipping those in
the image is an open item in the split backlog (task 10) — excluding it here
would make that `COPY` fail confusingly later, to save 39 MB.

`.mypy_cache/` is not added — the existing Cache section already covers it.

Verification: after the change, every root directory ≥20 MB is matched by an
ignore rule except `tests/` as noted. `build-and-publish` on this PR exercises
a real image build with the new rules.